### PR TITLE
fix: resolve NodeNext js imports to ts sources

### DIFF
--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -142,6 +142,44 @@ describe('extract-import-map.mjs — TypeScript / JavaScript resolver', () => {
     expect(result.output.importMap['src/index.ts']).toEqual(['src/stuff/index.ts']);
   });
 
+  it('resolves NodeNext .js relative imports to TypeScript source when exact JavaScript target is absent', () => {
+    projectRoot = setupTree({
+      'src/a.ts':
+        `import { b } from './b.js';\n` +
+        `import { c } from './nested/c.js';\n` +
+        `import { d } from './dir/index.js';\n` +
+        `import { e } from './folder.js';\n` +
+        `import { f } from './format.mjs';\n` +
+        `b; c; d;\n`,
+      'src/b.ts': `export const b = 1;\n`,
+      'src/nested/c.tsx': `export const c = 2;\n`,
+      'src/dir/index.ts': `export const d = 3;\n`,
+      'src/folder/index.ts': `export const e = 4;\n`,
+      'src/format.ts': `export const f = 5;\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'src/a.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/b.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/nested/c.tsx', language: 'typescriptreact', fileCategory: 'code' },
+        { path: 'src/dir/index.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/folder/index.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/format.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['src/a.ts']).toEqual([
+      'src/b.ts',
+      'src/dir/index.ts',
+      'src/nested/c.tsx',
+    ]);
+    expect(result.output.importMap['src/a.ts']).not.toContain('src/folder/index.ts');
+    expect(result.output.importMap['src/a.ts']).not.toContain('src/format.ts');
+  });
+
   it('drops external package imports', () => {
     projectRoot = setupTree({
       'src/index.ts': `import express from 'express';\nimport { z } from 'zod';\nimport { foo } from './local';\n`,

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -369,6 +369,13 @@ const TS_EXT_PROBES = [
   '/index.ts', '/index.tsx', '/index.js', '/index.jsx',
 ];
 
+const TS_SOURCE_PROBES_BY_JS_IMPORT_EXT = new Map([
+  ['.js', ['.ts', '.tsx']],
+  ['.jsx', ['.tsx']],
+  ['.mjs', ['.mts']],
+  ['.cjs', ['.cts']],
+]);
+
 /**
  * Try ext probes against the file set for the given base path. Returns the
  * first matching project-relative path, or null. If the base path already has
@@ -378,6 +385,15 @@ function probeWithExtensions(basePath, fileSet) {
   if (!basePath) return null;
   // Exact match (import already had an extension)
   if (fileSet.has(basePath)) return basePath;
+  const importExt = posix.extname(basePath);
+  const tsSourceProbes = TS_SOURCE_PROBES_BY_JS_IMPORT_EXT.get(importExt);
+  if (tsSourceProbes) {
+    const extensionlessBase = basePath.slice(0, -importExt.length);
+    for (const ext of tsSourceProbes) {
+      const candidate = extensionlessBase + ext;
+      if (fileSet.has(candidate)) return candidate;
+    }
+  }
   for (const ext of TS_EXT_PROBES) {
     const candidate = basePath + ext;
     if (fileSet.has(candidate)) return candidate;


### PR DESCRIPTION
## Summary

Fixes TypeScript/NodeNext import-map extraction for explicit `.js` relative imports that point at TypeScript source files.

In NodeNext projects, source commonly writes:

```ts
import { b } from './b.js';
```

while the repository contains `src/b.ts`. Before this patch, `extract-import-map.mjs` treated the `.js` suffix as an exact target only and missed the internal edge.

## Proof

- Upstream `origin/main` at `26edf61`: temp fixture `src/a.ts -> ./b.js` produced `importMap["src/a.ts"] = []`.
- Fixed branch `51fe719`: same fixture produced `importMap["src/a.ts"] = ["src/b.ts"]`.
- Focused test: `pnpm vitest run tests/skill/understand/test_extract_import_map.test.mjs`
- Result: 1 file passed, 45 tests passed.

## Downstream Impact

- demos-agents graph proof from the original local fix: `root_cli_operatorEdges=879`.
