### PR TITLE
ci: also run CI checks on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Fixes #249

## Problem
The CI workflow only triggers on `pull_request`. Direct commits or merges to `main` are never validated, so broken code can land undetected.

## Change
Add `push: branches: [main]` trigger so every commit to `main` is also validated. No changes to the actual CI steps.