### PR TITLE
fix(merge-batch-graphs): recover dropped cross-batch edges when source has file: prefix and target is bare

### DIFF
--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -1183,5 +1183,87 @@ class TestUnrecognizedBatchFilename(unittest.TestCase):
         self.assertNotIn("file:src/y.ts", node_ids)
 
 
+class CrossBatchEdgeRecoveryTests(unittest.TestCase):
+    """When an agent emits a bare target ID (e.g., `_shared/audit_log.py`) from
+    a `file:`-prefixed source, the merge step should auto-prefix the target
+    if exactly one known node matches. Without this, the edge gets dropped
+    as "missing target" and real LLM-discovered relationships are lost.
+    """
+
+    def _make_batch(
+        self,
+        nodes: list[dict[str, Any]],
+        edges: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        return {"nodes": nodes, "edges": edges}
+
+    def test_bare_target_with_unique_match_is_recovered(self) -> None:
+        """Bare target matching exactly one known node's suffix gets prefixed."""
+        batch1 = self._make_batch(
+            nodes=[_file_node("pipeline.py")],
+            edges=[{
+                "source": "file:pipeline.py",
+                # Bare target — no prefix. Real-world bug pattern from LLM.
+                "target": "_shared/audit_log.py",
+                "type": "depends_on",
+            }],
+        )
+        batch2 = self._make_batch(
+            nodes=[_file_node("_shared/audit_log.py")],
+            edges=[],
+        )
+        graph, _report = mbg.merge_and_normalize([batch1, batch2])
+        edges = graph["edges"]
+        # The edge should be present, with target rewritten to canonical form
+        targets = [e["target"] for e in edges if e["source"] == "file:pipeline.py"]
+        self.assertIn(
+            "file:_shared/audit_log.py",
+            targets,
+            f"Expected cross-batch edge recovery; got edges: {edges}",
+        )
+
+    def test_bare_target_with_basename_only_is_recovered(self) -> None:
+        """Bare basename (no path) matching exactly one suffix is also recovered."""
+        batch1 = self._make_batch(
+            nodes=[_file_node("cli.py")],
+            edges=[{
+                "source": "file:cli.py",
+                # Just the basename — no directory either
+                "target": "audit_log.py",
+                "type": "calls",
+            }],
+        )
+        batch2 = self._make_batch(
+            nodes=[_file_node("_shared/audit_log.py")],
+            edges=[],
+        )
+        graph, _report = mbg.merge_and_normalize([batch1, batch2])
+        targets = [e["target"] for e in graph["edges"] if e["source"] == "file:cli.py"]
+        self.assertIn("file:_shared/audit_log.py", targets)
+
+    def test_bare_target_with_ambiguous_match_is_dropped(self) -> None:
+        """When the bare target matches >1 node, recovery is unsafe; drop as before."""
+        batch1 = self._make_batch(
+            nodes=[_file_node("a.py")],
+            edges=[{
+                "source": "file:a.py",
+                "target": "utils.py",  # ambiguous
+                "type": "depends_on",
+            }],
+        )
+        batch2 = self._make_batch(
+            nodes=[
+                _file_node("module_a/utils.py"),
+                _file_node("module_b/utils.py"),
+            ],
+            edges=[],
+        )
+        graph, _report = mbg.merge_and_normalize([batch1, batch2])
+        targets = [e["target"] for e in graph["edges"] if e["source"] == "file:a.py"]
+        # Neither candidate should be selected — ambiguous matches do not recover
+        self.assertNotIn("file:module_a/utils.py", targets)
+        self.assertNotIn("file:module_b/utils.py", targets)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -810,6 +810,27 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
 
     # ── Step 6: Deduplicate edges, drop dangling ─────────────────────
     node_ids = set(nodes_by_id.keys())
+
+    # Build a suffix index: bare filename / bare path → set of canonical node IDs
+    # ending in that suffix. Used to recover edges where an agent emitted a
+    # `file:` source but a BARE target (no prefix). Without this, the dedup
+    # step drops such edges as "missing target", silently losing real
+    # relationships that were correctly identified by the LLM but emitted with
+    # the wrong target-ID shape. Common when files live in different analysis
+    # batches and the LLM only saw the short name on the target side.
+    bare_to_prefixed: dict[str, set[str]] = {}
+    for nid in node_ids:
+        # Suffix forms we want to recover: full path after the type prefix,
+        # plus the bare basename. Both indexed because LLMs emit either.
+        if ":" in nid:
+            path_part = nid.split(":", 1)[1]
+            bare_to_prefixed.setdefault(path_part, set()).add(nid)
+            basename = path_part.rsplit("/", 1)[-1]
+            if basename != path_part:
+                bare_to_prefixed.setdefault(basename, set()).add(nid)
+
+    cross_batch_recovered = 0
+
     # Direction is part of the dedup key so a `forward` edge does not silently
     # overwrite a `bidirectional` one (or vice versa); they're different
     # semantic relationships that the dashboard renders distinctly.
@@ -820,6 +841,23 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
         etype = edge.get("type", "")
         direction = normalize_direction(edge.get("direction"))
         edge["direction"] = direction
+
+        # Cross-batch recovery: if target lacks a prefix but matches a known
+        # file-path suffix unambiguously, repair it. Only fires when target is
+        # bare (no `prefix:` separator) AND source IS prefixed (so we know the
+        # agent was operating in the prefixed-ID convention). Unambiguous =
+        # exactly one node has that suffix; ambiguous matches are left alone
+        # and fall through to the unfixable-drop path.
+        if (
+            tgt not in node_ids
+            and ":" not in tgt
+            and ":" in src
+        ):
+            candidates = bare_to_prefixed.get(tgt)
+            if candidates and len(candidates) == 1:
+                tgt = next(iter(candidates))
+                edge["target"] = tgt
+                cross_batch_recovered += 1
 
         if src not in node_ids or tgt not in node_ids:
             missing = []
@@ -849,6 +887,8 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
             fixed_lines.append(f"  {count:>4} × complexity {pattern}")
     if edges_rewritten:
         fixed_lines.append(f"  {edges_rewritten:>4} × edge references rewritten after ID normalization")
+    if cross_batch_recovered:
+        fixed_lines.append(f"  {cross_batch_recovered:>4} × cross-batch edges recovered (bare target → prefixed)")
     if duplicate_count:
         fixed_lines.append(f"  {duplicate_count:>4} × duplicate node IDs removed (kept last)")
     if tested_by_swapped:


### PR DESCRIPTION
## Problem

When the file-analyzer agent emits an edge whose `source` carries the canonical `file:` prefix but whose `target` is a bare filename, `merge-batch-graphs.py` currently drops the edge as a missing-target, because the bare name never matches the prefixed node ID in the deduplicated set. The agent has been observed emitting this pattern when a referenced file lives in a sibling batch and the agent has only seen the bare name in its own batch's context.

Concrete reproduction on a 124-file Python project: 14 edges silently dropped, including a real `tested_by` link from `test_cli_fallback.py → cli.py`, which then surfaced as a false negative ("`cli.py` appears untested"). The drop is silent because the warning bucket for missing targets is grouped and capped at 50.

## Fix

Before the unfixable-drop in step 6 of the merge ("Deduplicate edges, drop dangling"), build a one-pass suffix index `bare_to_prefixed: dict[str, set[str]]` from the canonical node IDs. Then, when an edge has the bare-target / prefixed-source pattern, look the target up in the suffix index. If exactly one node matches (unique recovery), rewrite the edge's target to the prefixed form and increment a `cross_batch_recovered` counter. Ambiguous matches (multiple suffix hits) are left to drop as before so we don't silently pick a wrong target.

The counter is surfaced in the fix-patterns report so users can see how many edges were auto-recovered.

## Scope

- 1 file: `understand-anything-plugin/skills/understand/merge-batch-graphs.py` (~25 LOC added)
- Behavior change: edges that previously dropped silently with a "missing target" warning now resolve when a unique suffix match exists. No existing behavior is changed; this only converts previously-dropped edges into present ones.

## Tests

3 new tests in `tests/skill/understand/test_merge_batch_graphs.py` (`CrossBatchEdgeRecoveryTests`):
1. Unique suffix match is recovered (the canonical fix path)
2. Basename-only suffix match is recovered (handles agents that strip directory prefixes)
3. Ambiguous suffix match is left to drop (safety case — we don't pick when multiple candidates match)

Full suite: 72/72 pass.

## Performance

The suffix index is built once per merge pass with O(n) work over the node-ID set. Edge resolution becomes a single dict lookup per dangling edge, so the fix is constant-time per edge. Negligible overhead on the largest projects tested.

## Backwards compatibility

The fix only affects edges that were previously dropped. Edges that resolved before continue to resolve identically. No schema changes; no public API surface change.

## Verification notes

The unit tests exercise the recovery path directly with constructed batch fixtures that reproduce the original bare-target / prefixed-source pattern, including the unique-match and ambiguous-match branches. We additionally attempted an end-to-end rerun against the original 124-file project where the bug was first observed, but in that rerun the upstream batches did not contain cross-file edges to recover (the input had `filesWithImports=0` because `extract-import-map.mjs` was invoked in a configuration that didn't produce import data for the project root), so the recovery counter did not fire. The unit-test coverage is what verifies the fix; the rerun was inconclusive on its own terms.

Anyone reproducing the original bug pattern (batches where `source` carries the `file:` prefix and `target` is a bare filename matching a sibling-batch node) will see the recovery counter increment and the previously-dropped edges retained.
