### PR TITLE
Fix auto-update hooks on Windows

### DIFF
--- a/understand-anything-plugin/hooks/auto-update-check.mjs
+++ b/understand-anything-plugin/hooks/auto-update-check.mjs
@@ -1,0 +1,74 @@
+import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const GRAPH_DIR = ".understand-anything";
+const CONFIG_PATH = `${GRAPH_DIR}/config.json`;
+const GRAPH_PATH = `${GRAPH_DIR}/knowledge-graph.json`;
+const META_PATH = `${GRAPH_DIR}/meta.json`;
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function autoUpdateEnabled() {
+  const config = readJson(CONFIG_PATH);
+  return config?.autoUpdate === true;
+}
+
+function graphExists() {
+  return existsSync(GRAPH_PATH);
+}
+
+function promptPath() {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT || process.env.UA_PLUGIN_ROOT || "";
+  return pluginRoot ? `${pluginRoot.replace(/[\\/]$/, "")}/hooks/auto-update-prompt.md` : "hooks/auto-update-prompt.md";
+}
+
+function currentCommit() {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function emit(reason) {
+  console.log(
+    `[understand-anything] ${reason}. You MUST read the file at ${promptPath()} and execute its instructions to incrementally update the knowledge graph. Do not ask the user for confirmation — just do it.`,
+  );
+}
+
+const mode = process.argv[2];
+
+if (!autoUpdateEnabled() || !graphExists()) {
+  process.exit(0);
+}
+
+if (mode === "post-tool-use") {
+  const toolInput = process.env.TOOL_INPUT || "";
+  if (/\bgit\s+(commit|merge|cherry-pick|rebase)\b/.test(toolInput)) {
+    emit("Commit detected with auto-update enabled");
+  }
+  process.exit(0);
+}
+
+if (mode === "session-start") {
+  if (!existsSync(META_PATH)) {
+    process.exit(0);
+  }
+
+  const meta = readJson(META_PATH);
+  const previousCommit = meta?.gitCommitHash || "";
+  const head = currentCommit();
+
+  if (previousCommit && head && previousCommit !== head) {
+    emit("Knowledge graph is stale");
+  }
+}

--- a/understand-anything-plugin/hooks/hooks.json
+++ b/understand-anything-plugin/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "printf '%s' \"$TOOL_INPUT\" | grep -qE 'git\\s+(commit|merge|cherry-pick|rebase)' && [ -f .understand-anything/config.json ] && grep -q '\"autoUpdate\".*true' .understand-anything/config.json && [ -f .understand-anything/knowledge-graph.json ] && echo \"[understand-anything] Commit detected with auto-update enabled. You MUST read the file at ${CLAUDE_PLUGIN_ROOT}/hooks/auto-update-prompt.md and execute its instructions to incrementally update the knowledge graph. Do not ask the user for confirmation — just do it.\" || true"
+            "command": "node -e \"const path=require('node:path');const{pathToFileURL}=require('node:url');const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.UA_PLUGIN_ROOT||process.cwd();import(pathToFileURL(path.join(root,'hooks','auto-update-check.mjs')).href).catch(()=>{})\" post-tool-use"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -f .understand-anything/config.json ] && grep -q '\"autoUpdate\".*true' .understand-anything/config.json && [ -f .understand-anything/meta.json ] && [ -f .understand-anything/knowledge-graph.json ] && [ \"$(node -p \"JSON.parse(require('fs').readFileSync('.understand-anything/meta.json','utf8')).gitCommitHash\")\" != \"$(git rev-parse HEAD 2>/dev/null)\" ] && echo \"[understand-anything] Knowledge graph is stale. You MUST read the file at ${CLAUDE_PLUGIN_ROOT}/hooks/auto-update-prompt.md and execute its instructions to check for structural changes and update the graph. Do not ask the user for confirmation — just do it.\" || true"
+            "command": "node -e \"const path=require('node:path');const{pathToFileURL}=require('node:url');const root=process.env.CLAUDE_PLUGIN_ROOT||process.env.UA_PLUGIN_ROOT||process.cwd();import(pathToFileURL(path.join(root,'hooks','auto-update-check.mjs')).href).catch(()=>{})\" session-start"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- replace POSIX shell expressions in plugin hooks with a cross-platform Node hook runner
- preserve the existing post-tool-use commit detection and session-start stale graph checks
- avoid Windows cmd.exe errors like `'[' is not recognized` and `'true' is not recognized`

Fixes #262.

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('understand-anything-plugin/hooks/hooks.json','utf8')); console.log('hooks json ok')"`
- `git diff --check`
- manual Node hook smoke test for post-tool-use commit detection

Note: I attempted `pnpm install --frozen-lockfile`, but it hung while bootstrapping the pinned pnpm version and was terminated to avoid leaving a stuck process. This PR only changes hook command wiring and adds a dependency-free Node script.