### PR TITLE
chore: add missing metadata to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,23 @@
       "tree-sitter-rust",
       "tree-sitter-typescript"
     ]
+  },
+  "description": "Turn any code into an interactive knowledge graph \u2014 multi-agent pipeline for Claude Code, Cursor, Copilot and more",
+  "homepage": "https://understand-anything.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Lum1104/Understand-Anything.git"
+  },
+  "keywords": [
+    "knowledge-graph",
+    "code-analysis",
+    "claude-code",
+    "multi-agent",
+    "developer-tools",
+    "codebase",
+    "visualization"
+  ],
+  "bugs": {
+    "url": "https://github.com/Lum1104/Understand-Anything/issues"
   }
 }


### PR DESCRIPTION
Fixes #251

Adds missing npm metadata fields:
- `description` — shown on npmjs.com and GitHub sidebar
- `repository` — links to the GitHub repo
- `homepage` — points to understand-anything.com
- `keywords` — improves discoverability
- `bugs` — links issue tracker

No functional changes.