### PR TITLE
fix(install): add claude code platform support to installer scripts (…

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -29,6 +29,7 @@ $PluginLink = Join-Path $HOME '.understand-anything-plugin'
 # Platform table — Target = skills directory; Style = "per-skill" | "folder"
 $Platforms = [ordered]@{
     gemini      = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
+    claude      = @{ Target = (Join-Path $HOME '.claude\skills');             Style = 'per-skill' }
     codex       = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     opencode    = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
     pi          = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
@@ -201,7 +202,10 @@ function Cmd-Install([string]$Id) {
 
     Write-Host "`n✓ Installed Understand-Anything for $Id"
     Write-Host '  Restart your CLI or IDE to pick up the skills.'
-    if ($Id -eq 'vscode') {
+    if ($Id -eq 'claude') {
+        Write-Host "`n  Tip: Claude Code can also natively discover the plugin by opening this repo"
+        Write-Host '       directly (it reads .claude-plugin/plugin.json), no symlinks needed.'
+    } elseif ($Id -eq 'vscode') {
         Write-Host "`n  Tip: VS Code can also auto-discover the plugin by opening this repo"
         Write-Host '       directly (it reads .copilot-plugin/plugin.json), no symlinks needed.'
     }

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,7 @@ PLUGIN_LINK="$HOME/.understand-anything-plugin"
 platforms_table() {
   cat <<EOF
 gemini|$HOME/.agents/skills|per-skill
+claude|$HOME/.claude/skills|per-skill
 codex|$HOME/.agents/skills|per-skill
 opencode|$HOME/.agents/skills|per-skill
 pi|$HOME/.agents/skills|per-skill
@@ -191,7 +192,10 @@ cmd_install() {
 
   printf '\n✓ Installed Understand-Anything for %s\n' "$id"
   printf '  Restart your CLI or IDE to pick up the skills.\n'
-  if [[ "$id" == "vscode" ]]; then
+  if [[ "$id" == "claude" ]]; then
+    printf '\n  Tip: Claude Code can also natively discover the plugin by opening this repo\n'
+    printf '       directly (it reads .claude-plugin/plugin.json), no symlinks needed.\n'
+  elif [[ "$id" == "vscode" ]]; then
     printf '\n  Tip: VS Code can also auto-discover the plugin by opening this repo\n'
     printf '       directly (it reads .copilot-plugin/plugin.json), no symlinks needed.\n'
   fi


### PR DESCRIPTION
…#307)

### Description
Adds native installation support for **Claude Code** to the project's installer scripts (`install.sh` and `install.ps1`). 

### Changes
* **`install.sh`**:
  * Registered `claude` platform mapping to `$HOME/.claude/skills` with `per-skill` symlinking style.
  * Added a post-install tip informing users of native auto-discovery via `.claude-plugin/plugin.json`.
* **`install.ps1`**:
  * Added the `claude` entry to `$Platforms` targeting `Join-Path $HOME '.claude\skills'` with `per-skill` symlinks.
  * Included a corresponding post-install discovery tip.

### Verification
* Successfully ran manual sandbox tests for both the **installation** and **uninstallation** workflows in an isolated `$HOME` directory, verifying that all symlinks are created and cleaned up correctly.

Fixes #307
