### PR TITLE
Resume interrupted full analysis from completed batches

### DIFF
--- a/tests/skill/understand/test_plan_resume_batches.test.mjs
+++ b/tests/skill/understand/test_plan_resume_batches.test.mjs
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(__dirname, '../../../understand-anything-plugin/skills/understand/plan-resume-batches.mjs');
+
+function runScript(projectRoot) {
+  return spawnSync('node', [SCRIPT, projectRoot], {
+    encoding: 'utf-8',
+  });
+}
+
+function setupProject() {
+  const root = mkdtempSync(join(tmpdir(), 'ua-resume-test-'));
+  const intermediate = join(root, '.understand-anything', 'intermediate');
+  mkdirSync(intermediate, { recursive: true });
+  writeFileSync(join(intermediate, 'batches.json'), JSON.stringify({
+    totalBatches: 3,
+    batches: [
+      { batchIndex: 1, files: [{ path: 'src/a.ts' }] },
+      { batchIndex: 2, files: [{ path: 'src/b.ts' }] },
+      { batchIndex: 3, files: [{ path: 'src/c.ts' }] },
+    ],
+  }));
+  return root;
+}
+
+function writeBatch(root, name, body = { nodes: [], edges: [] }) {
+  writeFileSync(
+    join(root, '.understand-anything', 'intermediate', name),
+    typeof body === 'string' ? body : JSON.stringify(body),
+  );
+}
+
+function readPlan(root) {
+  return JSON.parse(readFileSync(
+    join(root, '.understand-anything', 'intermediate', 'resume-plan.json'),
+    'utf-8',
+  ));
+}
+
+describe('plan-resume-batches.mjs', () => {
+  let root;
+
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = undefined;
+  });
+
+  it('marks every batch pending when no checkpoints exist', () => {
+    root = setupProject();
+
+    const result = runScript(root);
+    expect(result.status).toBe(0);
+
+    const plan = readPlan(root);
+    expect(plan.completedBatchIndexes).toEqual([]);
+    expect(plan.pendingBatchIndexes).toEqual([1, 2, 3]);
+    expect(plan.completed).toBe(0);
+    expect(plan.pending).toBe(3);
+  });
+
+  it('reuses valid single-file and multipart checkpoints', () => {
+    root = setupProject();
+    writeBatch(root, 'batch-1.json');
+    writeBatch(root, 'batch-2-part-1.json');
+
+    const result = runScript(root);
+    expect(result.status).toBe(0);
+
+    const plan = readPlan(root);
+    expect(plan.completedBatchIndexes).toEqual([1, 2]);
+    expect(plan.pendingBatchIndexes).toEqual([3]);
+    expect(plan.completed).toBe(2);
+    expect(plan.pending).toBe(1);
+  });
+
+  it('keeps malformed checkpoint files pending', () => {
+    root = setupProject();
+    writeBatch(root, 'batch-1.json', '{not json');
+    writeBatch(root, 'batch-2.json', { nodes: [] });
+
+    const result = runScript(root);
+    expect(result.status).toBe(0);
+
+    const plan = readPlan(root);
+    expect(plan.completedBatchIndexes).toEqual([]);
+    expect(plan.pendingBatchIndexes).toEqual([1, 2, 3]);
+    expect(plan.invalidBatchFiles).toEqual(['batch-1.json', 'batch-2.json']);
+  });
+
+  it('ignores checkpoint files from stale batch indexes', () => {
+    root = setupProject();
+    writeBatch(root, 'batch-9.json');
+
+    const result = runScript(root);
+    expect(result.status).toBe(0);
+
+    const plan = readPlan(root);
+    expect(plan.completedBatchIndexes).toEqual([]);
+    expect(plan.pendingBatchIndexes).toEqual([1, 2, 3]);
+    expect(plan.invalidBatchFiles).toEqual([]);
+  });
+});

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -18,6 +18,8 @@ Analyze the current codebase and produce a `knowledge-graph.json` file in `.unde
   - `--language <lang>` — Generate all textual content (summaries, descriptions, tags, titles, languageNotes, languageLesson) in the specified language. Accepts ISO 639-1 codes (`zh`, `ja`, `ko`, `en`, `es`, `fr`, `de`, etc.) or friendly names (`chinese`, `japanese`, `korean`, `english`, `spanish`, etc.). Locale variants supported: `zh-TW`, `zh-HK`, etc. Defaults to `en` (English). Stores preference in `.understand-anything/config.json` for consistency across incremental updates.
   - A directory path (e.g. `/path/to/repo` or `../other-project`) — Analyze the given directory instead of the current working directory
 
+Full-analysis checkpointing is automatic. If a previous run was interrupted after writing valid `batch-*.json` files, rerunning `/understand --full` reuses those completed batches and dispatches only missing or invalid batches. Delete `.understand-anything/intermediate/batch-*.json` before rerunning if you intentionally want to discard checkpoints.
+
 ---
 
 ## Progress Reporting
@@ -296,11 +298,28 @@ If the script exits non-zero, the failure is hard — relay the full stderr to t
 
 ### Full analysis path
 
-Load `.understand-anything/intermediate/batches.json` (produced by Phase 1.5). Iterate the `batches[]` array.
+Load `.understand-anything/intermediate/batches.json` (produced by Phase 1.5).
+
+Build the resume plan before dispatching file analyzers:
+```bash
+node <SKILL_DIR>/plan-resume-batches.mjs $PROJECT_ROOT
+```
+
+This writes `$PROJECT_ROOT/.understand-anything/intermediate/resume-plan.json`. Load it and use `pendingBatchIndexes` to decide which batches still need analysis. A batch is considered complete only when a valid `batch-<batchIndex>.json` or `batch-<batchIndex>-part-<k>.json` already exists with `nodes` and `edges` arrays.
+
+If `completed > 0`, report:
+> `Resume checkpoint: found <completed>/<totalBatches> completed batches; analyzing <pending> remaining batches.`
+
+If `invalidBatchFiles` is non-empty, report:
+> `Ignoring invalid checkpoint files: <file list>`
+
+Iterate only the `batches[]` entries whose `batchIndex` appears in `pendingBatchIndexes`.
 
 Report: `[Phase 2/7] Analyzing files — <totalFiles> files in <totalBatches> batches (up to 5 concurrent)...`
 
-For each batch, dispatch a subagent using the `file-analyzer` agent definition (at `agents/file-analyzer.md`). Run up to **5 subagents concurrently**. Append the following additional context:
+If `pending` is `0`, skip file-analyzer dispatch and proceed directly to the merge step.
+
+For each pending batch, dispatch a subagent using the `file-analyzer` agent definition (at `agents/file-analyzer.md`). Run up to **5 subagents concurrently**. Append the following additional context:
 
 > **Additional context from main session:**
 >
@@ -336,7 +355,7 @@ Dispatch prompt template (fill in batch-specific values from `batches.json[i]`):
 
 **Output naming is per-batchIndex — no fusion.** If you fuse multiple small batches into a single file-analyzer dispatch for token efficiency, the dispatched agent must STILL write one output file per original `batchIndex` using `batch-<batchIndex>.json` or `batch-<batchIndex>-part-<k>.json`. The merge script's regex (`batch-(\d+)(?:-part-(\d+))?\.json`) silently drops any other naming (e.g., `batch-fused-8-13.json`, `batch-8-13.json`), losing every node and edge in that file. After each dispatch returns, verify each `batchIndex` in the dispatched input has a corresponding `batch-<batchIndex>.json` (or `batch-<batchIndex>-part-*.json`) on disk before proceeding to the next dispatch.
 
-After ALL batches complete, report to the user: `Phase 2 complete. All <totalBatches> batches analyzed.`
+After ALL pending batches complete, report to the user: `Phase 2 complete. All <totalBatches> batches available.`
 
 Run the merge-and-normalize script bundled with this skill (located next to this SKILL.md file — use the skill directory path, not the project root):
 ```bash

