### PR TITLE
feat: add on-demand guide annotations to CodeViewer

### DIFF
--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -233,6 +233,8 @@ Indicators from script data:
 **Language Notes** (optional, your expert judgment):
 If the structural data reveals notable language-specific patterns (e.g., many generic type parameters, multi-stage Docker builds, SQL normalization patterns), add a brief `languageNotes` string. Only add this when genuinely educational.
 
+**Guide annotations:** This batch analyzer MUST NOT emit guide annotations during normal analysis. They are reserved for lazy, on-demand explanation workflows where a user asks to read a specific node with inline commentary. Those workflows should write scoped sidecar files under `.understand-anything/guide-annotations/`, not mutate `knowledge-graph.json`. Each annotation should include or inherit `nodeId`, include a 1-based `line`, concise `text`, and preferably an `anchor` snippet from the target source line so the dashboard can reattach notes after line-number drift. Do not use `languageNotes` for pseudo-code or guided walkthroughs.
+
 ### Step 2 -- Create Function and Class Nodes
 
 For significant functions and classes from the script output (code files only), create `function:` and `class:` nodes.

--- a/understand-anything-plugin/agents/knowledge-graph-guide.md
+++ b/understand-anything-plugin/agents/knowledge-graph-guide.md
@@ -78,6 +78,27 @@ Tours are guided walkthroughs with sequential steps. Each step has:
 - `nodeIds` (string array) — 1-5 node IDs to highlight
 - `languageLesson` (string, optional) — language-specific educational note
 
+### On-Demand Guide Annotations
+
+Projects may optionally include lazy guide annotation sidecar files under `.understand-anything/guide-annotations/`, used by the dashboard's Code view to show explanatory comments between original source lines. Prefer scoped files that mirror the source path and node name, for example `.understand-anything/guide-annotations/src/example.ts/save.json`:
+
+```json
+{
+  "version": 1,
+  "nodeId": "function:src/example.ts:save",
+  "filePath": "src/example.ts",
+  "annotations": [
+    {
+      "line": 104,
+      "anchor": "const nextProgram = assembly.program;",
+      "text": "This line starts the save flow by reading the current editor state."
+    }
+  ]
+}
+```
+
+Use this only when the user asks for inline code guidance, annotated reading, or source comments for a specific file/function/class. Update only the requested node(s), keep each note concise and grounded in the actual source, and use 1-based line numbers from `filePath`. A guide annotation file may set `nodeId` and `filePath` once at the top level, or per annotation when a file intentionally contains notes for multiple nodes. Include `anchor` whenever possible, using a short stable snippet from the source line so notes can survive line-number drift; add optional `before` and `after` snippets when the anchor is ambiguous. Do not generate annotations for the whole graph, do not write them into `knowledge-graph.json`, and do not store pseudo-code or walkthrough notes in `languageNotes`.
+
 ### Domain Graph Specifics
 
 The domain graph (`domain-graph.json`) uses a three-level hierarchy:

--- a/understand-anything-plugin/packages/dashboard/src/App.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useMemo, useCallback, lazy, Suspense } from "react
 import { validateGraph } from "@understand-anything/core/schema";
 import type { GraphIssue } from "@understand-anything/core/schema";
 import { useDashboardStore } from "./store";
+import type { GuideAnnotationRecord } from "./store";
 import GraphView from "./components/GraphView";
 import DomainGraphView from "./components/DomainGraphView";
 import KnowledgeGraphView from "./components/KnowledgeGraphView";
