### PR TITLE
fix: supplement Python tested_by links by unique basename

### DIFF
--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -299,6 +299,43 @@ class LinkTestsTests(unittest.TestCase):
         # Test node is not tagged with "tested"
         self.assertNotIn("tested", nodes_by_id["file:src/foo.test.ts"]["tags"])
 
+    def test_python_src_package_layout_pairs_by_unique_basename(self) -> None:
+        nodes_by_id = {
+            "file:zone2-charts/src/zone2_charts/chart_renderer.py": _file_node(
+                "zone2-charts/src/zone2_charts/chart_renderer.py"
+            ),
+            "file:zone2-charts/tests/test_chart_renderer.py": _file_node(
+                "zone2-charts/tests/test_chart_renderer.py"
+            ),
+        }
+        edges: list[dict[str, Any]] = []
+
+        added, dropped, tagged, swapped = mbg.link_tests(nodes_by_id, edges)
+
+        self.assertEqual((added, dropped, tagged, swapped), (1, 0, 1, 0))
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(
+            edges[0]["source"],
+            "file:zone2-charts/src/zone2_charts/chart_renderer.py",
+        )
+        self.assertEqual(
+            edges[0]["target"],
+            "file:zone2-charts/tests/test_chart_renderer.py",
+        )
+
+    def test_basename_fallback_skips_ambiguous_production_matches(self) -> None:
+        nodes_by_id = {
+            "file:pkg-a/src/pkg_a/client.py": _file_node("pkg-a/src/pkg_a/client.py"),
+            "file:pkg-b/src/pkg_b/client.py": _file_node("pkg-b/src/pkg_b/client.py"),
+            "file:tests/test_client.py": _file_node("tests/test_client.py"),
+        }
+        edges: list[dict[str, Any]] = []
+
+        added, dropped, tagged, swapped = mbg.link_tests(nodes_by_id, edges)
+
+        self.assertEqual((added, dropped, tagged, swapped), (0, 0, 0, 0))
+        self.assertEqual(edges, [])
+
     def test_no_production_counterpart_no_edge(self) -> None:
         nodes_by_id = {
             "file:src/foo.test.ts": _file_node("src/foo.test.ts"),

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -593,6 +593,7 @@ def link_tests(
     file_paths_to_nodes: dict[str, dict[str, Any]] = {}
     node_id_to_classification: dict[str, str] = {}  # id → "test" | "prod"
     test_nodes: list[tuple[str, dict[str, Any]]] = []
+    prod_nodes_by_basename: dict[str, list[dict[str, Any]]] = {}
     for node in nodes_by_id.values():
         path = _file_node_path(node)
         if path is None:
@@ -603,6 +604,7 @@ def link_tests(
             test_nodes.append((path, node))
         else:
             node_id_to_classification[node["id"]] = "prod"
+            prod_nodes_by_basename.setdefault(_basename(path), []).append(node)
 
     # ── Pass 1: walk existing tested_by edges, canonicalize or drop.
     # `covered` tracks (production_id, test_id) pairs that have a kept edge
@@ -684,27 +686,44 @@ def link_tests(
     for test_path, test_node in test_nodes:
         if test_node["id"] in paired_test_ids:
             continue
-        for cand_path in production_candidates(test_path):
+        candidate_paths = production_candidates(test_path)
+        prod_node = None
+        for cand_path in candidate_paths:
             prod_node = file_paths_to_nodes.get(cand_path)
             if prod_node is None:
                 continue
             if is_test_path(cand_path):
                 # Don't link a test to another test even if naming aligns.
+                prod_node = None
                 continue
-            pair = (prod_node["id"], test_node["id"])
-            if pair in covered:
-                continue
-            edges.append({
-                "source": prod_node["id"],
-                "target": test_node["id"],
-                "type": "tested_by",
-                "direction": "forward",
-                "weight": 0.5,
-                "description": "Path-based pairing (deterministic)",
-            })
-            covered.add(pair)
-            added += 1
             break
+
+        if prod_node is None and test_path.endswith(".py"):
+            candidate_basenames: list[str] = []
+            for cand_path in candidate_paths:
+                _add_unique(candidate_basenames, _basename(cand_path))
+            for cand_basename in candidate_basenames:
+                matches = prod_nodes_by_basename.get(cand_basename, [])
+                if len(matches) == 1:
+                    prod_node = matches[0]
+                    break
+
+        if prod_node is None:
+            continue
+
+        pair = (prod_node["id"], test_node["id"])
+        if pair in covered:
+            continue
+        edges.append({
+            "source": prod_node["id"],
+            "target": test_node["id"],
+            "type": "tested_by",
+            "direction": "forward",
+            "weight": 0.5,
+            "description": "Path-based pairing (deterministic)",
+        })
+        covered.add(pair)
+        added += 1
 
     # ── Tag every production node that ended up sourcing a tested_by edge
     # (covers Pass 1 canonical + swapped + Pass 2 supplements in one place).


### PR DESCRIPTION
Fixes #302.

## Problem Background

The deterministic `tested_by` linker supplements LLM-emitted test relationships by matching test files to production files through path conventions. This is useful when a test file clearly maps to a production file but the LLM did not emit a `tested_by` edge.

A common Python layout places production code under `src/<package>/` and tests under `tests/`, for example:

- `zone2-charts/src/zone2_charts/chart_renderer.py`
- `zone2-charts/tests/test_chart_renderer.py`

## Problem Symptoms

Before this change, the path-convention linker could not supplement this relationship.

For `zone2-charts/tests/test_chart_renderer.py`, the existing candidate generation only tried paths such as:

- `zone2-charts/tests/chart_renderer.py`
- `zone2-charts/chart_renderer.py`

It did not find the actual production file under `src/zone2_charts/`, so no supplemental `tested_by` edge was produced.

## Solution

This PR keeps the existing exact path matching as the first choice.

If no exact candidate matches, and the test file is a Python file, the linker now falls back to matching by production basename. The fallback is intentionally conservative: it only emits a `tested_by` edge when that basename maps to exactly one production file. If multiple production files share the same basename, the linker skips the fallback instead of guessing.

This allows standard Python `tests/test_*.py` → `src/<package>/*.py` layouts to get deterministic `tested_by` edges while avoiding ambiguous links.
