### PR TITLE
feat: add native codex plugin support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "author": {
     "name": "Lum1104"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "understand-anything",
+  "version": "2.7.6",
+  "description": "AI-powered codebase understanding - analyze, visualize, and explain any project",
+  "author": {
+    "name": "Lum1104"
+  },
+  "homepage": "https://github.com/Lum1104/Understand-Anything",
+  "repository": "https://github.com/Lum1104/Understand-Anything",
+  "license": "MIT",
+  "keywords": ["codebase-analysis", "knowledge-graph", "architecture", "onboarding", "dashboard"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Understand Anything",
+    "shortDescription": "Analyze, visualize, and explain any codebase.",
+    "longDescription": "Understand Anything combines LLM analysis with static code scanning to build interactive architecture maps, onboarding guides, and codebase explanations.",
+    "developerName": "Lum1104",
+    "category": "Developer Tools",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://github.com/Lum1104/Understand-Anything",
+    "defaultPrompt": [
+      "Map this codebase with Understand Anything.",
+      "Explain the architecture of this project.",
+      "Build an onboarding guide for this repo."
+    ],
+    "brandColor": "#D4A574"
+  }
+}

--- a/.copilot-plugin/plugin.json
+++ b/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "author": {
     "name": "Lum1104"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "understand-anything",
   "displayName": "Understand Anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "author": {
     "name": "Lum1104"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,12 +55,13 @@ An open-source tool combining LLM intelligence + static analysis to produce inte
 - `scripts/generate-large-graph.mjs` — Generates a fake knowledge graph for performance testing (e.g. large-graph layout). Writes to `.understand-anything/knowledge-graph.json`. Usage: `node scripts/generate-large-graph.mjs [nodeCount]` (default: 3000 nodes). Not part of the production pipeline.
 
 ## Versioning
-When pushing to remote, bump the version in **all five** of these files (keep them in sync):
+When pushing to remote, bump the version in **all six** of these files (keep them in sync):
 - `understand-anything-plugin/package.json` → `"version"` field
 - `understand-anything-plugin/.claude-plugin/plugin.json` → `"version"` field
 - `.claude-plugin/plugin.json` → `"version"` field
 - `.cursor-plugin/plugin.json` → `"version"` field
 - `.copilot-plugin/plugin.json` → `"version"` field
+- `.codex-plugin/plugin.json` → `"version"` field
 
 Note: `.claude-plugin/marketplace.json` does **not** carry a version — the `plugins[]` entry only supports `name` and `source`, and adding other fields causes marketplace schema validation failures.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,13 @@ Understand-Anything works across multiple AI coding platforms.
 /plugin install understand-anything
 ```
 
-### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI)
+### Codex (Native)
+
+Codex auto-discovers the plugin via `.codex-plugin/plugin.json` when this repo is cloned. No manual installation needed - just clone and open in Codex.
+
+For personal skills available across all projects, run the one-line installer below with the `codex` platform.
+
+### One-line install (OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI)
 
 **macOS / Linux:**
 ```bash
@@ -229,7 +235,7 @@ copilot plugin install Lum1104/Understand-Anything:understand-anything-plugin
 | Cursor | ✅ Supported | Auto-discovery |
 | VS Code + GitHub Copilot | ✅ Supported | Auto-discovery |
 | Copilot CLI | ✅ Supported | Plugin install |
-| Codex | ✅ Supported | `install.sh codex` |
+| Codex | ✅ Native | Auto-discovery |
 | OpenCode | ✅ Supported | `install.sh opencode` |
 | OpenClaw | ✅ Supported | `install.sh openclaw` |
 | Antigravity | ✅ Supported | `install.sh antigravity` |

--- a/skills
+++ b/skills
@@ -1,0 +1,1 @@
+understand-anything-plugin/skills

--- a/tests/plugin-manifests.test.mjs
+++ b/tests/plugin-manifests.test.mjs
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+
+function readJson(relativePath) {
+  return JSON.parse(readFileSync(resolve(repoRoot, relativePath), "utf8"));
+}
+
+function expectRelativePathExists(manifestPath, relativePath) {
+  const target = resolve(repoRoot, relativePath);
+
+  expect(existsSync(target), `${manifestPath} points to missing ${relativePath}`).toBe(true);
+}
+
+describe("platform plugin manifests", () => {
+  const manifestPaths = [
+    ".claude-plugin/plugin.json",
+    ".cursor-plugin/plugin.json",
+    ".copilot-plugin/plugin.json",
+    ".codex-plugin/plugin.json",
+    "understand-anything-plugin/.claude-plugin/plugin.json",
+  ];
+
+  it("keeps every platform manifest version in sync with the package", () => {
+    const packageJson = readJson("understand-anything-plugin/package.json");
+
+    for (const manifestPath of manifestPaths) {
+      const manifest = readJson(manifestPath);
+
+      expect(manifest.version, manifestPath).toBe(packageJson.version);
+    }
+  });
+
+  it("ships a native Codex manifest with discoverable skills", () => {
+    const manifestPath = ".codex-plugin/plugin.json";
+    const manifest = readJson(manifestPath);
+
+    expect(manifest.name).toBe("understand-anything");
+    expect(manifest.skills).toBe("./skills/");
+    expect(manifest.interface.displayName).toBe("Understand Anything");
+    expect(manifest.interface.category).toBe("Developer Tools");
+    expect(manifest.interface.defaultPrompt).toContain("Map this codebase with Understand Anything.");
+
+    expectRelativePathExists(manifestPath, manifest.skills);
+    expect(statSync(resolve(repoRoot, "understand-anything-plugin/skills/understand/SKILL.md")).isFile()).toBe(true);
+  });
+});

--- a/understand-anything-plugin/.claude-plugin/plugin.json
+++ b/understand-anything-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "author": {
     "name": "Lum1104"
   },

--- a/understand-anything-plugin/package.json
+++ b/understand-anything-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understand-anything/skill",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Adds native Codex plugin discovery via `.codex-plugin/plugin.json`, wires Codex to the existing skills tree, updates docs, and adds manifest coverage.