### PR TITLE
Add Hermes Agent plugin support

### DIFF
--- a/.hermes-plugin/README.md
+++ b/.hermes-plugin/README.md
@@ -1,0 +1,56 @@
+# Understand-Anything for Hermes
+
+[Hermes Agent](https://github.com/hermes-agent/hermes-agent) plugin support for Understand-Anything.
+
+## Installation
+
+### One-line install (macOS / Linux)
+```bash
+curl -fsSL https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/install.sh | bash -s hermes
+```
+
+### What the installer does
+1. Clones this repo to `~/.understand-anything/repo`
+2. Symlinks `understand-anything-plugin/skills/` into `~/.hermes/skills/understand-anything/`
+3. All 8 sub-skills are auto-discovered by Hermes on next startup or `/reload-skills`
+
+### Manual install
+```bash
+git clone https://github.com/Lum1104/Understand-Anything.git ~/.understand-anything/repo
+ln -sfn ~/.understand-anything/repo/understand-anything-plugin/skills ~/.hermes/skills/understand-anything
+```
+
+### Update
+```bash
+~/.understand-anything/repo/install.sh --update
+```
+
+## Available Skills
+
+After installation, these skills are available in Hermes:
+
+| Skill | Purpose |
+|---|---|
+| `understand` | Analyze codebase and generate knowledge graph |
+| `understand-chat` | Ask natural-language questions about code |
+| `understand-dashboard` | Open interactive web dashboard |
+| `understand-diff` | Analyze impact of uncommitted changes |
+| `understand-explain` | Deep-dive a specific file or function |
+| `understand-onboard` | Generate onboarding guide |
+| `understand-domain` | Extract business domain knowledge |
+| `understand-knowledge` | Analyze a Karpathy-pattern LLM wiki |
+
+## Quick Start
+
+```bash
+# In any project directory
+/understand                    # Generate knowledge graph
+/understand-dashboard          # Open dashboard
+/understand-chat "How does auth work?"
+```
+
+## Links
+
+- Homepage: https://understand-anything.com/
+- Demo: https://understand-anything.com/demo/
+- Discord: https://discord.gg/pydat66RY

--- a/.hermes-plugin/SKILL.md
+++ b/.hermes-plugin/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: understand-anything
+description: "Use when analyzing, visualizing, or explaining codebases with Understand-Anything. Interactive knowledge graphs, architecture tours, diff impact, and semantic Q&A for any project."
+version: 2.7.5
+author: Lum1104
+license: MIT
+metadata:
+  hermes:
+    tags: [codebase-analysis, knowledge-graph, architecture, onboarding, dashboard, code-review]
+    related_skills: [github-code-review, codebase-inspection]
+---
+
+# Understand-Anything for Hermes
+
+## Overview
+
+Understand-Anything turns any codebase into an interactive knowledge graph you can explore, search, and ask questions about. It works with Claude Code, Codex, Cursor, Copilot, Gemini CLI, and **Hermes**.
+
+> "Graphs that teach > graphs that impress."
+
+## Installation
+
+### One-line install (macOS / Linux)
+```bash
+curl -fsSL https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/install.sh | bash -s hermes
+```
+
+### Manual install
+```bash
+git clone https://github.com/Lum1104/Understand-Anything.git ~/.understand-anything/repo
+ln -sfn ~/.understand-anything/repo/understand-anything-plugin/skills ~/.hermes/skills/understand-anything
+```
+
+### Update
+```bash
+~/.understand-anything/repo/install.sh --update
+```
+
+## Commands
+
+| Command | What it does | When to use |
+|---|---|---|
+| `/understand` | Analyze codebase and generate `knowledge-graph.json` | First run on any project |
+| `/understand-dashboard` | Open interactive web dashboard | Explore visually |
+| `/understand-chat <query>` | Ask natural-language questions about the code | "How does auth work?" |
+| `/understand-diff` | Analyze impact of current uncommitted changes | Before committing |
+| `/understand-explain <path>` | Deep-dive a specific file or function | Focus on one component |
+| `/understand-onboard` | Generate onboarding guide for new devs | Team onboarding |
+| `/understand-domain` | Extract business domain knowledge | Map code to business |
+| `/understand-knowledge <path>` | Analyze a Karpathy-pattern LLM wiki | Wiki visualization |
+
+## Workflow
+
+### First-time analysis
+```bash
+/understand
+```
+Generates `.understand-anything/knowledge-graph.json`. This is the source of truth for all other commands.
+
+### Daily usage
+```bash
+/understand-chat "How does the payment flow work?"
+/understand-diff
+/understand-dashboard
+```
+
+### Incremental updates
+After code changes, re-run `/understand` to update the graph. Only changed files are re-analyzed.
+
+### Auto-update on every commit
+```bash
+/understand --auto-update
+```
+Installs a post-commit hook.
+
+## Graph Structure (for power users)
+
+The knowledge graph JSON contains:
+- `project` — metadata (name, description, languages, frameworks)
+- `nodes[]` — files, functions, classes, modules, concepts, configs, services, etc.
+- `edges[]` — imports, contains, calls, depends_on, configures, documents, deploys, triggers
+- `layers[]` — architectural layers (API, Service, Data, UI, Utility)
+- `tour[]` — auto-generated architecture walkthrough ordered by dependency
+
+Node ID format: `file:path`, `function:path:name`, `class:path:name`, `config:path`
+
+## Hermes-Specific Notes
+
+- All 8 sub-skills are auto-discovered after installation: `understand`, `understand-chat`, `understand-dashboard`, `understand-diff`, `understand-domain`, `understand-explain`, `understand-knowledge`, `understand-onboard`
+- Skills live under `~/.hermes/skills/understand-anything/` as symlinks to the upstream repo
+- The graph file is project-local (`.understand-anything/knowledge-graph.json`), not global
+- For monorepos, scope analysis: `/understand src/frontend`
+
+## Links
+
+- Repo: https://github.com/Lum1104/Understand-Anything
+- Homepage: https://understand-anything.com/
+- Demo: https://understand-anything.com/demo/

--- a/.hermes-plugin/plugin.json
+++ b/.hermes-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "understand-anything",
+  "displayName": "Understand Anything",
+  "description": "AI-powered codebase understanding \u2014 analyze, visualize, and explain any project with interactive knowledge graphs",
+  "version": "2.7.5",
+  "author": {
+    "name": "Lum1104"
+  },
+  "homepage": "https://github.com/Lum1104/Understand-Anything",
+  "repository": "https://github.com/Lum1104/Understand-Anything",
+  "license": "MIT",
+  "keywords": ["codebase-analysis", "knowledge-graph", "architecture", "onboarding", "dashboard", "hermes"],
+  "skills": "./understand-anything-plugin/skills/",
+  "agents": "./understand-anything-plugin/agents/"
+}


