### PR TITLE
fix: build core on plugin install

### DIFF
--- a/understand-anything-plugin/package.json
+++ b/understand-anything-plugin/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "postinstall": "pnpm --filter @understand-anything/core build",
     "test": "node -e \"console.log('skill tests live at <repo-root>/tests/skill — run via root \\`pnpm test\\`')\""
   },
   "dependencies": {


### PR DESCRIPTION


When installing/using the Understand Anything plugin in Cursor, the plugin code can be present but @understand-anything/core is not built, so packages/core/dist/index.js is missing. This causes /understand (and anything importing @understand-anything/core) to fail with ERR_MODULE_NOT_FOUND.

This PR adds a postinstall hook to the plugin package so that installing the plugin workspace builds @understand-anything/core automatically.

**What changed** -------------------------------------------------------------------------------------------------------------
Added postinstall: pnpm --filter @understand-anything/core build to understand-anything-plugin/package.json.
Reproduction (before)
Install the plugin in Cursor.
Run /understand.
Observe failure similar to:
Error [ERR_MODULE_NOT_FOUND]: Cannot find module .../packages/core/dist/index.js
Expected behavior (after)
pnpm install for the plugin workspace triggers postinstall, ensuring packages/core/dist/index.js exists.
/understand can import @understand-anything/core successfully.


