### PR TITLE
fix(merge): recognize batch-existing.json as baseline batch (#292)

### DIFF
--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -1183,5 +1183,124 @@ class TestUnrecognizedBatchFilename(unittest.TestCase):
         self.assertNotIn("file:src/y.ts", node_ids)
 
 
+# ── Issue #292: batch-existing.json baseline recognition ──────────────────
+
+
+class TestBatchExistingBaseline(unittest.TestCase):
+    """Incremental flow writes pruned baseline as `batch-existing.json`
+    (see SKILL.md "Incremental update"). The merge regex must accept this
+    literal alongside `batch-<N>.json` / `batch-<N>-part-<K>.json`, otherwise
+    every baseline node/edge is silently dropped (Issue #292)."""
+
+    def setUp(self) -> None:
+        import tempfile
+        self.tmp = Path(tempfile.mkdtemp(prefix="ua-mbg-existing-"))
+        self.intermediate = self.tmp / ".understand-anything" / "intermediate"
+        self.intermediate.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self) -> None:
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_batch(self, name: str, nodes: list, edges: list) -> None:
+        import json as _j
+        (self.intermediate / name).write_text(
+            _j.dumps({"nodes": nodes, "edges": edges}),
+            encoding="utf-8",
+        )
+
+    def _run_merge(self) -> tuple[int, str, dict]:
+        import subprocess
+        import json as _j
+        result = subprocess.run(
+            ["python3", str(_MODULE_PATH), str(self.tmp)],
+            capture_output=True, text=True,
+        )
+        out_path = self.intermediate / "assembled-graph.json"
+        assembled = _j.loads(out_path.read_text()) if out_path.exists() else {}
+        return result.returncode, result.stderr, assembled
+
+    def test_existing_baseline_plus_numeric_batch(self) -> None:
+        # T1: batch-0.json (2 fresh) + batch-existing.json (5 baseline, 3 edges)
+        # → all 7 nodes and 3 edges merged; no unrecognized warning.
+        self._write_batch(
+            "batch-0.json",
+            [_file_node("src/new1.ts"), _file_node("src/new2.ts")],
+            [],
+        )
+        self._write_batch(
+            "batch-existing.json",
+            [_file_node(f"src/keep{i}.ts") for i in range(1, 6)],
+            [
+                {"source": "file:src/keep1.ts", "target": "file:src/keep2.ts",
+                 "type": "imports", "direction": "forward", "weight": 0.7},
+                {"source": "file:src/keep2.ts", "target": "file:src/keep3.ts",
+                 "type": "imports", "direction": "forward", "weight": 0.7},
+                {"source": "file:src/keep4.ts", "target": "file:src/keep5.ts",
+                 "type": "imports", "direction": "forward", "weight": 0.7},
+            ],
+        )
+        rc, stderr, assembled = self._run_merge()
+        self.assertEqual(rc, 0)
+        node_ids = {n["id"] for n in assembled["nodes"]}
+        expected = {f"file:src/keep{i}.ts" for i in range(1, 6)} | {
+            "file:src/new1.ts", "file:src/new2.ts",
+        }
+        self.assertEqual(node_ids, expected)
+        self.assertEqual(len(assembled["edges"]), 3)
+        self.assertNotIn("unrecognized filenames", stderr)
+
+    def test_only_existing_baseline(self) -> None:
+        # T2: only batch-existing.json present (e.g. incremental run with no
+        # newly analysed files) — must still load and emit baseline.
+        self._write_batch(
+            "batch-existing.json",
+            [_file_node(f"src/keep{i}.ts") for i in range(1, 6)],
+            [],
+        )
+        rc, stderr, assembled = self._run_merge()
+        self.assertEqual(rc, 0)
+        node_ids = {n["id"] for n in assembled["nodes"]}
+        self.assertEqual(
+            node_ids,
+            {f"file:src/keep{i}.ts" for i in range(1, 6)},
+        )
+        self.assertNotIn("unrecognized filenames", stderr)
+
+    def test_existing_baseline_with_multi_part_numeric(self) -> None:
+        # T3: existing baseline + a multi-part numeric batch. Both must be
+        # recognised; parts under one logical batch interleave correctly.
+        self._write_batch(
+            "batch-existing.json",
+            [_file_node("src/keep.ts")],
+            [],
+        )
+        self._write_batch(
+            "batch-0-part-1.json", [_file_node("src/a.ts")], [],
+        )
+        self._write_batch(
+            "batch-0-part-2.json", [_file_node("src/b.ts")], [],
+        )
+        rc, stderr, assembled = self._run_merge()
+        self.assertEqual(rc, 0)
+        node_ids = {n["id"] for n in assembled["nodes"]}
+        self.assertEqual(
+            node_ids,
+            {"file:src/keep.ts", "file:src/a.ts", "file:src/b.ts"},
+        )
+        self.assertNotIn("unrecognized filenames", stderr)
+
+    def test_numeric_only_baseline_unchanged(self) -> None:
+        # T4 regression guard: with no `existing` file present, the existing
+        # numeric-only behaviour is unchanged — both batches load, no warning.
+        self._write_batch("batch-0.json", [_file_node("src/a.ts")], [])
+        self._write_batch("batch-1.json", [_file_node("src/b.ts")], [])
+        rc, stderr, assembled = self._run_merge()
+        self.assertEqual(rc, 0)
+        node_ids = {n["id"] for n in assembled["nodes"]}
+        self.assertEqual(node_ids, {"file:src/a.ts", "file:src/b.ts"})
+        self.assertNotIn("unrecognized filenames", stderr)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -998,6 +998,30 @@ def recover_imports_from_scan(
     return recovered, lines
 
 
+# ── Batch filename parsing ────────────────────────────────────────────────
+
+# Recognised batch filenames: numeric (batch-<N>.json), multi-part
+# (batch-<N>-part-<K>.json), or the "existing" baseline written by the
+# incremental flow (batch-existing.json, see SKILL.md "Incremental update").
+# The "existing" baseline sorts BEFORE numeric batches so its pruned-graph
+# nodes/edges merge first and later numeric batches can override them.
+_BATCH_FILENAME_RE = re.compile(r"batch-(\d+|existing)(?:-part-(\d+))?\.json")
+
+
+def _batch_sort_key(p: Path) -> tuple[int, int]:
+    m = _BATCH_FILENAME_RE.match(p.name)
+    if not m:
+        return (10**9, 0)  # unrecognised → end of list (still flagged & dropped)
+    primary = -1 if m.group(1) == "existing" else int(m.group(1))
+    secondary = int(m.group(2)) if m.group(2) else 0
+    return (primary, secondary)
+
+
+def _batch_label(idx: int) -> str:
+    """Format a logical batch key for user-facing messages."""
+    return "existing" if idx == -1 else str(idx)
+
+
 # ── Main ──────────────────────────────────────────────────────────────────
 
 def main() -> None:
@@ -1012,12 +1036,12 @@ def main() -> None:
         print(f"Error: {intermediate_dir} does not exist", file=sys.stderr)
         sys.exit(1)
 
-    # Discover batch files, sorted by numeric index (not lexicographic)
+    # Discover batch files, sorted: "existing" baseline first (logical key -1),
+    # then numeric ascending; multi-part files (batch-<N>-part-<K>.json)
+    # interleave by (N, K) via _batch_sort_key.
     batch_files = sorted(
         intermediate_dir.glob("batch-*.json"),
-        key=lambda p: int(re.search(r"batch-(\d+)", p.stem).group(1))
-        if re.search(r"batch-(\d+)", p.stem)
-        else 0,
+        key=_batch_sort_key,
     )
     if not batch_files:
         print("Error: no batch-*.json files found in intermediate/", file=sys.stderr)
@@ -1033,9 +1057,12 @@ def main() -> None:
     by_batch = _dd(list)
     unrecognized_batch_files: list[str] = []
     for f in batch_files:
-        m = re.match(r"batch-(\d+)(?:-part-(\d+))?\.json", f.name)
+        m = _BATCH_FILENAME_RE.match(f.name)
         if m:
-            by_batch[int(m.group(1))].append((f.name, int(m.group(2)) if m.group(2) else None))
+            # Mirror _batch_sort_key: "existing" → logical key -1 so it sorts
+            # first and merges before any numeric batch can override it.
+            key = -1 if m.group(1) == "existing" else int(m.group(1))
+            by_batch[key].append((f.name, int(m.group(2)) if m.group(2) else None))
         else:
             unrecognized_batch_files.append(f.name)
 
@@ -1050,7 +1077,7 @@ def main() -> None:
             f"Warning: merge-batch-graphs: {len(unrecognized_batch_files)} "
             f"batch file(s) with unrecognized filenames will be DROPPED — "
             f"files: {preview}{suffix} — fix the file-analyzer agent to use "
-            f"only batch-<N>.json or batch-<N>-part-<K>.json patterns",
+            f"only batch-<N>.json / batch-<N>-part-<K>.json / batch-existing.json patterns",
             file=sys.stderr,
         )
 