--- a/understand-anything-plugin/skills/understand/plan-resume-batches.mjs
+++ b/understand-anything-plugin/skills/understand/plan-resume-batches.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+function fail(message) {
+  console.error(`Error: plan-resume-batches: ${message}`);
+  process.exit(1);
+}
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch (error) {
+    fail(`failed to read ${path}: ${error.message}`);
+  }
+}
+
+function isValidBatchOutput(path) {
+  try {
+    const data = JSON.parse(readFileSync(path, 'utf-8'));
+    return Array.isArray(data.nodes) && Array.isArray(data.edges);
+  } catch {
+    return false;
+  }
+}
+
+const projectRoot = process.argv[2];
+if (!projectRoot) {
+  fail('usage: node plan-resume-batches.mjs <project-root>');
+}
+
+const intermediateDir = join(projectRoot, '.understand-anything', 'intermediate');
+const batchesPath = join(intermediateDir, 'batches.json');
+
+if (!existsSync(batchesPath)) {
+  fail(`missing ${batchesPath}`);
+}
+
+const batchesDoc = readJson(batchesPath);
+const batches = Array.isArray(batchesDoc.batches) ? batchesDoc.batches : [];
+const batchIndexes = batches.map((batch, position) =>
+  Number.isInteger(batch.batchIndex) ? batch.batchIndex : position + 1,
+);
+const knownBatchIndexes = new Set(batchIndexes);
+const completed = new Set();
+const invalidBatchFiles = [];
+
+if (existsSync(intermediateDir)) {
+  for (const name of readdirSync(intermediateDir)) {
+    const match = /^batch-(\d+)(?:-part-\d+)?\.json$/.exec(name);
+    if (!match) continue;
+
+    const batchIndex = Number.parseInt(match[1], 10);
+    if (!knownBatchIndexes.has(batchIndex)) continue;
+
+    const path = join(intermediateDir, name);
+    if (isValidBatchOutput(path)) {
+      completed.add(batchIndex);
+    } else {
+      invalidBatchFiles.push(name);
+    }
+  }
+}
+
+const completedBatchIndexes = batchIndexes.filter(batchIndex => completed.has(batchIndex));
+const pendingBatchIndexes = batchIndexes.filter(batchIndex => !completed.has(batchIndex));
+
+const plan = {
+  schemaVersion: 1,
+  totalBatches: batchIndexes.length,
+  completed: completedBatchIndexes.length,
+  pending: pendingBatchIndexes.length,
+  completedBatchIndexes,
+  pendingBatchIndexes,
+  invalidBatchFiles: invalidBatchFiles.sort(),
+};
+
+mkdirSync(intermediateDir, { recursive: true });
+writeFileSync(join(intermediateDir, 'resume-plan.json'), `${JSON.stringify(plan, null, 2)}\n`);
+console.log(JSON.stringify(plan, null, 2));