### PR DESCRIPTION
## Summary

Adds `.hermes-plugin/` directory for [Hermes Agent](https://github.com/hermes-agent/hermes-agent) parity with existing `.claude-plugin/`, `.cursor-plugin/`, and `.copilot-plugin/`.

## What's included

- `.hermes-plugin/plugin.json` — manifest matching Cursor/Copilot format (skills + agents paths)
- `.hermes-plugin/README.md` — Hermes-specific install docs (one-liner curl, manual symlink, update flow)
- `.hermes-plugin/SKILL.md` — umbrella quick-reference skill covering all 8 commands

## How Hermes discovery works

Hermes scans `~/.hermes/skills/` recursively for `SKILL.md` files. The existing `install.sh` already symlinks `understand-anything-plugin/skills/` -> `~/.hermes/skills/understand-anything/`, so all 8 sub-skills (`understand`, `understand-chat`, `understand-dashboard`, `understand-diff`, `understand-domain`, `understand-explain`, `understand-knowledge`, `understand-onboard`) are auto-discoverable after install.

This PR simply adds the missing plugin metadata directory so Hermes users get the same first-class experience as Claude/Cursor/Copilot users.

## Tested

- Local skill installation verified on macOS + Hermes latest
- All 8 sub-skills load correctly via `/reload-skills`