@@ -1077,7 +1104,7 @@ def main() -> None:
         missing = sorted(expected - present)
         if missing:
             msg = (
-                f"batch {idx} has parts {sorted(present)} but "
+                f"batch {_batch_label(idx)} has parts {sorted(present)} but "
                 f"missing part {missing} — possible truncated write — "
                 f"affected nodes/edges may be lost"
             )
@@ -1132,9 +1159,9 @@ def main() -> None:
         report.append(
             f"Warning: dropped {len(unrecognized_batch_files)} batch file(s) "
             f"with unrecognized filenames — files: {preview}{suffix} — "
-            f"fix the file-analyzer agent to use only batch-<N>.json or "
-            f"batch-<N>-part-<K>.json patterns (every node/edge in these "
-            f"files was excluded from the final graph)"
+            f"fix the file-analyzer agent to use only batch-<N>.json / "
+            f"batch-<N>-part-<K>.json / batch-existing.json patterns "
+            f"(every node/edge in these files was excluded from the final graph)"
         )
 
     # Recover any imports edges file-analyzer batches dropped despite


### PR DESCRIPTION
## Summary
Fix #292: `/understand`'s incremental update path writes the pruned-existing baseline as `batch-existing.json` (per `SKILL.md` line 381), but `merge-batch-graphs.py` only accepts `batch-<N>.json` / `batch-<N>-part-<K>.json` filenames. As a result, the baseline file is silently dropped during merge, and every incremental update loses every node that wasn't re-analyzed this run (~70% data loss in the reporter's scenario: 305-node baseline → 92-node merged graph).

## Root cause
In `merge-batch-graphs.py` (`skills/understand/`), the filename matcher is:
```python
m = re.match(r"batch-(\d+)(?:-part-(\d+))?\.json", f.name)