### PR DESCRIPTION
## Summary

Adds an automatic checkpoint/resume plan for full `/understand --full` runs:

- detect valid existing `batch-<index>.json` and `batch-<index>-part-<k>.json` outputs
- write `.understand-anything/intermediate/resume-plan.json` with completed and pending batch indexes
- update the `/understand` flow to dispatch only missing or invalid batches before merging
- cover the planner with tests for empty, completed, multipart, malformed, and stale-index checkpoint files

Fixes #149.

## Why

Large codebases can hit rate limits or other interruptions after expensive file-analysis batches have already been written. Before this change, rerunning a full analysis would treat the run as all-or-nothing and repeat work that already completed.

With this change, rerunning `/understand --full` after an interruption can reuse the valid batch fragments already on disk and continue from the remaining batches.

## Testing

- `node --check understand-anything-plugin/skills/understand/plan-resume-batches.mjs`
- `node --check tests/skill/understand/test_plan_resume_batches.test.mjs`
- manual smoke test: created a temporary `.understand-anything/intermediate` with two batches and one valid `batch-1.json`; verified the planner reported batch 1 completed and batch 2 pending
- `git diff --check`

I could not run the Vitest test locally because `pnpm` hangs while bootstrapping the pinned package-manager version in this environment, even for `pnpm --version`.
