### PR TITLE
fix(skills/understand): preflight node/pnpm before pipeline starts

### DIFF
--- a/tests/skill/understand/test_preflight.test.mjs
+++ b/tests/skill/understand/test_preflight.test.mjs
@@ -1,0 +1,187 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  writeFileSync,
+  chmodSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(
+  __dirname,
+  '../../../understand-anything-plugin/skills/understand/preflight.sh',
+);
+
+/**
+ * Resolve the real node binary on PATH so we can put its directory into
+ * tightly-scoped test PATHs (vs. inheriting the parent process's full PATH,
+ * which would let preflight see things we don't want it to in negative tests).
+ */
+function realNodeDir() {
+  const which = spawnSync('which', ['node'], { encoding: 'utf-8' });
+  if (which.status !== 0 || !which.stdout.trim()) {
+    throw new Error('test environment has no `node` on PATH — cannot test preflight.sh');
+  }
+  return dirname(which.stdout.trim());
+}
+
+function realPnpmDir() {
+  const which = spawnSync('which', ['pnpm'], { encoding: 'utf-8' });
+  if (which.status !== 0 || !which.stdout.trim()) {
+    return null; // pnpm may be unavailable in some envs — happy-path test will skip
+  }
+  return dirname(which.stdout.trim());
+}
+
+/**
+ * Resolve bash by absolute path. spawnSync uses the *child env's* PATH to
+ * locate the executable, not the parent's — so tests that strip PATH down to
+ * just a fixture directory would otherwise fail with ENOENT for bash itself.
+ */
+const BASH = (() => {
+  const which = spawnSync('which', ['bash'], { encoding: 'utf-8' });
+  return which.status === 0 && which.stdout.trim() ? which.stdout.trim() : '/bin/bash';
+})();
+
+/**
+ * Track every temp dir created so afterEach can sweep them.
+ */
+const tempDirs = [];
+
+function mkTemp() {
+  const dir = mkdtempSync(join(tmpdir(), 'ua-preflight-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Write a shell-script shim into `dir/name` that responds to specific argv
+ * patterns. Used to fake old-node and similar scenarios without touching the
+ * real toolchain.
+ */
+function writeShim(dir, name, body) {
+  const path = join(dir, name);
+  writeFileSync(path, body, 'utf-8');
+  chmodSync(path, 0o755);
+  return path;
+}
+
+/**
+ * Run preflight.sh under a controlled PATH. `env` overrides go on top of a
+ * minimal {PATH, HOME} base so tests are deterministic across hosts.
+ */
+// System bin dirs the preflight script itself needs (for `cat`, etc.) but
+// which never contain node or pnpm on a stock install. Tests prepend their
+// own fixture dirs to this baseline so they can control whether node/pnpm
+// are visible without losing access to coreutils.
+const SYSTEM_BIN = ['/bin', '/usr/bin'];
+
+function runPreflight({ path = '', extraEnv = {} } = {}) {
+  const fullPath = [path, ...SYSTEM_BIN].filter(Boolean).join(':');
+  return spawnSync(BASH, [SCRIPT], {
+    env: {
+      PATH: fullPath,
+      HOME: process.env.HOME ?? '/tmp',
+      ...extraEnv,
+    },
+    encoding: 'utf-8',
+  });
+}
+
+describe('preflight.sh', () => {
+  it('succeeds when node >= 22 and pnpm are both on PATH', () => {
+    const pnpmDir = realPnpmDir();
+    if (!pnpmDir) {
+      // Skip in environments without pnpm — the negative tests still cover the
+      // pnpm-missing branch, so we don't lose coverage.
+      return;
+    }
+
+    const result = runPreflight({
+      path: [realNodeDir(), pnpmDir].join(':'),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/^preflight: node v\d+\.\d+\.\d+, pnpm \d+\.\d+\.\d+/);
+    expect(result.stderr).toBe('');
+  });
+
+  it('exits 1 with an actionable message when node is missing', () => {
+    const empty = mkTemp();
+    const result = runPreflight({ path: empty });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('`node` is not on PATH');
+    expect(result.stderr).toContain('non-interactive shells');
+    // The error mentions at least one of the version managers users may have
+    // installed Node through; we don't pin the exact name so the test stays
+    // resilient to wording tweaks.
+    expect(result.stderr).toMatch(/nvm|fnm|mise|asdf/);
+    expect(result.stdout).toBe('');
+  });
+
+  it('exits 1 with a version message when node < 22 is on PATH', () => {
+    const shimDir = mkTemp();
+    // Fake node that responds to the exact two invocations preflight makes:
+    //   node --version
+    //   node -e 'console.log(process.versions.node.split(".")[0])'
+    writeShim(
+      shimDir,
+      'node',
+      `#!/usr/bin/env bash
+case "$1" in
+  --version) echo "v20.11.0" ;;
+  -e) echo "20" ;;
+  *) echo "mock node: unexpected args: $*" >&2; exit 1 ;;
+esac
+`,
+    );
+
+    const result = runPreflight({ path: shimDir });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Node.js >= 22 required');
+    expect(result.stderr).toContain('v20.11.0');
+    expect(result.stdout).toBe('');
+  });
+
+  it('exits 1 when node >= 22 is present but pnpm is missing', () => {
+    // Real node, nothing else — preflight should fail at the pnpm check, not
+    // the node checks.
+    const result = runPreflight({ path: realNodeDir() });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('`pnpm` is not on PATH');
+    expect(result.stdout).toBe('');
+  });
+
+  it('exits 1 when `node` is on PATH but the binary itself is broken', () => {
+    const shimDir = mkTemp();
+    // A "node" that prints nothing and exits non-zero — simulates a corrupt
+    // install or a broken nvm symlink.
+    writeShim(
+      shimDir,
+      'node',
+      `#!/usr/bin/env bash
+exit 1
+`,
+    );
+
+    const result = runPreflight({ path: shimDir });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('`node -e` failed');
+    expect(result.stdout).toBe('');
+  });
+});

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -113,12 +113,23 @@ Determine whether to run a full analysis or incremental update.
      exit 1
    fi
 
+   # Preflight: verify `node` (>= 22) and `pnpm` are reachable in the current
+   # shell before invoking anything that needs them. Phase 7 step 2 will later
+   # invoke `node build-fingerprints.mjs`, and Claude Code / Cursor / opencode
+   # spawn non-interactive Bash subshells that may not inherit the PATH set
+   # by ~/.zshrc or ~/.bashrc. Users on nvm/fnm/mise/asdf commonly hit this:
+   # their shim is sourced in the interactive rc file but not in ~/.zshenv
+   # or ~/.bash_profile. If node isn't reachable, the fingerprint script
+   # silently fails and meta.json advances without fingerprints.json — which
+   # permanently breaks subsequent auto-updates (issue #152 family).
+   bash "$PLUGIN_ROOT/skills/understand/preflight.sh" || exit 1
+
    if [ ! -f "$PLUGIN_ROOT/packages/core/dist/index.js" ]; then
      cd "$PLUGIN_ROOT" && (pnpm install --frozen-lockfile 2>/dev/null || pnpm install) && pnpm --filter @understand-anything/core build
    fi
    ```
 
-   If `pnpm` is missing, report to the user: "Install Node.js ≥ 22 and pnpm ≥ 10, then re-run `/understand`."
+   If `preflight.sh` exits non-zero, surface its stderr to the user verbatim — the message names the most likely fix (e.g., sourcing nvm/fnm/mise from `~/.zshenv` for non-interactive shells, or upgrading Node).
 
 2. Get the current git commit hash:
    ```bash

--- a/understand-anything-plugin/skills/understand/preflight.sh
+++ b/understand-anything-plugin/skills/understand/preflight.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# preflight.sh
+#
+# Verifies that the shell environment has the tools `/understand` depends on
+# (Node.js >= 22 and pnpm) before any later phase tries to invoke them.
+#
+# Why this exists: Phase 7 step 2 runs `node build-fingerprints.mjs` to
+# produce the structural-fingerprint baseline. If `node` isn't reachable in
+# the current shell, that step silently fails and Phase 7 step 3 advances
+# `meta.json` to the new commit hash anyway — leaving the project in a state
+# where every subsequent auto-update sees "no stored fingerprint" for every
+# file, classifies them all as STRUCTURAL, and escalates to FULL_UPDATE
+# permanently (issue #152 family).
+#
+# Most common cause: Claude Code, Cursor, opencode, and similar agents spawn
+# non-interactive Bash subshells when running tool calls. Those shells don't
+# source ~/.zshrc or ~/.bashrc. If a user installed Node via nvm / fnm /
+# mise / asdf and only hooked the shim into the interactive rc file, the
+# subshell sees no `node` on PATH even though `node --version` works in the
+# user's regular terminal.
+#
+# Exit codes:
+#   0  — node (>= 22) and pnpm are both reachable
+#   1  — at least one prerequisite is missing or incompatible (stderr names which)
+#
+# Tested by: tests/skill/understand/test_preflight.test.mjs
+
+set -u
+
+# ---- node present ---------------------------------------------------------
+
+if ! command -v node >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+Error: `node` is not on PATH in this shell.
+
+Claude Code (and similar agents) spawn non-interactive shells that may not
+source your shell's interactive rc file (~/.zshrc, ~/.bashrc).
+
+If you use nvm / fnm / mise / asdf, source the shim from a file loaded by
+non-interactive shells (~/.zshenv on zsh, ~/.bash_profile on bash) rather
+than only the interactive rc file. For example, on zsh + mise:
+
+  echo 'eval "$(mise activate zsh)"' >> ~/.zshenv
+
+Then restart Claude Code (or your agent) and re-run /understand.
+EOF
+  exit 1
+fi
+
+# ---- node >= 22 -----------------------------------------------------------
+
+NODE_MAJOR=$(node -e 'console.log(process.versions.node.split(".")[0])' 2>/dev/null || echo "")
+if [ -z "$NODE_MAJOR" ]; then
+  echo "Error: \`node\` is on PATH but \`node -e\` failed. Reinstall Node.js >= 22." >&2
+  exit 1
+fi
+
+if [ "$NODE_MAJOR" -lt 22 ]; then
+  cat >&2 <<EOF
+Error: Node.js >= 22 required, found $(node --version 2>/dev/null || echo unknown).
+
+Upgrade Node (https://nodejs.org/) and re-run /understand.
+EOF
+  exit 1
+fi
+
+# ---- pnpm present ---------------------------------------------------------
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+Error: `pnpm` is not on PATH (Node.js >= 22 and pnpm >= 10 are both required).
+
+Install pnpm (https://pnpm.io/installation) and re-run /understand.
+EOF
+  exit 1
+fi
+
+# All preflight checks passed. Print a single line so callers (and tests)
+# can confirm the script actually ran, since silent success is itself a
+# failure mode worth detecting.
+echo "preflight: node $(node --version), pnpm $(pnpm --version)"
+exit 0


### PR DESCRIPTION
## Summary

Closes the residual silent-failure window from #152: when `node` isn't reachable in the shell `/understand` runs in, Phase 7 step 2 fails silently and Phase 7 step 3 advances `meta.json` anyway — leaving the project with a fresh commit hash recorded but no `fingerprints.json`. The next auto-update sees no stored fingerprint for any file, classifies them all as STRUCTURAL, and escalates every commit to FULL_UPDATE permanently.

Reproduced on plugin v2.7.4 with a user whose nvm/fnm/mise shim was hooked into `~/.zshrc` but not `~/.zshenv`. `node --version` works in her terminal; Claude Code's non-interactive Bash subshell can't see it. `meta.json` + `knowledge-graph.json` get written, no `fingerprints.json`, no error surfaced. Auto-update silently broken from that point onward.

#152's own issue body acknowledges this exact case as a residual gap:

> *"Same failure mode exists in the `/understand` full rebuild (Phase 7, step 2.5) — if the Node.js fingerprint script is skipped or fails silently, meta.json advances to the new commit hash but fingerprints.json stays at the previous state."*

The 2.7.3 fix added the prompt-level "abort Phase 7 if fingerprints fail" instruction. The case above demonstrates that prompt-level abort isn't always honoured by the LLM executor — a deterministic preflight that exits before Phase 7 even runs is the complement.

## Changes

- New `understand-anything-plugin/skills/understand/preflight.sh` — verifies `node` is on PATH, Node major version >= 22, and `pnpm` is on PATH. Each failure exits 1 with an actionable message (e.g., the node-missing message specifically names nvm/fnm/mise/asdf as common triggers and points users at `~/.zshenv` vs `~/.zshrc`).
- `understand-anything-plugin/skills/understand/SKILL.md` — Phase 0 step 1.5 now invokes `bash "\$PLUGIN_ROOT/skills/understand/preflight.sh" || exit 1` after plugin-root resolution and before the conditional `pnpm install` / core build.
- New `tests/skill/understand/test_preflight.test.mjs` — 5 vitest cases covering the happy path, missing node, old node (<22, shim returns v20.11.0), missing pnpm, and broken node binary.

## Why this should be acceptable where #201 wasn't

Aware of #201's rejection grounds — addressing each:

- **"Hard-codes macOS-specific paths"** — no platform-specific paths anywhere. `command -v` and `node --version` only. Cross-platform.
- **"~15 lines of shell preamble in skill files"** — SKILL.md gains 11 lines (1 invocation + 10-line comment). All logic lives in a bundled script — same pattern as `build-fingerprints.mjs` (e7af9ae) and `scan-project.mjs`, both already accepted.
- **"Token/prompt-noise cost for an edge case"** — happy path prints one line of stdout and exits in <100ms. No prompt-side cost.
- **"Fallback masks 'not installed' vs. 'not on PATH'"** — this PR does the opposite. There's no fallback; we just refuse to proceed with an honest error. Directly aligned with the stated maintainer preference.

The qualitative difference from #201: that PR worked around a *visible* error users could already see and fix. This one addresses a *silent* failure mode where users have no idea they're running with a corrupt baseline until weeks later when token spend spikes.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — 201/201 (includes the 5 new preflight cases)
- [x] `pnpm --filter @understand-anything/core test` — 670/670
- [x] `pnpm --filter @understand-anything/skill test` — passes (delegates to root)
- [x] `pnpm build` — all packages build (dashboard chunk-size warning is pre-existing, not introduced by this PR)
- [x] Manual: `env -i PATH=...` invocations confirm each error path surfaces the expected message (missing node, old node, missing pnpm, broken node binary)

## Compatibility

- Backwards compatible. Users with node + pnpm on PATH see one new line of stdout from the preflight, then everything else behaves identically.
- No new dependencies. No CI changes needed (existing `pnpm test` step picks up the new test file via the root `vitest.config.ts`).
- No version bump required (per CONTRIBUTING or maintainer preference).

## Related

- #152 — original auto-update FULL_UPDATE cascade (closed). This PR closes the residual `/understand --full` half explicitly called out in #152's issue body.
- #162 — silent-failure pattern in `extract-structure.mjs` (closed). Same family of "bundled scripts can fail silently and the LLM doesn't notice."

🤖 Generated with [Claude Code](https://claude.com/claude-code)