### PR TITLE
Fix Antigravity 2 plugin install path

### DIFF
--- a/agents
+++ b/agents
@@ -1,0 +1,1 @@
+understand-anything-plugin/agents

--- a/hooks
+++ b/hooks
@@ -1,0 +1,1 @@
+understand-anything-plugin/hooks

--- a/install.ps1
+++ b/install.ps1
@@ -26,14 +26,15 @@ $RepoUrl    = if ($env:UA_REPO_URL) { $env:UA_REPO_URL } else { 'https://github.
 $RepoDir    = if ($env:UA_DIR)      { $env:UA_DIR }      else { Join-Path $HOME '.understand-anything\repo' }
 $PluginLink = Join-Path $HOME '.understand-anything-plugin'
 
-# Platform table — Target = skills directory; Style = "per-skill" | "folder"
+# Platform table — Target = install directory; Style = "per-skill" | "folder" | "plugin-root"
 $Platforms = [ordered]@{
     gemini      = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     codex       = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     opencode    = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     pi          = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     openclaw    = @{ Target = (Join-Path $HOME '.openclaw\skills');           Style = 'folder' }
-    antigravity = @{ Target = (Join-Path $HOME '.gemini\antigravity\skills'); Style = 'folder' }
+    antigravity = @{ Target = (Join-Path $HOME '.gemini\config\plugins');     Style = 'plugin-root' }
+    'antigravity-legacy' = @{ Target = (Join-Path $HOME '.gemini\antigravity\skills'); Style = 'folder' }
     vscode      = @{ Target = (Join-Path $HOME '.copilot\skills');            Style = 'per-skill' }
     hermes      = @{ Target = (Join-Path $HOME '.hermes\skills');             Style = 'folder' }
     cline       = @{ Target = (Join-Path $HOME '.cline\skills');              Style = 'folder' }
@@ -150,6 +151,12 @@ function Link-Skills([string]$Target, [string]$Style) {
             New-Junction $link $root
             Write-Host "  ✓ $link → $root"
         }
+        'plugin-root' {
+            $link = Join-Path $Target 'understand-anything-plugin'
+            $src = Join-Path $RepoDir 'understand-anything-plugin'
+            New-Junction $link $src
+            Write-Host "  ✓ $link → $src"
+        }
         default { Write-Error "Unknown style: $Style" }
     }
 }
@@ -177,6 +184,9 @@ function Unlink-Skills([string]$Target, [string]$Style) {
         }
         'folder' {
             Remove-Reparse (Join-Path $Target 'understand-anything') | Out-Null
+        }
+        'plugin-root' {
+            Remove-Reparse (Join-Path $Target 'understand-anything-plugin') | Out-Null
         }
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -22,10 +22,12 @@ REPO_URL="${UA_REPO_URL:-https://github.com/Lum1104/Understand-Anything.git}"
 REPO_DIR="${UA_DIR:-$HOME/.understand-anything/repo}"
 PLUGIN_LINK="$HOME/.understand-anything-plugin"
 
-# Platform table — id|skills-target-dir|style
+# Platform table — id|install-target-dir|style
 # style "per-skill": one symlink per skill into the target dir
 # style "folder":    one symlink for the whole skills/ dir into the target,
 #                    named "understand-anything"
+# style "plugin-root": one symlink for the whole plugin root into the target,
+#                      named "understand-anything-plugin"
 platforms_table() {
   cat <<EOF
 gemini|$HOME/.agents/skills|per-skill
@@ -33,7 +35,8 @@ codex|$HOME/.agents/skills|per-skill
 opencode|$HOME/.agents/skills|per-skill
 pi|$HOME/.agents/skills|per-skill
 openclaw|$HOME/.openclaw/skills|folder
-antigravity|$HOME/.gemini/antigravity/skills|folder
+antigravity|$HOME/.gemini/config/plugins|plugin-root
+antigravity-legacy|$HOME/.gemini/antigravity/skills|folder
 vibe|$HOME/.vibe/skills|per-skill
 vscode|$HOME/.copilot/skills|per-skill
 hermes|$HOME/.hermes/skills|folder
@@ -132,6 +135,10 @@ link_skills() {
       ln -sfn "$root" "$target/understand-anything"
       printf '  ✓ %s → %s\n' "$target/understand-anything" "$root"
       ;;
+    plugin-root)
+      ln -sfn "$REPO_DIR/understand-anything-plugin" "$target/understand-anything-plugin"
+      printf '  ✓ %s → %s\n' "$target/understand-anything-plugin" "$REPO_DIR/understand-anything-plugin"
+      ;;
     *)
       printf 'Unknown style: %s\n' "$style" >&2
       exit 1
@@ -163,6 +170,9 @@ unlink_skills() {
       ;;
     folder)
       [[ -L "$target/understand-anything" ]] && rm -f "$target/understand-anything"
+      ;;
+    plugin-root)
+      [[ -L "$target/understand-anything-plugin" ]] && rm -f "$target/understand-anything-plugin"
       ;;
   esac
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "understand-anything",
+  "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
+  "version": "2.7.5",
+  "author": {
+    "name": "Lum1104"
+  },
+  "homepage": "https://github.com/Lum1104/Understand-Anything",
+  "repository": "https://github.com/Lum1104/Understand-Anything",
+  "license": "MIT",
+  "keywords": [
+    "codebase-analysis",
+    "knowledge-graph",
+    "architecture",
+    "onboarding",
+    "dashboard"
+  ],
+  "skills": "./skills/",
+  "agents": "./agents/"
+}

--- a/skills
+++ b/skills
@@ -1,0 +1,1 @@
+understand-anything-plugin/skills

--- a/understand-anything-plugin/plugin.json
+++ b/understand-anything-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "understand-anything",
+  "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
+  "version": "2.7.5",
+  "author": {
+    "name": "Lum1104"
+  },
+  "homepage": "https://github.com/Lum1104/Understand-Anything",
+  "repository": "https://github.com/Lum1104/Understand-Anything",
+  "license": "MIT",
+  "keywords": [
+    "codebase-analysis",
+    "knowledge-graph",
+    "architecture",
+    "onboarding",
+    "dashboard"
+  ],
+  "skills": "./skills/",
+  "agents": "./agents/"
+}


### PR DESCRIPTION
## Summary
- Update the default Antigravity install target to the Antigravity 2 plugin directory: `~/.gemini/config/plugins/understand-anything-plugin`.
- Keep the old `~/.gemini/antigravity/skills` install available as `antigravity-legacy`.
- Add plugin manifests for both install paths:
  - `understand-anything-plugin/plugin.json` for installer-created plugin-root links.
  - root `plugin.json` plus root `skills`, `agents`, and `hooks` links so `agy plugin install .` from a cloned repo sees the full plugin surface instead of only a manifest.
- Mirror the same installer behavior in `install.sh` and `install.ps1` for parity.

Fixes #178.

## Testing
- `bash -n install.sh`
- `node -e "JSON.parse(require('fs').readFileSync('plugin.json','utf8')); JSON.parse(require('fs').readFileSync('understand-anything-plugin/plugin.json','utf8')); console.log('plugin json ok')"`
- `test -f skills/understand/SKILL.md`
- `test -f agents/project-scanner.md`
- `test -f hooks/hooks.json`
- `git diff --check`

Note: PowerShell is not installed in this local environment, so I could not run `install.ps1` directly.