### PR TITLE
fix(windows): make install.ps1 PowerShell 5.1 friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,12 @@ The installer clones the repo to `~/.understand-anything/repo` and creates the r
 > **Note on invoking skills:** the invocation prefix differs per platform. Most platforms use slash commands (`/understand`), but **Codex uses `$` instead** — type `$understand`, not `/understand`. If neither prefix is recognized on your platform, just ask in plain language: *"Use the understand skill to analyze this project."*
 
 - Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`
-- Update later: `./install.sh --update`
-- Uninstall: `./install.sh --uninstall <platform>`
+- Update later:
+  - macOS / Linux: `./install.sh --update`
+  - Windows: `& "$HOME/.understand-anything/repo/install.ps1" -Update`
+- Uninstall:
+  - macOS / Linux: `./install.sh --uninstall <platform>`
+  - Windows: `& "$HOME/.understand-anything/repo/install.ps1" -Uninstall <platform>`
 
 ### Cursor
 

--- a/install.ps1
+++ b/install.ps1
@@ -26,7 +26,7 @@ $RepoUrl    = if ($env:UA_REPO_URL) { $env:UA_REPO_URL } else { 'https://github.
 $RepoDir    = if ($env:UA_DIR)      { $env:UA_DIR }      else { Join-Path $HOME '.understand-anything\repo' }
 $PluginLink = Join-Path $HOME '.understand-anything-plugin'
 
-# Platform table — Target = skills directory; Style = "per-skill" | "folder"
+# Platform table - Target = skills directory; Style = "per-skill" | "folder"
 $Platforms = [ordered]@{
     gemini      = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     codex       = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
@@ -88,10 +88,10 @@ function Get-SkillsRoot { Join-Path $RepoDir 'understand-anything-plugin\skills'
 
 function Clone-Or-Update {
     if (Test-Path (Join-Path $RepoDir '.git')) {
-        Write-Host "→ Updating existing checkout at $RepoDir"
+        Write-Host "-> Updating existing checkout at $RepoDir"
         git -C $RepoDir pull --ff-only
     } else {
-        Write-Host "→ Cloning $RepoUrl → $RepoDir"
+        Write-Host "-> Cloning $RepoUrl -> $RepoDir"
         $parent = Split-Path -Parent $RepoDir
         if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Path $parent | Out-Null }
         git clone $RepoUrl $RepoDir
@@ -120,7 +120,7 @@ function Remove-Reparse([string]$Path) {
         $item.Delete()
         return $true
     }
-    Write-Warning "Refusing to delete $Path — it is a real file/directory, not a junction/symlink we created. Remove it manually if you intended to."
+    Write-Warning "Refusing to delete $Path - it is a real file/directory, not a junction/symlink we created. Remove it manually if you intended to."
     return $false
 }
 
@@ -129,7 +129,7 @@ function New-Junction([string]$LinkPath, [string]$TargetPath) {
         if (Test-IsReparse $LinkPath) {
             (Get-Item -LiteralPath $LinkPath -Force).Delete()
         } else {
-            Write-Error "Refusing to overwrite $LinkPath — it is a real file/directory, not a junction. Move or remove it first."
+            Write-Error "Refusing to overwrite $LinkPath - it is a real file/directory, not a junction. Move or remove it first."
         }
     }
     New-Item -ItemType Junction -Path $LinkPath -Target $TargetPath | Out-Null
@@ -145,13 +145,13 @@ function Link-Skills([string]$Target, [string]$Style) {
                 $link = Join-Path $Target $skill
                 $src  = Join-Path $root $skill
                 New-Junction $link $src
-                Write-Host "  ✓ $link → $src"
+                Write-Host "  OK $link -> $src"
             }
         }
         'folder' {
             $link = Join-Path $Target 'understand-anything'
             New-Junction $link $root
-            Write-Host "  ✓ $link → $root"
+            Write-Host "  OK $link -> $root"
         }
         default { Write-Error "Unknown style: $Style" }
     }
@@ -167,7 +167,7 @@ function Unlink-Skills([string]$Target, [string]$Style) {
                     Remove-Reparse (Join-Path $Target $skill) | Out-Null
                 }
             } else {
-                # Checkout is gone — scan the target dir for stale links pointing
+                # Checkout is gone - scan the target dir for stale links pointing
                 # into our plugin tree so we can still clean up.
                 Get-ChildItem -LiteralPath $Target -Force | ForEach-Object {
                     if ($_.LinkType -eq 'Junction' -or $_.LinkType -eq 'SymbolicLink') {
@@ -186,11 +186,11 @@ function Unlink-Skills([string]$Target, [string]$Style) {
 
 function Link-Plugin-Root {
     if (Test-Path $PluginLink) {
-        Write-Host "  • $PluginLink already exists, leaving as-is"
+        Write-Host "  * $PluginLink already exists, leaving as-is"
     } else {
         $src = Join-Path $RepoDir 'understand-anything-plugin'
         New-Item -ItemType Junction -Path $PluginLink -Target $src | Out-Null
-        Write-Host "  ✓ $PluginLink → $src"
+        Write-Host "  OK $PluginLink -> $src"
     }
 }
 
@@ -202,13 +202,13 @@ function ConvertTo-FileUri([string]$Path) {
 function Cmd-Install([string]$Id) {
     $cfg = Resolve-Platform $Id
     Clone-Or-Update
-    Write-Host "→ Linking skills for $Id ($($cfg.Style) → $($cfg.Target))"
+    Write-Host "-> Linking skills for $Id ($($cfg.Style) -> $($cfg.Target))"
     Link-Skills $cfg.Target $cfg.Style
-    Write-Host '→ Linking universal plugin root'
+    Write-Host '-> Linking universal plugin root'
     Link-Plugin-Root
 
     if ($Id -eq 'kiro') {
-        Write-Host '→ Creating Kiro agent configuration'
+        Write-Host '-> Creating Kiro agent configuration'
         $agentsDir = Join-Path $HOME '.kiro\agents'
         if (-not (Test-Path $agentsDir)) { New-Item -ItemType Directory -Path $agentsDir | Out-Null }
         $pluginRoot = Join-Path $RepoDir 'understand-anything-plugin'
@@ -222,7 +222,7 @@ function Cmd-Install([string]$Id) {
         )
         $agent = [ordered]@{
             name        = 'understand'
-            description = 'Analyze codebase into interactive knowledge graph — Understand Anything'
+            description = 'Analyze codebase into interactive knowledge graph - Understand Anything'
             prompt      = ConvertTo-FileUri (Join-Path $pluginRoot 'skills\understand\SKILL.md')
             tools       = @('read', 'write', 'shell', 'grep', 'glob', 'code', 'subagent')
             resources   = $resources
@@ -230,13 +230,13 @@ function Cmd-Install([string]$Id) {
         $agentJson = Join-Path $agentsDir 'understand.json'
         # WriteAllText emits UTF-8 without a BOM on every PowerShell version.
         [System.IO.File]::WriteAllText($agentJson, ($agent | ConvertTo-Json -Depth 5))
-        Write-Host "  ✓ $agentJson"
+        Write-Host "  OK $agentJson"
     }
 
-    Write-Host "`n✓ Installed Understand-Anything for $Id"
+    Write-Host "`nOK Installed Understand-Anything for $Id"
     Write-Host '  Restart your CLI or IDE to pick up the skills.'
     if ($Id -eq 'codex') {
-        Write-Host "`n  Tip: Codex invokes skills with `$ instead of / — type `$understand, not /understand."
+        Write-Host "`n  Tip: Codex invokes skills with `$ instead of / - type `$understand, not /understand."
     }
     if ($Id -eq 'vscode') {
         Write-Host "`n  Tip: VS Code can also auto-discover the plugin by opening this repo"
@@ -249,17 +249,17 @@ function Cmd-Install([string]$Id) {
 
 function Cmd-Uninstall([string]$Id) {
     $cfg = Resolve-Platform $Id
-    Write-Host "→ Removing skill links for $Id"
+    Write-Host "-> Removing skill links for $Id"
     Unlink-Skills $cfg.Target $cfg.Style
     if ($Id -eq 'kiro') {
         $agentJson = Join-Path $HOME '.kiro\agents\understand.json'
         if (Test-Path $agentJson) {
             Remove-Item -LiteralPath $agentJson -Force
-            Write-Host "  ✓ removed $agentJson"
+            Write-Host "  OK removed $agentJson"
         }
     }
     if (Remove-Reparse $PluginLink) {
-        Write-Host "  ✓ removed $PluginLink"
+        Write-Host "  OK removed $PluginLink"
     }
     if (Test-Path $RepoDir) {
         Write-Host "`nThe checkout at $RepoDir was kept (other platforms may still use it)."
@@ -272,7 +272,7 @@ function Cmd-Update {
         Write-Error "No installation found at $RepoDir. Run install first."
     }
     git -C $RepoDir pull --ff-only
-    Write-Host '✓ Updated.'
+    Write-Host 'OK Updated.'
 }
 
 if ($Help) { Show-Usage; return }


### PR DESCRIPTION
## Summary

- make `install.ps1` parse reliably in Windows PowerShell 5.1 by keeping the no-BOM script ASCII-only
- preserve every current platform, including newer Vibe, nanobot, and Kiro support
- document native Windows update and uninstall commands alongside the Unix commands

## Verification

- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File ./install.ps1 -Help`
- Windows PowerShell parser API: zero parse errors
- non-ASCII sweep of `install.ps1`: zero matches
- `git diff origin/main...HEAD --check`

## Refresh note

Rebuilt on current `main` as `3369980`. The obsolete Vibe addition from the original draft was dropped because upstream already added it; newer Kiro configuration and Codex invocation guidance are retained.