@@ -52,6 +53,7 @@ function dataUrl(fileName: string, token: string | null): string {
     const envMap: Record<string, string | undefined> = {
       "knowledge-graph.json": import.meta.env.VITE_GRAPH_URL,
       "domain-graph.json": import.meta.env.VITE_DOMAIN_GRAPH_URL,
+      "guide-annotations.json": import.meta.env.VITE_GUIDE_ANNOTATIONS_URL,
       "meta.json": import.meta.env.VITE_META_URL,
       "diff-overlay.json": import.meta.env.VITE_DIFF_OVERLAY_URL,
       "config.json": import.meta.env.VITE_CONFIG_URL,
@@ -107,6 +109,7 @@ function App() {
 
 function Dashboard({ accessToken }: { accessToken: string }) {
   const setGraph = useDashboardStore((s) => s.setGraph);
+  const setGuideAnnotations = useDashboardStore((s) => s.setGuideAnnotations);
   const setDomainGraph = useDashboardStore((s) => s.setDomainGraph);
   const setDiffOverlay = useDashboardStore((s) => s.setDiffOverlay);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -161,6 +164,33 @@ function Dashboard({ accessToken }: { accessToken: string }) {
         setLoadError(`Failed to load knowledge graph: ${err instanceof Error ? err.message : String(err)}`);
       });
   }, [setGraph]);
+
+  useEffect(() => {
+    fetch(dataUrl("guide-annotations.json", accessToken))
+      .then((res) => {
+        if (!res.ok) return null;
+        return res.json();
+      })
+      .then((data: unknown) => {
+        if (!data || typeof data !== "object") return;
+        const annotations = (data as { annotations?: unknown }).annotations;
+        if (!Array.isArray(annotations)) return;
+        setGuideAnnotations(
+          annotations.filter((entry): entry is GuideAnnotationRecord => {
+            if (!entry || typeof entry !== "object") return false;
+            const record = entry as Record<string, unknown>;
+            return (
+              typeof record.nodeId === "string" &&
+              typeof record.line === "number" &&
+              Number.isInteger(record.line) &&
+              record.line > 0 &&
+              typeof record.text === "string"
+            );
+          }),
+        );
+      })
+      .catch(() => {});
+  }, [accessToken, setGuideAnnotations]);
 
   useEffect(() => {
     fetch(dataUrl("diff-overlay.json", accessToken))

--- a/understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Highlight, themes } from "prism-react-renderer";
 import { useDashboardStore } from "../store";
 import { useI18n } from "../contexts/I18nContext";
+import { buildGuideLines, type GuideLine } from "../utils/guideAnnotations";
 
 interface CodeViewerProps {
   accessToken: string;
@@ -22,6 +23,10 @@ type SourceState =
   | { status: "idle" | "loading"; source: null; error: null }
   | { status: "loaded"; source: SourceFile; error: null }
   | { status: "error"; source: null; error: string };
+
+type GuideRenderState =
+  | { status: "idle" | "pending"; lines: GuideLine[] }
+  | { status: "ready"; lines: GuideLine[] };
 
 function fileContentUrl(filePath: string, token: string): string {
   const params = new URLSearchParams({ token, path: filePath });
@@ -64,6 +69,7 @@ export default function CodeViewer({
 }: CodeViewerProps) {
   const graph = useDashboardStore((s) => s.graph);
   const domainGraph = useDashboardStore((s) => s.domainGraph);
+  const guideAnnotationsByNodeId = useDashboardStore((s) => s.guideAnnotationsByNodeId);
   const viewMode = useDashboardStore((s) => s.viewMode);
   const codeViewerNodeId = useDashboardStore((s) => s.codeViewerNodeId);
   const closeCodeViewer = useDashboardStore((s) => s.closeCodeViewer);
@@ -78,6 +84,10 @@ export default function CodeViewer({
     status: "idle",
     source: null,
     error: null,
+  });
+  const [guideRenderState, setGuideRenderState] = useState<GuideRenderState>({
+    status: "idle",
+    lines: [],
   });
   const { t } = useI18n();
 
@@ -124,6 +134,54 @@ export default function CodeViewer({
     return { start: node.lineRange[0], end: node.lineRange[1] };
   }, [node?.lineRange]);
 
+  const source = state.source;
+  const language = source?.language ?? fallbackLanguage(node?.filePath);
+  const guideAnnotations = useMemo(
+    () => (node ? guideAnnotationsByNodeId.get(node.id) ?? [] : []),
+    [guideAnnotationsByNodeId, node],
+  );
+  const hasInlineGuide = guideAnnotations.length > 0;
+
+  useEffect(() => {
+    if (!source || !node || !hasInlineGuide) {
+      setGuideRenderState({ status: "idle", lines: [] });
+      return;
+    }
+
+    let cancelled = false;
+    let timeoutId: number | null = null;
+    let idleId: number | null = null;
+    const idleWindow = window as Window & {
+      requestIdleCallback?: (callback: IdleRequestCallback, options?: IdleRequestOptions) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+
+    setGuideRenderState({ status: "pending", lines: [] });
+
+    const resolveGuideLines = () => {
+      const nextLines = buildGuideLines(
+        source.content,
+        language,
+        guideAnnotations,
+      );
+      if (!cancelled) {
+        setGuideRenderState({ status: "ready", lines: nextLines });
+      }
+    };
+
+    if (idleWindow.requestIdleCallback) {
+      idleId = idleWindow.requestIdleCallback(resolveGuideLines, { timeout: 500 });
+    } else {
+      timeoutId = window.setTimeout(resolveGuideLines, 0);
+    }
+
+    return () => {
+      cancelled = true;
+      if (idleId !== null) idleWindow.cancelIdleCallback?.(idleId);
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+    };
+  }, [source, language, node, hasInlineGuide, guideAnnotations]);
+
   if (!node) {
     return (
       <div className="h-full w-full flex items-center justify-center bg-surface">
@@ -132,13 +190,14 @@ export default function CodeViewer({
     );
   }
 
-  const source = state.source;
-  const language = source?.language ?? fallbackLanguage(node.filePath);
   const lineInfo = highlightedRange
     ? `${t.codeViewer.lines} ${highlightedRange.start}-${highlightedRange.end}`
     : t.codeViewer.fullFile;
   const isModal = presentation === "modal";
   const handleClose = onClose ?? closeCodeViewer;
+  const shouldRenderGuide = hasInlineGuide && guideRenderState.status === "ready";
+  const guideLines = shouldRenderGuide ? guideRenderState.lines : [];
+  const guideCode = shouldRenderGuide ? guideLines.map((line) => line.text).join("\n") : "";
 
   return (
     <div className="h-full w-full flex flex-col bg-surface overflow-hidden">
@@ -212,9 +271,12 @@ export default function CodeViewer({
           <>
             <div className="px-4 py-2 border-b border-border-subtle bg-surface text-[11px] text-text-muted flex items-center justify-between">
               <span>{source.lineCount} {t.codeViewer.linesLabel}</span>
+              {hasInlineGuide && guideRenderState.status === "pending" && (
+                <span>{t.codeViewer.resolvingAnnotations}</span>
+              )}
               <span>{formatBytes(source.sizeBytes)}</span>
             </div>
-            <Highlight code={source.content} language={language} theme={themes.vsDark}>
+            <Highlight code={shouldRenderGuide ? guideCode : source.content} language={language} theme={themes.vsDark}>
               {({ className, style, tokens, getLineProps, getTokenProps }) => (
                 <pre
                   className={`${className} min-w-max p-0 m-0 ${
@@ -223,22 +285,26 @@ export default function CodeViewer({
                   style={{ ...style, background: "transparent" }}
                 >
                   {tokens.map((line, index) => {
-                    const lineNumber = index + 1;
+                    const guideLine = shouldRenderGuide ? guideLines[index] : null;
+                    const lineNumber = guideLine?.lineNumber ?? index + 1;
                     const isHighlighted =
+                      !guideLine?.isGuideComment &&
                       highlightedRange !== null &&
                       lineNumber >= highlightedRange.start &&
                       lineNumber <= highlightedRange.end;
                     const lineProps = getLineProps({ line });
                     return (
                       <div
-                        key={lineNumber}
+                        key={shouldRenderGuide ? `guide-${index}` : lineNumber}
                         {...lineProps}
                         className={`${lineProps.className} flex ${
-                          isHighlighted ? "bg-accent/15" : "hover:bg-elevated/40"
+                          guideLine?.isGuideComment
+                            ? "bg-accent/10"
+                            : isHighlighted ? "bg-accent/15" : "hover:bg-elevated/40"
                         }`}
                       >
                         <span className="w-12 shrink-0 select-none border-r border-border-subtle pr-3 text-right text-text-muted bg-surface/60">
-                          {lineNumber}
+                          {guideLine?.isGuideComment ? "" : lineNumber}
                         </span>
                         <span className="pl-3 pr-6 whitespace-pre">
                           {line.map((token, key) => (

--- a/understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx
@@ -3,6 +3,7 @@ import { Highlight, themes } from "prism-react-renderer";
 import { useDashboardStore } from "../store";
 import { useI18n } from "../contexts/I18nContext";
 import { buildGuideLines, type GuideLine } from "../utils/guideAnnotations";
+import type { GuideAnnotationRecord } from "../store";
 
 interface CodeViewerProps {
   accessToken: string;
@@ -31,6 +32,23 @@ type GuideRenderState =
 function fileContentUrl(filePath: string, token: string): string {
   const params = new URLSearchParams({ token, path: filePath });
   return `/file-content.json?${params.toString()}`;
+}
+
+function guideAnnotationsUrl(token: string): string {
+  const params = new URLSearchParams({ token });
+  return `/guide-annotations.json?${params.toString()}`;
+}
+
+function isGuideAnnotationRecord(entry: unknown): entry is GuideAnnotationRecord {
+  if (!entry || typeof entry !== "object") return false;
+  const record = entry as Record<string, unknown>;
+  return (
+    typeof record.nodeId === "string" &&
+    typeof record.line === "number" &&
+    Number.isInteger(record.line) &&
+    record.line > 0 &&
+    typeof record.text === "string"
+  );
 }
 
 function fallbackLanguage(filePath: string | undefined): string {
@@ -72,7 +90,9 @@ export default function CodeViewer({
   const guideAnnotationsByNodeId = useDashboardStore((s) => s.guideAnnotationsByNodeId);
   const viewMode = useDashboardStore((s) => s.viewMode);
   const codeViewerNodeId = useDashboardStore((s) => s.codeViewerNodeId);
+  const codeViewerOpenRequest = useDashboardStore((s) => s.codeViewerOpenRequest);
   const closeCodeViewer = useDashboardStore((s) => s.closeCodeViewer);
+  const setGuideAnnotations = useDashboardStore((s) => s.setGuideAnnotations);
   const activeGraph = viewMode === "domain" && domainGraph ? domainGraph : graph;
   // Files tab always builds its tree from the structural graph, so a node ID opened from
   // there may not exist in the active (domain) graph — fall back to the structural graph.
@@ -128,6 +148,27 @@ export default function CodeViewer({
 
     return () => controller.abort();
   }, [accessToken, node?.filePath]);
+
+  useEffect(() => {
+    if (!node || accessToken === "__demo__") return;
+
+    const controller = new AbortController();
+    fetch(guideAnnotationsUrl(accessToken), { signal: controller.signal })
+      .then(async (res) => {
+        if (!res.ok) return null;
+        return (await res.json()) as { annotations?: unknown[] };
+      })
+      .then((data) => {
+        if (!data || !Array.isArray(data.annotations)) return;
+        setGuideAnnotations(data.annotations.filter(isGuideAnnotationRecord));
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        console.warn("Failed to refresh guide annotations:", err);
+      });
+
+    return () => controller.abort();
+  }, [accessToken, codeViewerOpenRequest, node, setGuideAnnotations]);
 
   const highlightedRange = useMemo(() => {
     if (!node?.lineRange) return null;

--- a/understand-anything-plugin/packages/dashboard/src/locales/en.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/en.ts
@@ -179,6 +179,7 @@ export const en = {
     closeExpanded: "Close expanded code viewer",
     closeViewer: "Close code viewer",
     sourceUnavailable: "Source unavailable",
+    resolvingAnnotations: "Resolving annotations...",
   },
   customNode: {
     tested: "Tested",

--- a/understand-anything-plugin/packages/dashboard/src/locales/ja.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/ja.ts
@@ -179,6 +179,7 @@ export const ja = {
     closeExpanded: "展開したコードビューアを閉じる",
     closeViewer: "コードビューアを閉じる",
     sourceUnavailable: "ソースが利用できません",
+    resolvingAnnotations: "注釈を解決中...",
   },
   customNode: {
     tested: "テスト済み",

--- a/understand-anything-plugin/packages/dashboard/src/locales/ko.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/ko.ts
@@ -179,6 +179,7 @@ export const ko = {
     closeExpanded: "확장된 코드 뷰어 닫기",
     closeViewer: "코드 뷰어 닫기",
     sourceUnavailable: "소스 사용 불가",
+    resolvingAnnotations: "주석 위치 확인 중...",
   },
   customNode: {
     tested: "테스트됨",

--- a/understand-anything-plugin/packages/dashboard/src/locales/ru.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/ru.ts
@@ -179,6 +179,7 @@ export const ru = {
     closeExpanded: "Закрыть расширенный просмотрщик кода",
     closeViewer: "Закрыть просмотрщик кода",
     sourceUnavailable: "Исходный код недоступен",
+    resolvingAnnotations: "Разрешение аннотаций...",
   },
   customNode: {
     tested: "Покрыт тестами",

--- a/understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts
@@ -179,6 +179,7 @@ export const zhTW = {
     closeExpanded: "關閉展開的程式碼檢視器",
     closeViewer: "關閉程式碼檢視器",
     sourceUnavailable: "原始碼不可用",
+    resolvingAnnotations: "正在解析註解...",
   },
   customNode: {
     tested: "已測試",

--- a/understand-anything-plugin/packages/dashboard/src/locales/zh.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/zh.ts
@@ -179,6 +179,7 @@ export const zh = {
     closeExpanded: "关闭展开的代码查看器",
     closeViewer: "关闭代码查看器",
     sourceUnavailable: "源码不可用",
+    resolvingAnnotations: "正在解析注释...",
   },
   customNode: {
     tested: "已测试",

--- a/understand-anything-plugin/packages/dashboard/src/store.ts
+++ b/understand-anything-plugin/packages/dashboard/src/store.ts
@@ -8,6 +8,7 @@ import type {
   TourStep,
 } from "@understand-anything/core/types";
 import type { ReactFlowInstance } from "@xyflow/react";
+import type { GuideAnnotationInput } from "./utils/guideAnnotations";
 
 export type Persona = "non-technical" | "junior" | "experienced";
 export type NavigationLevel = "overview" | "layer-detail";
@@ -16,6 +17,10 @@ export type Complexity = "simple" | "moderate" | "complex";
 export type EdgeCategory = "structural" | "behavioral" | "data-flow" | "dependencies" | "semantic" | "infrastructure" | "domain" | "knowledge";
 export type ViewMode = "structural" | "domain" | "knowledge";
 export type DetailLevel = "file" | "class";
+export type GuideAnnotationRecord = GuideAnnotationInput & {
+  nodeId: string;
+  filePath?: string;
+};
 
 export interface FilterState {
   nodeTypes: Set<NodeType>;
@@ -80,17 +85,52 @@ function buildGraphIndexes(graph: KnowledgeGraph): {
   for (const node of graph.nodes) nodesById.set(node.id, node);
   const nodeIdToLayerId = new Map<string, string>();
   const nodeIdToLayerIds = new Map<string, Set<string>>();
+  const addNodeLayer = (nodeId: string, layerId: string) => {
+    if (!nodeIdToLayerId.has(nodeId)) nodeIdToLayerId.set(nodeId, layerId);
+    let set = nodeIdToLayerIds.get(nodeId);
+    if (!set) {
+      set = new Set<string>();
+      nodeIdToLayerIds.set(nodeId, set);
+    }
+    set.add(layerId);
+  };
+
   for (const layer of graph.layers) {
     for (const nid of layer.nodeIds) {
-      if (!nodeIdToLayerId.has(nid)) nodeIdToLayerId.set(nid, layer.id);
-      let set = nodeIdToLayerIds.get(nid);
-      if (!set) {
-        set = new Set<string>();
-        nodeIdToLayerIds.set(nid, set);
-      }
-      set.add(layer.id);
+      addNodeLayer(nid, layer.id);
     }
   }
+
+  // Function/class nodes are often represented as children of a file node but
+  // not listed directly in layer.nodeIds. Inherit the file's layer so search,
+  // sidebar links, and Focus can navigate into the correct layer detail view.
+  for (const edge of graph.edges) {
+    if (edge.type !== "contains") continue;
+    const sourceLayerIds = nodeIdToLayerIds.get(edge.source);
+    if (!sourceLayerIds) continue;
+    for (const layerId of sourceLayerIds) addNodeLayer(edge.target, layerId);
+  }
+
+  const filePathToLayerIds = new Map<string, Set<string>>();
+  for (const node of graph.nodes) {
+    if (!node.filePath) continue;
+    const layerIds = nodeIdToLayerIds.get(node.id);
+    if (!layerIds) continue;
+    let set = filePathToLayerIds.get(node.filePath);
+    if (!set) {
+      set = new Set<string>();
+      filePathToLayerIds.set(node.filePath, set);
+    }
+    for (const layerId of layerIds) set.add(layerId);
+  }
+
+  for (const node of graph.nodes) {
+    if (!node.filePath || nodeIdToLayerIds.has(node.id)) continue;
+    const layerIds = filePathToLayerIds.get(node.filePath);
+    if (!layerIds) continue;
+    for (const layerId of layerIds) addNodeLayer(node.id, layerId);
+  }
+
   return { nodesById, nodeIdToLayerId, nodeIdToLayerIds };
 }
 
@@ -99,6 +139,7 @@ const MAX_HISTORY = 50;
 
 interface DashboardStore {
   graph: KnowledgeGraph | null;
+  guideAnnotationsByNodeId: Map<string, GuideAnnotationRecord[]>;
   /** id → node lookup, rebuilt by setGraph. Empty before any graph loads. */
   nodesById: Map<string, GraphNode>;
   /** id → layer id (first-matching-layer wins), rebuilt by setGraph. Empty before any graph loads. */
@@ -155,6 +196,7 @@ interface DashboardStore {
   toggleShowFunctionsInClassView: () => void;
 
   setGraph: (graph: KnowledgeGraph) => void;
+  setGuideAnnotations: (annotations: GuideAnnotationRecord[]) => void;
   selectNode: (nodeId: string | null) => void;
   navigateToNode: (nodeId: string) => void;
   navigateToNodeInLayer: (nodeId: string) => void;
@@ -288,6 +330,7 @@ function layerResetIfChanged(
 
 export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   graph: null,
+  guideAnnotationsByNodeId: new Map<string, GuideAnnotationRecord[]>(),
   nodesById: new Map<string, GraphNode>(),
   nodeIdToLayerId: new Map<string, string>(),
   nodeIdToLayerIds: new Map<string, Set<string>>(),
@@ -391,6 +434,18 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
       stage1Tick: 0,
       layoutIssues: [],
     });
+  },
+  setGuideAnnotations: (annotations) => {
+    const guideAnnotationsByNodeId = new Map<string, GuideAnnotationRecord[]>();
+    for (const annotation of annotations) {
+      const list = guideAnnotationsByNodeId.get(annotation.nodeId) ?? [];
+      list.push(annotation);
+      guideAnnotationsByNodeId.set(annotation.nodeId, list);
+    }
+    for (const list of guideAnnotationsByNodeId.values()) {
+      list.sort((left, right) => left.line - right.line);
+    }
+    set({ guideAnnotationsByNodeId });
   },
 
   selectNode: (nodeId) => {

--- a/understand-anything-plugin/packages/dashboard/src/store.ts
+++ b/understand-anything-plugin/packages/dashboard/src/store.ts
@@ -160,6 +160,7 @@ interface DashboardStore {
   codeViewerOpen: boolean;
   codeViewerNodeId: string | null;
   codeViewerExpanded: boolean;
+  codeViewerOpenRequest: number;
 
   tourActive: boolean;
   currentTourStep: number;
@@ -345,6 +346,7 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
   codeViewerOpen: false,
   codeViewerNodeId: null,
   codeViewerExpanded: false,
+  codeViewerOpenRequest: 0,
 
   tourActive: false,
   currentTourStep: 0,
@@ -597,7 +599,12 @@ export const useDashboardStore = create<DashboardStore>()((set, get) => ({
     }),
 
   openCodeViewer: (nodeId) =>
-    set({ codeViewerOpen: true, codeViewerNodeId: nodeId, codeViewerExpanded: false }),
+    set((state) => ({
+      codeViewerOpen: true,
+      codeViewerNodeId: nodeId,
+      codeViewerExpanded: false,
+      codeViewerOpenRequest: state.codeViewerOpenRequest + 1,
+    })),
   closeCodeViewer: () =>
     set({ codeViewerOpen: false, codeViewerNodeId: null, codeViewerExpanded: false }),
   expandCodeViewer: () => set({ codeViewerExpanded: true }),

--- a/understand-anything-plugin/packages/dashboard/src/utils/__tests__/guideAnnotations.test.ts
+++ b/understand-anything-plugin/packages/dashboard/src/utils/__tests__/guideAnnotations.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildGuideLines } from "../guideAnnotations";
+
+describe("buildGuideLines", () => {
+  it("reattaches annotations when an anchor moves to a different line", () => {
+    const lines = buildGuideLines(
+      ["const intro = true;", "const target = run();", "const outro = true;"].join("\n"),
+      "typescript",
+      [
+        {
+          line: 1,
+          anchor: "const target = run();",
+          text: "Target explanation.",
+        },
+      ],
+    );
+
+    const guideIndex = lines.findIndex((line) => line.isGuideComment);
+    expect(guideIndex).toBeGreaterThan(0);
+    expect(lines[guideIndex].text).toContain("Target explanation. (moved from line 1)");
+    expect(lines[guideIndex + 1]).toMatchObject({
+      text: "const target = run();",
+      lineNumber: 2,
+      isGuideComment: false,
+    });
+  });
+
+  it("marks an annotation stale when its anchor cannot be found", () => {
+    const lines = buildGuideLines(
+      ["const intro = true;", "const target = run();"].join("\n"),
+      "typescript",
+      [
+        {
+          line: 2,
+          anchor: "missingAnchor()",
+          text: "Old explanation.",
+        },
+      ],
+    );
+
+    const guideLine = lines.find((line) => line.isGuideComment);
+    expect(guideLine?.text).toContain("[stale anchor] Old explanation.");
+  });
+});

--- a/understand-anything-plugin/packages/dashboard/src/utils/guideAnnotations.ts
+++ b/understand-anything-plugin/packages/dashboard/src/utils/guideAnnotations.ts
@@ -1,0 +1,158 @@
+export interface GuideLine {
+  text: string;
+  lineNumber: number | null;
+  isGuideComment: boolean;
+}
+
+export interface GuideAnnotationInput {
+  nodeId?: string;
+  filePath?: string;
+  line: number;
+  text: string;
+  anchor?: string;
+  before?: string;
+  after?: string;
+  stale?: boolean;
+}
+
+interface ResolvedGuideAnnotation {
+  text: string;
+  requestedLine: number;
+  resolvedLine: number;
+  stale: boolean;
+}
+
+function commentPrefixForLanguage(language: string): string {
+  if (["python", "ruby", "bash", "shell", "sh", "yaml"].includes(language)) {
+    return "#";
+  }
+  return "//";
+}
+
+function normalizedSnippet(value: string | undefined): string {
+  return value?.trim().replace(/\s+/g, " ") ?? "";
+}
+
+function lineContainsSnippet(line: string | undefined, snippet: string): boolean {
+  if (!snippet) return false;
+  return normalizedSnippet(line).includes(snippet);
+}
+
+function scoreAnchorCandidate(
+  sourceLines: string[],
+  lineIndex: number,
+  annotation: GuideAnnotationInput,
+): number {
+  let score = 0;
+  const before = normalizedSnippet(annotation.before);
+  const after = normalizedSnippet(annotation.after);
+  if (before) {
+    for (let index = Math.max(0, lineIndex - 3); index < lineIndex; index += 1) {
+      if (lineContainsSnippet(sourceLines[index], before)) score += 2;
+    }
+  }
+  if (after) {
+    for (let index = lineIndex + 1; index <= Math.min(sourceLines.length - 1, lineIndex + 3); index += 1) {
+      if (lineContainsSnippet(sourceLines[index], after)) score += 2;
+    }
+  }
+  score -= Math.abs(lineIndex + 1 - annotation.line) / 1000;
+  return score;
+}
+
+function resolveGuideAnnotation(
+  sourceLines: string[],
+  annotation: GuideAnnotationInput,
+): ResolvedGuideAnnotation | null {
+  const requestedLine = annotation.line;
+  const fallbackLine = Math.min(Math.max(requestedLine, 1), Math.max(sourceLines.length, 1));
+  const anchor = normalizedSnippet(annotation.anchor);
+
+  if (!anchor) {
+    return {
+      text: annotation.text,
+      requestedLine,
+      resolvedLine: fallbackLine,
+      stale: Boolean(annotation.stale),
+    };
+  }
+
+  const requestedIndex = requestedLine - 1;
+  if (lineContainsSnippet(sourceLines[requestedIndex], anchor)) {
+    return {
+      text: annotation.text,
+      requestedLine,
+      resolvedLine: requestedLine,
+      stale: Boolean(annotation.stale),
+    };
+  }
+
+  const candidates = sourceLines
+    .map((line, index) => ({ line, index }))
+    .filter(({ line }) => lineContainsSnippet(line, anchor));
+
+  if (candidates.length === 0) {
+    if (fallbackLine < 1 || fallbackLine > sourceLines.length) return null;
+    return {
+      text: annotation.text,
+      requestedLine,
+      resolvedLine: fallbackLine,
+      stale: true,
+    };
+  }
+
+  candidates.sort((left, right) => {
+    const scoreDelta =
+      scoreAnchorCandidate(sourceLines, right.index, annotation) -
+      scoreAnchorCandidate(sourceLines, left.index, annotation);
+    if (scoreDelta !== 0) return scoreDelta;
+    return Math.abs(left.index + 1 - requestedLine) - Math.abs(right.index + 1 - requestedLine);
+  });
+
+  return {
+    text: annotation.text,
+    requestedLine,
+    resolvedLine: candidates[0].index + 1,
+    stale: Boolean(annotation.stale),
+  };
+}
+
+export function buildGuideLines(
+  sourceContent: string,
+  language: string,
+  guideAnnotations: GuideAnnotationInput[] | undefined,
+): GuideLine[] {
+  const prefix = commentPrefixForLanguage(language);
+  const lines: GuideLine[] = [];
+  const annotationsByLine = new Map<number, string[]>();
+  const sourceLines = sourceContent.split(/\r?\n/);
+  for (const annotation of guideAnnotations ?? []) {
+    const resolved = resolveGuideAnnotation(sourceLines, annotation);
+    if (!resolved) continue;
+    const list = annotationsByLine.get(resolved.resolvedLine) ?? [];
+    const movedSuffix = resolved.resolvedLine !== resolved.requestedLine
+      ? ` (moved from line ${resolved.requestedLine})`
+      : "";
+    const stalePrefix = resolved.stale ? "[stale anchor] " : "";
+    list.push(`${stalePrefix}${resolved.text}${movedSuffix}`);
+    annotationsByLine.set(resolved.resolvedLine, list);
+  }
+
+  for (let lineNumber = 1; lineNumber <= sourceLines.length; lineNumber += 1) {
+    for (const annotation of annotationsByLine.get(lineNumber) ?? []) {
+      for (const rawLine of annotation.split(/\r?\n/)) {
+        lines.push({
+          text: rawLine.trim() ? `${prefix} ${rawLine}` : prefix,
+          lineNumber: null,
+          isGuideComment: true,
+        });
+      }
+    }
+    lines.push({
+      text: sourceLines[lineNumber - 1] ?? "",
+      lineNumber,
+      isGuideComment: false,
+    });
+  }
+  return lines;
+}

--- a/understand-anything-plugin/packages/dashboard/vite.config.ts
+++ b/understand-anything-plugin/packages/dashboard/vite.config.ts
@@ -23,6 +23,17 @@ function graphFileCandidates(fileName: string): string[] {
   ];
 }
 
+function guideAnnotationDirCandidates(): string[] {
+  const graphDir = process.env.GRAPH_DIR;
+  return [
+    ...(graphDir
+      ? [path.resolve(graphDir, ".understand-anything/guide-annotations")]
+      : []),
+    path.resolve(process.cwd(), ".understand-anything/guide-annotations"),
+    path.resolve(process.cwd(), "../../../.understand-anything/guide-annotations"),
+  ];
+}
+
 function findGraphFile(fileName: string): string | null {
   return graphFileCandidates(fileName).find((candidate) => fs.existsSync(candidate)) ?? null;
 }
@@ -105,6 +116,76 @@ function sendJson(res: import("http").ServerResponse, statusCode: number, payloa
   res.statusCode = statusCode;
   res.setHeader("Content-Type", "application/json");
   res.end(JSON.stringify(payload));
+}
+
+function collectJsonFiles(root: string): string[] {
+  const files: string[] = [];
+  if (!fs.existsSync(root)) return files;
+  const stat = fs.statSync(root);
+  if (!stat.isDirectory()) return files;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectJsonFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function normalizeGuideAnnotation(entry: unknown, defaults: { nodeId?: string; filePath?: string }) {
+  if (!entry || typeof entry !== "object") return null;
+  const record = entry as Record<string, unknown>;
+  const nodeId = typeof record.nodeId === "string" ? record.nodeId : defaults.nodeId;
+  const filePath = typeof record.filePath === "string" ? record.filePath : defaults.filePath;
+  if (!nodeId || typeof record.line !== "number" || !Number.isInteger(record.line) || record.line <= 0) {
+    return null;
+  }
+  if (typeof record.text !== "string") return null;
+  return {
+    nodeId,
+    ...(filePath ? { filePath } : {}),
+    line: record.line,
+    text: record.text,
+    ...(typeof record.anchor === "string" ? { anchor: record.anchor } : {}),
+    ...(typeof record.before === "string" ? { before: record.before } : {}),
+    ...(typeof record.after === "string" ? { after: record.after } : {}),
+    ...(typeof record.stale === "boolean" ? { stale: record.stale } : {}),
+  };
+}
+
+function readGuideAnnotations() {
+  const annotations: unknown[] = [];
+  const legacyFiles = graphFileCandidates("guide-annotations.json").filter((candidate) =>
+    fs.existsSync(candidate),
+  );
+  for (const candidate of legacyFiles) {
+    const raw = JSON.parse(fs.readFileSync(candidate, "utf-8")) as { annotations?: unknown[] };
+    for (const entry of raw.annotations ?? []) {
+      const normalized = normalizeGuideAnnotation(entry, {});
+      if (normalized) annotations.push(normalized);
+    }
+  }
+
+  for (const dir of guideAnnotationDirCandidates()) {
+    for (const file of collectJsonFiles(dir)) {
+      const raw = JSON.parse(fs.readFileSync(file, "utf-8")) as {
+        nodeId?: string;
+        filePath?: string;
+        annotations?: unknown[];
+      };
+      for (const entry of raw.annotations ?? []) {
+        const normalized = normalizeGuideAnnotation(entry, {
+          nodeId: raw.nodeId,
+          filePath: raw.filePath,
+        });
+        if (normalized) annotations.push(normalized);
+      }
+    }
+  }
+
+  return { version: 1, annotations };
 }
 
 function rejectFileRequest(message: string, statusCode = 400) {
@@ -250,6 +331,7 @@ export default defineConfig({
           const isProtectedEndpoint =
             pathname === "/knowledge-graph.json" ||
             pathname === "/domain-graph.json" ||
+            pathname === "/guide-annotations.json" ||
             pathname === "/diff-overlay.json" ||
             pathname === "/meta.json" ||
             pathname === "/config.json" ||
@@ -288,6 +370,16 @@ export default defineConfig({
               }
             }
             sendJson(res, 200, { autoUpdate: false, outputLanguage: "en" });
+            return;
+          }
+
+          if (pathname === "/guide-annotations.json") {
+            try {
+              sendJson(res, 200, readGuideAnnotations());
+            } catch (err) {
+              console.error("[understand-anything] Failed to read guide annotations:", err);
+              sendJson(res, 500, { error: "Failed to read guide annotations" });
+            }
             return;
           }
 

--- a/understand-anything-plugin/packages/dashboard/vite.config.ts
+++ b/understand-anything-plugin/packages/dashboard/vite.config.ts
@@ -114,7 +114,7 @@ function detectLanguage(filePath: string): string {
 
 function sendJson(res: import("http").ServerResponse, statusCode: number, payload: unknown) {
   res.statusCode = statusCode;
-  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
   res.end(JSON.stringify(payload));
 }
 

--- a/understand-anything-plugin/skills/understand-explain/SKILL.md
+++ b/understand-anything-plugin/skills/understand-explain/SKILL.md
@@ -56,3 +56,26 @@ The knowledge graph JSON has this structure:
    - Data flow (inputs → processing → outputs — from source code)
    - Explain clearly, assuming the reader may not know the programming language
    - Highlight any patterns, idioms, or complexity worth understanding
+
+8. **Optional on-demand code guide annotations**:
+   - If the user asks for inline guidance, annotated code, comments between source lines, or a guided reading experience in the dashboard, update a scoped JSON file under `.understand-anything/guide-annotations/`, not `knowledge-graph.json`.
+   - Do not annotate the whole graph. Keep this lazy and scoped to what the user asked to read.
+   - Prefer mirroring the source path and node name, for example `.understand-anything/guide-annotations/src/example.ts/save.json`, using this shape:
+     ```json
+     {
+       "version": 1,
+       "nodeId": "function:src/example.ts:save",
+       "filePath": "src/example.ts",
+       "annotations": [
+         {
+           "line": 104,
+           "anchor": "const nextProgram = assembly.program;",
+           "text": "This line starts the save flow by reading the current editor state."
+         }
+       ]
+     }
+     ```
+   - `nodeId` should be the exact graph node id being annotated. Set `nodeId` and `filePath` at the top level for single-node files, or per annotation only when a file intentionally contains notes for multiple nodes. `line` is a 1-based line number in `filePath`; the dashboard renders the annotation before that source line without changing the source file.
+   - Include `anchor` whenever possible, using a short stable snippet from the source line. This lets the dashboard reattach the annotation if edits move the code to a different line. If the same anchor appears multiple times, add optional `before` and `after` snippets from nearby lines to disambiguate.
+   - `text` should be 1-2 concise, source-grounded sentences. Prefer explaining intent, data flow, or side effects at that point in the code.
+   - Do not put pseudo-code, walkthrough prose, or inline reading notes in `languageNotes`; that field is only for language-specific concepts and idioms.

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -20,6 +20,31 @@ Analyze the current codebase and produce a `knowledge-graph.json` file in `.unde
 
 ---
 
+## On-Demand Guide Annotations
+
+`/understand` MUST NOT populate guide annotations during normal full or incremental analysis, and MUST NOT write reading notes into `knowledge-graph.json`. Inline reading notes are intentionally lazy: they are reserved for later deep-reading flows where a user asks an agent to annotate a specific file, function, class, or small set of nodes.
+
+When such a request happens outside `/understand`, an agent may create or update one or more scoped JSON files under `.understand-anything/guide-annotations/` with only the requested node(s). Prefer mirroring the source path and node name, for example `.understand-anything/guide-annotations/src/example.ts/save.json`:
+
+```json
+{
+  "version": 1,
+  "nodeId": "function:src/example.ts:save",
+  "filePath": "src/example.ts",
+  "annotations": [
+    {
+      "line": 104,
+      "anchor": "const nextProgram = assembly.program;",
+      "text": "Short source-grounded explanation rendered before this source line."
+    }
+  ]
+}
+```
+
+Each `line` is a 1-based source line in `filePath`; the dashboard renders the annotation before that line without modifying the source file. A guide annotation file may set `nodeId` and `filePath` once at the top level, or per annotation when a file intentionally contains notes for multiple nodes. Include `anchor` whenever possible, using a short stable snippet from the source line so the dashboard can reattach the note if the file changes and line numbers drift. Optional `before` and `after` snippets may be included when the anchor text appears multiple times. Do not store walkthroughs or pseudo-code in `languageNotes`; that field is only for language-specific concepts and idioms.
+
+---
+
 ## Progress Reporting
 
 Throughout execution, report progress to the user at each phase transition and during batch processing. This keeps users informed on large codebases where analysis can take a long time.

--- a/understand-anything-plugin/src/explain-builder.ts
+++ b/understand-anything-plugin/src/explain-builder.ts
@@ -190,6 +190,7 @@ export function formatExplainPrompt(ctx: ExplainContext): string {
   lines.push("3. How it interacts with connected components");
   lines.push("4. Any patterns, idioms, or design decisions worth noting");
   lines.push("5. Potential gotchas or areas of complexity");
+  lines.push("6. If the user explicitly asks for inline annotated reading in the dashboard, produce scoped sidecar files under .understand-anything/guide-annotations/ only, using the requested node id, 1-based source line numbers, an anchor snippet from the target source line when possible, and concise source-grounded text. Do not mutate knowledge-graph.json or use languageNotes for pseudo-code or walkthrough prose.");
   lines.push("");
 
   return lines.join("\n");


### PR DESCRIPTION
## Summary

Adds optional, lazy guide annotations that agents can create for inline code reading. The dashboard aggregates scoped sidecar JSON files from `.understand-anything/guide-annotations/**/*.json` and renders those notes between source lines without modifying source files or mutating the generated knowledge graph.

## What changed

- Load scoped guide annotation sidecar files from `.understand-anything/guide-annotations/**/*.json` and serve the aggregated payload through `/guide-annotations.json`.
- Keep guide annotations out of `knowledge-graph.json` and out of the core `GraphNode` schema.
- Support `anchor`, `before`, `after`, and `stale` metadata so annotations can survive line-number drift.
- Render annotations inline in the existing Code view while preserving full-file source display and line highlights.
- Resolve annotation anchors asynchronously after the source file is loaded, so opening code is not blocked.
- Move annotation positioning/render-line assembly into a dedicated dashboard utility with focused tests.
- Update agent/skill guidance so annotations are created only on demand for requested nodes, not during full `/understand` analysis.

## Validation

- pnpm --filter @understand-anything/core build
- pnpm --filter @understand-anything/core test
- pnpm --filter @understand-anything/dashboard test
- pnpm --filter @understand-anything/dashboard build

## Screenshot

<img width="1920" height="953" alt="Understand-Anything-05-27-2026_03_43_AM" src="https://github.com/user-attachments/assets/16a592e3-7863-4565-80cc-1d986312d6c2" />