### PR TITLE
fix: avoid generated Python batch helpers

### DIFF
--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -309,6 +309,7 @@ For each batch, dispatch a subagent using the `file-analyzer` agent definition (
 >
 > $LANGUAGE_DIRECTIVE
 
+Do not generate ad-hoc Python helper scripts for batch preparation or progress reporting in this phase. Use the already-produced `batches.json` data directly when filling each dispatch prompt. If a one-off shell-visible summary is needed, compute values in separate variables before formatting; never embed generator/set comprehensions directly inside Python f-strings.
 Dispatch prompt template (fill in batch-specific values from `batches.json[i]`):
 
 > Analyze these files and produce GraphNode and GraphEdge objects.


### PR DESCRIPTION
## Summary
- Instruct Phase 2 to use the existing `batches.json` data directly instead of generating ad-hoc Python helper scripts
- Add an explicit guard against embedding generator/set comprehensions directly inside Python f-strings

## Verification
- `pnpm lint`

Closes #272
