### PR TITLE
Fix Windows compatibility for Vitest test suite

### DIFF
--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = resolve(__dirname, '../../../understand-anything-plugin/skills/understand/extract-import-map.mjs');
@@ -1473,7 +1473,7 @@ describe('extract-import-map.mjs — tree-sitter init graceful failure', () => {
           { path: 'src/lib.ts', language: 'typescript', fileCategory: 'code' },
         ],
       },
-      ['--import', loaderPath],
+      ['--import', pathToFileURL(loaderPath).href],
     );
 
     expect(result.status).toBe(0);

--- a/understand-anything-plugin/skills/understand/extract-structure.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * extract-structure.mjs
  *

--- a/understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs
+++ b/understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs
@@ -13,8 +13,10 @@ let projectRoot;
 let intermediateDir;
 
 function runMerge() {
-  const result = spawnSync("python3", [MERGE_SCRIPT, projectRoot], {
+  const pythonCmd = process.platform === "win32" ? "python" : "python3";
+  const result = spawnSync(pythonCmd, [MERGE_SCRIPT, projectRoot], {
     encoding: "utf-8",
+    env: { ...process.env, PYTHONIOENCODING: "utf-8" },
   });
   if (result.status !== 0) {
     throw new Error(`merge script failed: status=${result.status}\nstderr:\n${result.stderr}`);

--- a/understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs
+++ b/understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs
@@ -27,6 +27,12 @@ fi
 echo "$PROJECT_ROOT"
 `;
 
+function normalizePath(p) {
+  let normalized = p.trim().replace(/\\/g, '/');
+  normalized = normalized.replace(/^\/([a-zA-Z])(?=\/|$)/, (_, letter) => `${letter.toUpperCase()}:`);
+  return normalized;
+}
+
 function runResolve(projectRoot, env = {}) {
   // No `set -e` — the snippet relies on `git ... 2>/dev/null` returning empty
   // strings when not in a git repo; `set -e` would short-circuit instead.
@@ -64,19 +70,19 @@ afterAll(() => {
 
 describe("worktree-redirect snippet (issue #133)", () => {
   it("leaves PROJECT_ROOT alone in a normal checkout", () => {
-    expect(runResolve(mainRepo)).toBe(mainRepo);
+    expect(normalizePath(runResolve(mainRepo))).toBe(normalizePath(mainRepo));
   });
 
   it("redirects PROJECT_ROOT to the main repo when started in a worktree", () => {
-    expect(runResolve(worktree)).toBe(mainRepo);
+    expect(normalizePath(runResolve(worktree))).toBe(normalizePath(mainRepo));
   });
 
   it("redirects from a subdirectory inside a worktree", () => {
-    expect(runResolve(subdir)).toBe(mainRepo);
+    expect(normalizePath(runResolve(subdir))).toBe(normalizePath(mainRepo));
   });
 
   it("respects UNDERSTAND_NO_WORKTREE_REDIRECT=1", () => {
-    expect(runResolve(worktree, { UNDERSTAND_NO_WORKTREE_REDIRECT: "1" })).toBe(worktree);
+    expect(normalizePath(runResolve(worktree, { UNDERSTAND_NO_WORKTREE_REDIRECT: "1" }))).toBe(normalizePath(worktree));
   });
 
   it("leaves PROJECT_ROOT alone when not inside a git repo", () => {
@@ -84,6 +90,6 @@ describe("worktree-redirect snippet (issue #133)", () => {
     // inside a parent git repo (e.g. when /tmp is symlinked into one).
     const nonGit = join(tmpRoot, "no-git");
     mkdirSync(nonGit, { recursive: true });
-    expect(runResolve(nonGit)).toBe(nonGit);
+    expect(normalizePath(runResolve(nonGit))).toBe(normalizePath(nonGit));
   });
 });


### PR DESCRIPTION
Resolves test execution failures on Windows environments, including the ESM loader scheme issue, missing python3 runner, worktree path representations, and SyntaxError on imported shebangs.