### PR TITLE
Add CodeBuddy CLI install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Understand-Anything works across multiple AI coding platforms.
 /plugin install understand-anything
 ```
 
-### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae)
+### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae / CodeBuddy CLI)
 
 **macOS / Linux:**
 ```bash
@@ -200,7 +200,7 @@ iwr -useb https://raw.githubusercontent.com/Lum1104/Understand-Anything/main/ins
 
 The installer clones the repo to `~/.understand-anything/repo` and creates the right symlinks for the chosen platform. Restart your CLI/IDE afterwards.
 
-- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`
+- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `codebuddy`
 - Update later: `./install.sh --update`
 - Uninstall: `./install.sh --uninstall <platform>`
 
@@ -241,6 +241,7 @@ copilot plugin install Lum1104/Understand-Anything:understand-anything-plugin
 | Cline | ✅ Supported | `install.sh cline` |
 | KIMI CLI | ✅ Supported | `install.sh kimi` |
 | Trae | ✅ Supported | `install.sh trae` |
+| CodeBuddy CLI | ✅ Supported | `install.sh codebuddy` |
 
 ---
 

--- a/install.ps1
+++ b/install.ps1
@@ -39,6 +39,7 @@ $Platforms = [ordered]@{
     cline       = @{ Target = (Join-Path $HOME '.cline\skills');              Style = 'folder' }
     kimi        = @{ Target = (Join-Path $HOME '.kimi\skills');               Style = 'folder' }
     trae        = @{ Target = (Join-Path $HOME '.trae\skills');               Style = 'per-skill' }
+    codebuddy   = @{ Target = (Join-Path $HOME '.codebuddy\skills');          Style = 'per-skill' }
 }
 
 function Show-Usage {

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ hermes|$HOME/.hermes/skills|folder
 cline|$HOME/.cline/skills|folder
 kimi|$HOME/.kimi/skills|folder
 trae|$HOME/.trae/skills|per-skill
+codebuddy|$HOME/.codebuddy/skills|per-skill
 EOF
 }
 


### PR DESCRIPTION
## Summary
- Add CodeBuddy CLI as a supported install target in the shell and PowerShell installers.
- Document the CodeBuddy CLI one-line install option in the English README.

## Test plan
- [x] Run `bash -n install.sh`
- [x] Parse `install.ps1` with PowerShell `[scriptblock]::Create(...)`
- [x] Run `./install.sh codebuddy` with isolated `HOME` and local `UA_DIR`
- [x] Run `./install.ps1 codebuddy` with isolated `USERPROFILE` and local `UA_DIR`