### PR TITLE
fix(dashboard): resolve port 5173 collision with strictPort + env var (#234)

### DIFF
--- a/understand-anything-plugin/packages/dashboard/vite.config.ts
+++ b/understand-anything-plugin/packages/dashboard/vite.config.ts
@@ -10,6 +10,7 @@ import crypto from "crypto";
 // This token is printed to the terminal and must be in the URL
 // to fetch knowledge-graph.json or diff-overlay.json.
 const ACCESS_TOKEN = process.env.UNDERSTAND_ACCESS_TOKEN || crypto.randomBytes(16).toString("hex");
+const DASHBOARD_PORT = Number(process.env.UNDERSTAND_DASHBOARD_PORT) || 5173;
 const MAX_SOURCE_FILE_BYTES = 1024 * 1024;
 
 function graphFileCandidates(fileName: string): string[] {
@@ -186,7 +187,8 @@ export default defineConfig({
   // This blocks access from any other device on the same LAN / WiFi.
   server: {
     host: "127.0.0.1",
-    port: 5173,
+    port: DASHBOARD_PORT,
+    strictPort: true,
     open: `/?token=${ACCESS_TOKEN}`,
   },
 
@@ -238,14 +240,14 @@ export default defineConfig({
         // Print the access URL once so the developer can open it.
         server.httpServer?.once("listening", () => {
           const address = server.httpServer?.address();
-          const port = typeof address === "object" && address ? address.port : 5173;
+          const port = typeof address === "object" && address ? address.port : DASHBOARD_PORT;
           console.log(
             `\n  🔑  Dashboard URL: http://127.0.0.1:${port}/?token=${ACCESS_TOKEN}\n`
           );
         });
 
         server.middlewares.use((req, res, next) => {
-          const url = new URL(req.url ?? "/", "http://127.0.0.1:5173");
+          const url = new URL(req.url ?? "/", "http://127.0.0.1");
           const pathname = url.pathname;
           const isProtectedEndpoint =
             pathname === "/knowledge-graph.json" ||

--- a/understand-anything-plugin/skills/understand-dashboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-dashboard/SKILL.md
@@ -79,7 +79,11 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
 
 5. Start the Vite dev server pointing at the project's knowledge graph:
    ```bash
-   cd <dashboard-dir> && GRAPH_DIR=<project-dir> npx vite --host 127.0.0.1
+   cd <dashboard-dir> && GRAPH_DIR=<project-dir> npx vite --host 127.0.0.1 --strictPort
+   ```
+   If port 5173 is already in use, the server will exit with an error. Set `UNDERSTAND_DASHBOARD_PORT` to use a different port:
+   ```bash
+   cd <dashboard-dir> && GRAPH_DIR=<project-dir> UNDERSTAND_DASHBOARD_PORT=5180 npx vite --host 127.0.0.1 --strictPort
    ```
    Run this in the background so the user can continue working.
 
@@ -101,5 +105,5 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
 ## Notes
 
 - The dashboard auto-opens in the default browser via `--open`
-- If port 5173 is already in use, Vite will pick the next available port
+- The dashboard uses port 5173 by default with `strictPort` enabled — if the port is already in use, the server will exit with an error. Set `UNDERSTAND_DASHBOARD_PORT` to pick a different port.
 - The `GRAPH_DIR` environment variable tells the dashboard where to find the knowledge graph


### PR DESCRIPTION
Ran into the exact scenario described in #234 — had a React dev server on 5173, ran `/understand-anything:understand-dashboard`, and it silently died without binding. The printed URL pointed at my other project.

The root cause is that the SKILL.md command (`npx vite --host 127.0.0.1`) doesn't pass `--strictPort`, and `vite.config.ts` doesn't set it either. When 5173 is taken, Vite just exits without a useful error.

This PR does what the issue author suggested as (1)+(3):

- **`strictPort: true`** in vite.config.ts — port collision now produces a clear error instead of silent failure
- **`UNDERSTAND_DASHBOARD_PORT` env var** — lets users pick a different port when 5173 is occupied (defaults to 5173 for back-compat)
- **SKILL.md updated** — adds `--strictPort` to the launch command and documents the env var
- Removed the hardcoded `5173` from the middleware URL base (cosmetic — it only served as a base for `new URL()` path parsing and didn't affect behavior)

Keeps `server.open` as-is since Vite resolves the actual listening port for relative paths.