### PR TITLE
feat: replace path finder selects with searchable dropdowns

### DIFF
--- a/understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useDashboardStore } from "../store";
+import SearchableSelect from "./SearchableSelect";
 
 interface PathFinderModalProps {
   isOpen: boolean;
@@ -14,12 +15,27 @@ export default function PathFinderModal({ isOpen, onClose }: PathFinderModalProp
   const [path, setPath] = useState<string[] | null>(null);
   const [searching, setSearching] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
+  const nodes = graph?.nodes ?? [];
+  const edges = graph?.edges ?? [];
+  const nodeOptions = useMemo(
+    () =>
+      nodes.map((node) => ({
+        value: node.id,
+        label: node.name,
+        meta: node.type,
+        searchText: `${node.id} ${node.filePath ?? ""}`,
+      })),
+    [nodes],
+  );
 
   // Close on outside click
   useEffect(() => {
     if (!isOpen) return;
 
     const handleClickOutside = (e: MouseEvent) => {
+      if ((e.target as HTMLElement | null)?.closest("[data-searchable-select-dropdown]")) {
+        return;
+      }
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
         onClose();
       }
@@ -34,6 +50,10 @@ export default function PathFinderModal({ isOpen, onClose }: PathFinderModalProp
     if (!isOpen) return;
 
     const handleEscape = (e: KeyboardEvent) => {
+      if ((e.target as HTMLElement | null)?.closest("[data-searchable-select]")) {
+        return;
+      }
+
       if (e.key === "Escape") {
         onClose();
       }
@@ -44,9 +64,6 @@ export default function PathFinderModal({ isOpen, onClose }: PathFinderModalProp
   }, [isOpen, onClose]);
 
   if (!isOpen || !graph) return null;
-
-  const nodes = graph.nodes;
-  const edges = graph.edges;
 
   // BFS to find shortest path
   const findPath = () => {
@@ -147,21 +164,15 @@ export default function PathFinderModal({ isOpen, onClose }: PathFinderModalProp
             <label className="block text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">
               From Node
             </label>
-            <select
+            <SearchableSelect
               value={fromNodeId}
-              onChange={(e) => {
-                setFromNodeId(e.target.value);
+              options={nodeOptions}
+              placeholder="Search nodes..."
+              onChange={(nodeId) => {
+                setFromNodeId(nodeId);
                 setPath(null);
               }}
-              className="w-full bg-elevated text-text-primary text-sm rounded-lg px-3 py-2 border border-border-subtle focus:outline-none focus:border-gold/50"
-            >
-              <option value="">Select a node...</option>
-              {nodes.map((node) => (
-                <option key={node.id} value={node.id}>
-                  {node.name} ({node.type})
-                </option>
-              ))}
-            </select>
+            />
           </div>
 
           {/* To Node */}
@@ -169,21 +180,15 @@ export default function PathFinderModal({ isOpen, onClose }: PathFinderModalProp
             <label className="block text-xs font-semibold text-text-secondary uppercase tracking-wider mb-2">
               To Node
             </label>
-            <select
+            <SearchableSelect
               value={toNodeId}
-              onChange={(e) => {
-                setToNodeId(e.target.value);
+              options={nodeOptions}
+              placeholder="Search nodes..."
+              onChange={(nodeId) => {
+                setToNodeId(nodeId);
                 setPath(null);
               }}
-              className="w-full bg-elevated text-text-primary text-sm rounded-lg px-3 py-2 border border-border-subtle focus:outline-none focus:border-gold/50"
-            >
-              <option value="">Select a node...</option>
-              {nodes.map((node) => (
-                <option key={node.id} value={node.id}>
-                  {node.name} ({node.type})
-                </option>
-              ))}
-            </select>
+            />
           </div>
 
           {/* Find Path Button */}

--- a/understand-anything-plugin/packages/dashboard/src/components/SearchableSelect.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/components/SearchableSelect.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+export interface SearchableSelectOption {
+  value: string;
+  label: string;
+  meta?: string;
+  searchText?: string;
+}
+
+interface SearchableSelectProps {
+  value: string;
+  options: SearchableSelectOption[];
+  placeholder: string;
+  onChange: (value: string) => void;
+}
+
+export default function SearchableSelect({
+  value,
+  options,
+  placeholder,
+  onChange,
+}: SearchableSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const selected = options.find((option) => option.value === value);
+  const filteredOptions = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return options;
+
+    return options.filter((option) => {
+      const haystack = `${option.label} ${option.meta ?? ""} ${option.searchText ?? ""}`.toLowerCase();
+      return haystack.includes(needle);
+    });
+  }, [options, query]);
+
+  const updatePosition = () => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const dropdownMaxH = 256;
+    const openUpward = spaceBelow < dropdownMaxH && rect.top > dropdownMaxH;
+    setDropdownStyle(
+      openUpward
+        ? { position: "fixed", bottom: window.innerHeight - rect.top + 4, left: rect.left, width: rect.width }
+        : { position: "fixed", top: rect.bottom + 4, left: rect.left, width: rect.width },
+    );
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    updatePosition();
+    window.addEventListener("scroll", updatePosition, true);
+    window.addEventListener("resize", updatePosition);
+    return () => {
+      window.removeEventListener("scroll", updatePosition, true);
+      window.removeEventListener("resize", updatePosition);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if ((e.target as HTMLElement | null)?.closest("[data-searchable-select-dropdown]")) {
+        return;
+      }
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setQuery("");
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+        setQuery("");
+        inputRef.current?.blur();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, []);
+
+  const selectOption = (nextValue: string) => {
+    onChange(nextValue);
+    setOpen(false);
+    setQuery("");
+    inputRef.current?.blur();
+  };
+
+  return (
+    <div ref={containerRef} className="relative" data-searchable-select>
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          value={open ? query : selected?.label ?? ""}
+          onFocus={() => {
+            setOpen(true);
+            setQuery("");
+          }}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          placeholder={placeholder}
+          className="w-full bg-elevated text-text-primary text-sm rounded-lg px-3 py-2 pr-9 border border-border-subtle focus:outline-none focus:border-gold/50 placeholder-text-muted"
+        />
+        <button
+          type="button"
+          onClick={() => {
+            setOpen((current) => !current);
+            inputRef.current?.focus();
+          }}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary transition-colors"
+          aria-label="Toggle options"
+        >
+          <svg
+            className={`w-4 h-4 transition-transform ${open ? "rotate-180" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      </div>
+
+      {open &&
+        createPortal(
+          <div
+            role="listbox"
+            data-searchable-select-dropdown
+            style={dropdownStyle}
+            className="z-[9999] max-h-64 overflow-y-auto glass rounded-lg shadow-xl"
+          >
+            {filteredOptions.length === 0 ? (
+              <div className="px-3 py-3 text-sm text-text-muted">No matches found</div>
+            ) : (
+              filteredOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="option"
+                  aria-selected={option.value === value}
+                  onClick={() => selectOption(option.value)}
+                  className={`w-full flex items-center gap-3 px-3 py-2 text-left transition-colors ${
+                    option.value === value
+                      ? "bg-gold/10 text-gold"
+                      : "text-text-primary hover:bg-elevated"
+                  }`}
+                >
+                  <span className="min-w-0 flex-1 truncate text-sm">{option.label}</span>
+                  {option.meta && (
+                    <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-text-muted">
+                      {option.meta}
+                    </span>
+                  )}
+                </button>
+              ))
+            )}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}


### PR DESCRIPTION
Replaces the two native `<select>` elements in the dependancy Path Finder modal with a `<SearchableSelect` component that supports live filtering by node name, type, and file path.

#why

with a large codebases the node list can have hundreds of entries, making `<select>` not easy to navigate. A searchable input lets users to search node names.

#verification

pnpm lint
pnpm dev:dashboard #open path finder modal, verify dropdowns filter and select correctly