### PR TITLE
feat(understand-knowledge): detect and parse doctrine-format markdown corpora

### DIFF
--- a/tests/skill/understand-knowledge/test_parse_knowledge_base.py
+++ b/tests/skill/understand-knowledge/test_parse_knowledge_base.py
@@ -1,0 +1,268 @@
+"""Tests for parse-knowledge-base.py — doctrine-format detection + parsing.
+
+Covers the Ext-1 extension that relaxes the Karpathy detector to also
+accept doctrine corpora (numbered files + prose cross-refs + standard
+markdown links). Existing Karpathy fixtures regress unchanged.
+"""
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Module loading — filename contains hyphens so we can't `import` it directly
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = (
+    _REPO_ROOT
+    / "understand-anything-plugin"
+    / "skills"
+    / "understand-knowledge"
+    / "parse-knowledge-base.py"
+)
+_spec = importlib.util.spec_from_file_location("parse_knowledge_base", _MODULE_PATH)
+parser_mod = importlib.util.module_from_spec(_spec)
+sys.modules["parse_knowledge_base"] = parser_mod
+_spec.loader.exec_module(parser_mod)
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+def _build_doctrine_corpus(root: Path) -> None:
+    """Create a doctrine-format fixture: numbered files + prose-refs + md links."""
+    _write(root, "00-foundation.md",
+           "# Foundation\n\nThe foundational doctrine. See canon/04 §6-7.\n"
+           "Cross-ref to [Layer Omega](04-layer-omega.md) explains the cycle.\n")
+    _write(root, "01-hard-rules.md",
+           "# Hard Rules\n\nReferences canon/00 for canonical names.\n"
+           "See [foundation](00-foundation.md) for grounding.\n")
+    _write(root, "02-naming.md",
+           "# Naming Conventions\n\nDoctrine #11 covers sub-patterns.\n"
+           "[Cross-link](01-hard-rules.md)\n")
+    _write(root, "04-layer-omega.md",
+           "# Layer Omega SOP\n\nThe 7-step cycle described here.\n"
+           "Refers back to canon/00 and canon/01.\n")
+    _write(root, "11-sub-patterns.md",
+           "# Sub-Pattern Activation\n\nOverview of doctrine sub-patterns.\n"
+           "Pairs with canon/04 for SOP invocation.\n")
+
+
+def _build_karpathy_corpus(root: Path) -> None:
+    """Create a Karpathy-format fixture: index.md + wikilinks."""
+    _write(root, "index.md",
+           "# Index\n\n## Core\n\n- [[foundation]]\n- [[ego-system]]\n\n"
+           "## Operational\n\n- [[deploy-flow]]\n")
+    _write(root, "foundation.md", "# Foundation\n\nLinks to [[ego-system]].\n")
+    _write(root, "ego-system.md", "# Ego System\n\nLinks back to [[foundation]].\n")
+    _write(root, "deploy-flow.md", "# Deploy Flow\n\nReferences [[ego-system]].\n")
+
+
+# ---------------------------------------------------------------------------
+# detect_format() — format dispatch
+# ---------------------------------------------------------------------------
+
+class DetectFormatTests(unittest.TestCase):
+
+    def test_doctrine_corpus_detected_as_doctrine(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _build_doctrine_corpus(root)
+            result = parser_mod.detect_format(root)
+            self.assertTrue(result["detected"])
+            self.assertEqual(result["format"], "doctrine")
+            self.assertGreaterEqual(result["numbered_count"], 3)
+            self.assertTrue(result["has_prose_refs"])
+            self.assertTrue(result["has_md_links"])
+
+    def test_karpathy_corpus_still_detected_as_karpathy(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _build_karpathy_corpus(root)
+            result = parser_mod.detect_format(root)
+            self.assertTrue(result["detected"])
+            self.assertEqual(result["format"], "karpathy")
+
+    def test_karpathy_precedence_over_doctrine_signals(self):
+        """When BOTH index.md and numbered files exist, Karpathy wins."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _build_doctrine_corpus(root)
+            # Add an index.md to make it also look Karpathy
+            _write(root, "index.md", "# Index\n\n## Articles\n\n- [[00-foundation]]\n")
+            result = parser_mod.detect_format(root)
+            self.assertEqual(result["format"], "karpathy",
+                             "Karpathy detection must take precedence when both "
+                             "signal sets are present (backwards compat)")
+
+    def test_empty_directory_unknown(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            result = parser_mod.detect_format(root)
+            self.assertFalse(result["detected"])
+            self.assertEqual(result["format"], "unknown")
+
+    def test_few_numbered_files_not_doctrine(self):
+        """Below the 3-file threshold, no doctrine detection."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _write(root, "00-foo.md", "# Foo\n")
+            _write(root, "01-bar.md", "# Bar\n")
+            result = parser_mod.detect_format(root)
+            self.assertEqual(result["format"], "unknown")
+
+
+# ---------------------------------------------------------------------------
+# _parse_doctrine_wiki() — manifest shape + edges
+# ---------------------------------------------------------------------------
+
+class DoctrineWikiParseTests(unittest.TestCase):
+
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.root = Path(self._td.name)
+        _build_doctrine_corpus(self.root)
+        self.manifest = parser_mod.parse_wiki(self.root)
+
+    def tearDown(self):
+        self._td.cleanup()
+
+    def test_format_is_doctrine(self):
+        self.assertEqual(self.manifest["format"], "doctrine")
+
+    def test_article_count_matches_fixture(self):
+        # 5 numbered files, no infra to skip
+        self.assertEqual(self.manifest["stats"]["articles"], 5)
+
+    def test_article_node_ids_use_article_prefix(self):
+        article_ids = {n["id"] for n in self.manifest["nodes"] if n["type"] == "article"}
+        self.assertIn("article:00-foundation", article_ids)
+        self.assertIn("article:04-layer-omega", article_ids)
+        self.assertIn("article:11-sub-patterns", article_ids)
+
+    def test_md_link_edges_resolve_to_known_articles(self):
+        related_edges = [
+            (e["source"], e["target"])
+            for e in self.manifest["edges"]
+            if e["type"] == "related"
+        ]
+        # 00-foundation → 04-layer-omega (via [Layer Omega](04-layer-omega.md))
+        self.assertIn(("article:00-foundation", "article:04-layer-omega"),
+                      related_edges)
+        # 01-hard-rules → 00-foundation (via [foundation](00-foundation.md))
+        self.assertIn(("article:01-hard-rules", "article:00-foundation"),
+                      related_edges)
+
+    def test_prose_refs_resolve_to_numbered_articles(self):
+        ref_edges = [
+            (e["source"], e["target"])
+            for e in self.manifest["edges"]
+            if e["type"] == "references"
+        ]
+        # 00-foundation refers to canon/04 → 04-layer-omega
+        self.assertIn(("article:00-foundation", "article:04-layer-omega"),
+                      ref_edges)
+        # 01-hard-rules refers to canon/00 → 00-foundation
+        self.assertIn(("article:01-hard-rules", "article:00-foundation"),
+                      ref_edges)
+
+    def test_topic_nodes_from_numeric_groups(self):
+        topic_ids = {n["id"] for n in self.manifest["nodes"] if n["type"] == "topic"}
+        # Files 00, 01, 02, 04 are in group-0; file 11 is in group-1
+        self.assertIn("topic:group-0", topic_ids)
+        self.assertIn("topic:group-1", topic_ids)
+
+    def test_categorized_under_edges_link_articles_to_groups(self):
+        cat_edges = [
+            (e["source"], e["target"])
+            for e in self.manifest["edges"]
+            if e["type"] == "categorized_under"
+        ]
+        self.assertIn(("article:00-foundation", "topic:group-0"), cat_edges)
+        self.assertIn(("article:11-sub-patterns", "topic:group-1"), cat_edges)
+
+    def test_backlinks_populated(self):
+        for node in self.manifest["nodes"]:
+            if node["id"] == "article:00-foundation":
+                bl = node["knowledgeMeta"]["backlinks"]
+                # 01-hard-rules links to 00-foundation via both md-link and prose-ref;
+                # backlinks dedupe per source-target pair within an edge type, but the
+                # backlink list collects from both 'related' and 'references' edges.
+                self.assertIn("article:01-hard-rules", bl)
+                break
+        else:
+            self.fail("article:00-foundation node not found")
+
+    def test_summary_extracted_from_first_paragraph(self):
+        for node in self.manifest["nodes"]:
+            if node["id"] == "article:00-foundation":
+                self.assertIn("foundational doctrine", node["summary"].lower())
+                break
+
+    def test_warnings_capped(self):
+        self.assertLessEqual(len(self.manifest["warnings"]), 50)
+
+
+# ---------------------------------------------------------------------------
+# extract_md_links() + extract_prose_refs() — direct unit coverage
+# ---------------------------------------------------------------------------
+
+class HelperExtractionTests(unittest.TestCase):
+
+    def test_md_links_skip_external_urls(self):
+        text = "See [home](https://example.com) and [local](foo.md)."
+        links = parser_mod.extract_md_links(text)
+        self.assertEqual(len(links), 1)
+        self.assertEqual(links[0]["target"], "foo.md")
+
+    def test_md_links_skip_code_blocks(self):
+        text = "```python\n[fake](bar.md)\n```\nReal [link](real.md)"
+        links = parser_mod.extract_md_links(text)
+        targets = [link["target"] for link in links]
+        self.assertEqual(targets, ["real.md"])
+
+    def test_md_links_strip_fragments(self):
+        text = "See [section](foo.md#some-anchor)."
+        links = parser_mod.extract_md_links(text)
+        self.assertEqual(links[0]["target"], "foo.md")
+
+    def test_prose_refs_dedupe_within_document(self):
+        text = "See canon/04 twice — canon/04 again. Also canon/01."
+        refs = parser_mod.extract_prose_refs(text)
+        keys = [(r["namespace"], r["num"]) for r in refs]
+        self.assertEqual(sorted(keys), [("canon", "01"), ("canon", "04")])
+
+    def test_prose_refs_match_variants(self):
+        text = "See canon/04 and Doctrine #11 plus chapter 5."
+        refs = parser_mod.extract_prose_refs(text)
+        namespaces = sorted(r["namespace"] for r in refs)
+        self.assertEqual(namespaces, ["canon", "chapter", "doctrine"])
+
+
+# ---------------------------------------------------------------------------
+# Karpathy regression — ensure existing path unchanged
+# ---------------------------------------------------------------------------
+
+class KarpathyRegressionTests(unittest.TestCase):
+
+    def test_karpathy_corpus_still_parses(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            _build_karpathy_corpus(root)
+            manifest = parser_mod.parse_wiki(root)
+            self.assertEqual(manifest["format"], "karpathy")
+            # 3 content articles (index.md is infra)
+            self.assertEqual(manifest["stats"]["articles"], 3)
+            # At least one wikilink edge resolved
+            related_edges = [e for e in manifest["edges"] if e["type"] == "related"]
+            self.assertGreater(len(related_edges), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py
+++ b/understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py
@@ -28,6 +28,14 @@ CODE_BLOCK_RE = re.compile(r"```(\w*)")
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 INDEX_SECTION_RE = re.compile(r"^##\s+(.+)$", re.MULTILINE)
 
+# Doctrine-format signals: numbered files (NN-name.md), prose cross-refs
+# like "canon/04 §6-7" or "Doctrine #11", and standard markdown links.
+NUMBERED_FILE_RE = re.compile(r"^(\d{2,})-")
+PROSE_REF_RE = re.compile(
+    r"\b(canon|doctrine|chapter)\s*[/#]?\s*(\d{1,3})\b", re.IGNORECASE
+)
+MD_LINK_RE = re.compile(r"\[([^\]\n]+)\]\(([^)\s#]+\.md)(?:#[^)]*)?\)")
+
 # Files that are part of wiki infrastructure, not content articles
 INFRA_FILES = {"index.md", "log.md", "claude.md", "agents.md", "soul.md"}
 
@@ -35,8 +43,48 @@ INFRA_FILES = {"index.md", "log.md", "claude.md", "agents.md", "soul.md"}
 # Detection: is this a Karpathy-pattern wiki?
 # ---------------------------------------------------------------------------
 
+def _scan_doctrine_signals(md_files: list[Path]) -> dict:
+    """Scan markdown files for doctrine-format signals.
+
+    Returns counts of numbered files (NN-name.md), whether prose
+    cross-refs like 'canon/04' or 'Doctrine #11' are present, and
+    whether standard markdown links '[name](file.md)' are used.
+    """
+    numbered_count = sum(
+        1 for f in md_files if NUMBERED_FILE_RE.match(f.name)
+    )
+    has_prose_refs = False
+    has_md_links = False
+    # Sample up to 20 files to keep detection cheap on large corpora
+    for f in md_files[:20]:
+        try:
+            text = f.read_text(encoding="utf-8", errors="replace")[:10000]
+        except OSError:
+            continue
+        if not has_prose_refs and PROSE_REF_RE.search(text):
+            has_prose_refs = True
+        if not has_md_links and MD_LINK_RE.search(text):
+            has_md_links = True
+        if has_prose_refs and has_md_links:
+            break
+    return {
+        "numbered_count": numbered_count,
+        "has_prose_refs": has_prose_refs,
+        "has_md_links": has_md_links,
+    }
+
+
 def detect_format(root: Path) -> dict:
-    """Detect if directory follows the Karpathy LLM wiki three-layer pattern."""
+    """Detect a known markdown-knowledge-base format.
+
+    Returns signals + a `format` field, one of:
+      - "karpathy"  — three-layer LLM wiki (index.md + wikilinks)
+      - "doctrine"  — numbered files + prose cross-refs + md links
+      - "unknown"   — neither pattern detected
+
+    Karpathy detection takes precedence when both signal sets are present
+    so existing Karpathy users see zero behavioral change.
+    """
     signals = {
         "has_index": (root / "index.md").is_file() or (root / "wiki" / "index.md").is_file(),
         "has_log": (root / "log.md").is_file() or (root / "wiki" / "log.md").is_file(),
@@ -62,10 +110,23 @@ def detect_format(root: Path) -> dict:
     if signals["has_index"] and signals["md_count"] >= 3:
         signals["detected"] = True
         signals["format"] = "karpathy"
-    else:
-        signals["detected"] = False
-        signals["format"] = "unknown"
+        return signals
 
+    # Secondary signal: doctrine format. Numbered files (NN-name.md) +
+    # at least one of {prose refs, md links}, with a meaningful md_count.
+    doctrine = _scan_doctrine_signals(md_files)
+    signals.update(doctrine)
+    if (
+        doctrine["numbered_count"] >= 3
+        and signals["md_count"] >= 3
+        and (doctrine["has_prose_refs"] or doctrine["has_md_links"])
+    ):
+        signals["detected"] = True
+        signals["format"] = "doctrine"
+        return signals
+
+    signals["detected"] = False
+    signals["format"] = "unknown"
     return signals
 
 
@@ -95,6 +156,46 @@ def extract_wikilinks(text: str) -> list[dict]:
             "display": m.group(2).strip() if m.group(2) else None,
         })
     return links
+
+
+def extract_md_links(text: str) -> list[dict]:
+    """Extract standard markdown links to .md files.
+
+    Skips links inside fenced code blocks. Returns dicts with display
+    text and the raw target path (relative to the source file).
+    """
+    # Strip fenced code blocks to avoid extracting links from code samples
+    stripped = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    links = []
+    for m in MD_LINK_RE.finditer(stripped):
+        target = m.group(2).strip()
+        # Skip external URLs
+        if target.startswith(("http://", "https://", "mailto:")):
+            continue
+        links.append({
+            "target": target,
+            "display": m.group(1).strip(),
+        })
+    return links
+
+
+def extract_prose_refs(text: str) -> list[dict]:
+    """Extract prose cross-references like 'canon/04' or 'Doctrine #11'.
+
+    Returns dicts with the matched namespace (canon|doctrine|chapter)
+    and the numeric reference. Deduplicated within a single document.
+    """
+    seen: set[tuple[str, str]] = set()
+    refs = []
+    for m in PROSE_REF_RE.finditer(text):
+        namespace = m.group(1).lower()
+        num = m.group(2)
+        key = (namespace, num)
+        if key in seen:
+            continue
+        seen.add(key)
+        refs.append({"namespace": namespace, "num": num})
+    return refs
 
 
 def extract_headings(text: str) -> list[dict]:
@@ -276,13 +377,28 @@ def resolve_wikilink(target: str, name_map: dict[str, str], node_ids: set[str] |
 
 
 def parse_wiki(root: Path) -> dict:
-    """Parse a Karpathy-pattern wiki and produce the scan manifest."""
+    """Parse a markdown knowledge base and produce the scan manifest.
+
+    Dispatches on detected format: Karpathy three-layer wikis use the
+    original index.md + wikilinks path; doctrine corpora (numbered files
+    + prose refs + md links) use the doctrine parser. Exits with a
+    json-encoded error on stderr when the directory matches neither.
+    """
     detection = detect_format(root)
     if not detection["detected"]:
-        print(json.dumps({"error": "Not a Karpathy-pattern wiki", "detection": detection}),
-              file=sys.stderr)
+        print(
+            json.dumps({"error": "Not a recognized knowledge-base format", "detection": detection}),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
+    if detection["format"] == "doctrine":
+        return _parse_doctrine_wiki(root, detection)
+    return _parse_karpathy_wiki(root, detection)
+
+
+def _parse_karpathy_wiki(root: Path, detection: dict) -> dict:
+    """Parse a Karpathy-pattern wiki and produce the scan manifest."""
     wiki_root = Path(detection["wiki_root"])
     raw_root = root / "raw"
 
@@ -479,6 +595,292 @@ def parse_wiki(root: Path) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# Doctrine-format parser
+# ---------------------------------------------------------------------------
+
+def _build_numbered_index(article_ids: set[str], wiki_root: Path) -> dict[str, list[str]]:
+    """Map numeric prefix (e.g. '04') to article IDs whose filename starts with it.
+
+    Multiple files can share a prefix in principle (e.g. across subdirs);
+    callers resolve only when a single match exists. Returns prefix → list
+    of article IDs to make ambiguity detectable.
+    """
+    prefix_map: dict[str, list[str]] = {}
+    for aid in article_ids:
+        if not aid.startswith("article:"):
+            continue
+        stem = aid.split(":", 1)[1]
+        basename = stem.rsplit("/", 1)[-1]
+        m = NUMBERED_FILE_RE.match(basename + ".md")
+        if not m:
+            continue
+        # Store both zero-padded and unpadded forms so 'canon/4' resolves
+        # to '04-foo.md' the same as 'canon/04'.
+        raw = m.group(1)
+        prefix_map.setdefault(raw, []).append(aid)
+        unpadded = str(int(raw))
+        if unpadded != raw:
+            prefix_map.setdefault(unpadded, []).append(aid)
+    return prefix_map
+
+
+def _resolve_md_link(target: str, source_rel: Path, name_map: dict[str, str],
+                     node_ids: set[str]) -> str | None:
+    """Resolve a markdown link target to an article node ID.
+
+    `target` is the raw href from `[label](target)`. Relative paths are
+    resolved against the source file's parent directory; absolute-style
+    paths (no leading dot) are resolved from the wiki root.
+    """
+    raw = target.strip()
+    if not raw or raw.startswith(("#", "http://", "https://", "mailto:")):
+        return None
+    # Strip .md suffix + any fragment
+    cleaned = raw.split("#", 1)[0]
+    if cleaned.endswith(".md"):
+        cleaned = cleaned[:-3]
+    cleaned = cleaned.lstrip("./")
+
+    # Try resolution relative to source file's parent first
+    parent = source_rel.parent.as_posix()
+    if parent and parent != ".":
+        candidate_path = (Path(parent) / cleaned).as_posix()
+        # Normalize ../ segments
+        parts: list[str] = []
+        for seg in candidate_path.split("/"):
+            if seg == ".." and parts:
+                parts.pop()
+            elif seg and seg != ".":
+                parts.append(seg)
+        candidate_path = "/".join(parts)
+        candidate_id = f"article:{candidate_path}"
+        if candidate_id in node_ids:
+            return candidate_id
+
+    # Fall back to wiki-root-relative + name_map lookup
+    return resolve_wikilink(cleaned, name_map, node_ids)
+
+
+def _parse_doctrine_wiki(root: Path, detection: dict) -> dict:
+    """Parse a doctrine-format corpus and produce the scan manifest.
+
+    Doctrine corpora identify articles by numeric filename prefix
+    (NN-name.md), cross-reference each other through prose refs like
+    'canon/04 §6-7' or 'Doctrine #11', and use standard markdown links
+    '[name](path.md)' rather than wikilinks. Categories are derived from
+    the tens-digit of each file's numeric prefix.
+    """
+    wiki_root = Path(detection["wiki_root"])
+    raw_root = root / "raw"
+
+    name_map = build_name_to_stem_map(wiki_root)
+
+    # --- Pre-compute article IDs ---
+    article_ids: set[str] = set()
+    for md_file in sorted(wiki_root.rglob("*.md")):
+        rel = md_file.relative_to(wiki_root)
+        stem = rel.with_suffix("").as_posix()
+        if rel.parent == Path(".") and rel.name.lower() in INFRA_FILES:
+            continue
+        article_ids.add(f"article:{stem}")
+
+    numbered_index = _build_numbered_index(article_ids, wiki_root)
+
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    warnings: list[str] = []
+    stats = {
+        "articles": 0,
+        "sources": 0,
+        "topics": 0,
+        "mdLinks": 0,
+        "proseRefs": 0,
+        "unresolved": 0,
+    }
+
+    # Track which numeric-prefix groups appear, for topic-node generation
+    group_to_articles: dict[str, list[str]] = {}
+
+    for md_file in sorted(wiki_root.rglob("*.md")):
+        rel = md_file.relative_to(wiki_root)
+        stem = rel.with_suffix("").as_posix()
+        basename = md_file.stem
+
+        if rel.parent == Path(".") and rel.name.lower() in INFRA_FILES:
+            continue
+
+        text = md_file.read_text(encoding="utf-8", errors="replace")
+        h1 = extract_h1(text)
+        frontmatter = extract_frontmatter(text)
+        md_links = extract_md_links(text)
+        prose_refs = extract_prose_refs(text)
+        headings = extract_headings(text)  # noqa: F841 — kept for parity / future use
+        code_langs = extract_code_blocks(text)  # noqa: F841
+        summary = extract_first_paragraph(text)
+
+        # Derive numeric-prefix group (tens digit) when present
+        prefix_match = NUMBERED_FILE_RE.match(md_file.name)
+        group_label = ""
+        if prefix_match:
+            n = int(prefix_match.group(1))
+            tens = n // 10
+            group_label = f"group-{tens}"
+
+        # Tag set: numeric group + parent dir + frontmatter tags
+        tag_set: set[str] = set()
+        if group_label:
+            tag_set.add(group_label)
+        if rel.parent != Path("."):
+            tag_set.add(str(rel.parent))
+        fm_tags = frontmatter.get("tags", "")
+        if fm_tags:
+            tag_set.update(t.strip() for t in fm_tags.split(",") if t.strip())
+        tags = sorted(tag_set)
+
+        # Complexity from combined link density (md links + prose refs)
+        link_count = len(md_links) + len(prose_refs)
+        if link_count > 15:
+            complexity = "complex"
+        elif link_count > 5:
+            complexity = "moderate"
+        else:
+            complexity = "simple"
+
+        node_id = f"article:{stem}"
+        nodes.append({
+            "id": node_id,
+            "type": "article",
+            "name": h1 or basename,
+            "filePath": str(rel),
+            "summary": summary or f"Doctrine article: {h1 or basename}",
+            "tags": tags,
+            "complexity": complexity,
+            "knowledgeMeta": {
+                "mdLinks": [ml["target"] for ml in md_links],
+                "proseRefs": [f"{r['namespace']}/{r['num']}" for r in prose_refs],
+                **({"category": group_label} if group_label else {}),
+                "content": text[:3000],
+            },
+        })
+        stats["articles"] += 1
+        stats["mdLinks"] += len(md_links)
+        stats["proseRefs"] += len(prose_refs)
+
+        if group_label:
+            group_to_articles.setdefault(group_label, []).append(node_id)
+
+        # --- Edges from markdown links ---
+        for ml in md_links:
+            target_id = _resolve_md_link(ml["target"], rel, name_map, article_ids)
+            if target_id and target_id != node_id:
+                edges.append({
+                    "source": node_id,
+                    "target": target_id,
+                    "type": "related",
+                    "direction": "forward",
+                    "weight": 0.7,
+                })
+            elif not target_id:
+                warnings.append(f"Unresolved md link: [{ml['display']}]({ml['target']}) in {rel}")
+                stats["unresolved"] += 1
+
+        # --- Edges from prose cross-refs ---
+        for pr in prose_refs:
+            candidates = numbered_index.get(pr["num"], [])
+            if len(candidates) == 1:
+                target_id = candidates[0]
+                if target_id != node_id:
+                    edges.append({
+                        "source": node_id,
+                        "target": target_id,
+                        "type": "references",
+                        "direction": "forward",
+                        "weight": 0.5,
+                    })
+            elif len(candidates) > 1:
+                warnings.append(
+                    f"Ambiguous prose ref {pr['namespace']}/{pr['num']} in {rel} "
+                    f"(matches {len(candidates)} files)"
+                )
+                stats["unresolved"] += 1
+            else:
+                # No numbered file with this prefix — common for back-refs to
+                # non-existent sections; record without spamming.
+                stats["unresolved"] += 1
+
+    # --- Build topic nodes from numeric-prefix groups ---
+    for group_label, member_ids in sorted(group_to_articles.items()):
+        topic_id = f"topic:{group_label}"
+        nodes.append({
+            "id": topic_id,
+            "type": "topic",
+            "name": group_label,
+            "summary": f"Doctrine group: {group_label} ({len(member_ids)} articles)",
+            "tags": ["category", "doctrine-group"],
+            "complexity": "simple",
+        })
+        stats["topics"] += 1
+        for aid in member_ids:
+            edges.append({
+                "source": aid,
+                "target": topic_id,
+                "type": "categorized_under",
+                "direction": "forward",
+                "weight": 0.6,
+            })
+
+    # --- Build source nodes from raw/ (same as Karpathy) ---
+    if raw_root.is_dir():
+        for raw_file in sorted(raw_root.rglob("*")):
+            if raw_file.is_file() and not raw_file.name.startswith("."):
+                rel_raw = raw_file.relative_to(root)
+                ext = raw_file.suffix.lower()
+                size_kb = raw_file.stat().st_size / 1024
+                source_id = f"source:{raw_file.relative_to(raw_root).with_suffix('')}"
+                nodes.append({
+                    "id": source_id,
+                    "type": "source",
+                    "name": raw_file.name,
+                    "filePath": str(rel_raw),
+                    "summary": f"Raw source ({ext or 'unknown'}, {size_kb:.0f} KB)",
+                    "tags": ["raw", ext.lstrip(".") or "unknown"],
+                    "complexity": "simple",
+                })
+                stats["sources"] += 1
+
+    # --- Backlinks ---
+    backlink_map: dict[str, list[str]] = {}
+    for edge in edges:
+        if edge["type"] in ("related", "references"):
+            backlink_map.setdefault(edge["target"], []).append(edge["source"])
+    for node in nodes:
+        if node["type"] == "article" and "knowledgeMeta" in node:
+            node["knowledgeMeta"]["backlinks"] = backlink_map.get(node["id"], [])
+
+    # --- Dedupe edges ---
+    seen_edges: set[tuple[str, str, str]] = set()
+    deduped_edges = []
+    for edge in edges:
+        key = (edge["source"], edge["target"], edge["type"])
+        if key not in seen_edges:
+            seen_edges.add(key)
+            deduped_edges.append(edge)
+
+    return {
+        "format": "doctrine",
+        "stats": stats,
+        "categories": [
+            {"name": g, "count": len(members)}
+            for g, members in sorted(group_to_articles.items())
+        ],
+        "logEntries": 0,
+        "nodes": nodes,
+        "edges": deduped_edges,
+        "warnings": warnings[:50],
+    }
+
+
 def main():
     if len(sys.argv) < 2:
         print("Usage: parse-knowledge-base.py <wiki-directory>", file=sys.stderr)
@@ -499,9 +901,21 @@ def main():
 
     # Report to stderr
     s = manifest["stats"]
-    print(f"[parse] Karpathy wiki: {s['articles']} articles, {s['sources']} sources, "
-          f"{s['topics']} topics, {s['wikilinks']} wikilinks "
-          f"({s['unresolved']} unresolved)", file=sys.stderr)
+    fmt = manifest.get("format", "unknown")
+    if fmt == "doctrine":
+        print(
+            f"[parse] Doctrine corpus: {s['articles']} articles, {s['sources']} sources, "
+            f"{s['topics']} groups, {s['mdLinks']} md-links, {s['proseRefs']} prose-refs "
+            f"({s['unresolved']} unresolved)",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"[parse] Karpathy wiki: {s['articles']} articles, {s['sources']} sources, "
+            f"{s['topics']} topics, {s['wikilinks']} wikilinks "
+            f"({s['unresolved']} unresolved)",
+            file=sys.stderr,
+        )
     print(f"[parse] Output: {out_path}", file=sys.stderr)
 
 


### PR DESCRIPTION
## Problem

`/understand-knowledge` currently rejects any markdown directory that doesn't follow the Karpathy three-layer pattern (`index.md` + `[[wikilinks]]` + `raw/`). Many real-world doctrine corpora — design canon dirs, RFC archives, layered ADR collections — use a different convention: numbered files (`NN-topic.md`), prose cross-references (`see canon/04 §6-7`, `Doctrine #11`), and standard markdown links (`[name](file.md)`). On these corpora, the parser currently exits with `{"error": "Not a Karpathy-pattern wiki"}` and the entire skill becomes unavailable.

Concrete reproduction on a 14-file numbered-doctrine directory: parser exits 1 with the Karpathy-rejection error before any extraction happens. Users must either restructure their docs to fit Karpathy or skip the skill entirely.

## Solution

Extend `detect_format()` to recognize a second format — `"doctrine"` — defined by three orthogonal signals:
1. Numbered file pattern (`NN-name.md`, at least 3 files matching)
2. Prose cross-refs (`canon/N`, `Doctrine #N`, `chapter N`)
3. Standard markdown links (`[name](path.md)`)

When at least signal 1 plus one of {2, 3} is present and `index.md` is not, the format is detected as `"doctrine"`. **Karpathy detection takes precedence when both signal sets are present**, so existing Karpathy users see zero behavioral change.

Add `_parse_doctrine_wiki()` that mirrors the Karpathy article-extraction loop but:
- Resolves edges via prose-ref → numbered-file suffix index (`canon/04` → `04-layer-omega.md`)
- Resolves edges from `[label](path.md)` markdown links rather than `[[wikilinks]]`
- Derives categories from each file's numeric-prefix tens-digit (`group-0` for files `00–09`, `group-1` for `10–19`, etc.)
- Emits a new `references` edge type for prose cross-refs alongside the existing `related` type for explicit links

The dispatcher `parse_wiki(root)` now routes on `detection["format"]`. The existing Karpathy code path is factored unchanged into `_parse_karpathy_wiki()`.

## Manifest schema

Doctrine manifests use the same top-level shape as Karpathy (`format`, `stats`, `categories`, `nodes`, `edges`, `warnings`) so downstream consumers like `merge-batch-graphs.py` work without modification. The `stats` block uses `mdLinks` + `proseRefs` keys instead of Karpathy's `wikilinks`, and `main()` dispatches the stderr report format accordingly.

## Scope

- 1 file: `understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py` (~414 net LOC: helpers, format dispatch, `_parse_doctrine_wiki()`, link/ref resolution)
- 1 new file: `tests/skill/understand-knowledge/test_parse_knowledge_base.py` (~230 LOC, 21 tests)

## Tests

21 new tests across 4 classes:
- `DetectFormatTests` (5): doctrine detection, Karpathy detection unchanged, Karpathy precedence when both signals present, below-threshold non-detection, empty-directory unknown
- `DoctrineWikiParseTests` (10): manifest format dispatch, article count, node-ID prefix convention, md-link edge resolution, prose-ref edge resolution, topic-node generation, categorized-under edges, backlinks population, first-paragraph summary extraction, warnings cap
- `HelperExtractionTests` (5): md-links skip external URLs, md-links skip code blocks, fragment-strip, prose-ref dedup, prose-ref namespace variants
- `KarpathyRegressionTests` (1): existing Karpathy fixture parses unchanged via the new dispatcher

Combined with the existing skill test suite: 93/93 pass (72 prior + 21 new).

## Backwards compatibility

- Existing Karpathy corpora detect, parse, and produce identical manifests via `_parse_karpathy_wiki()` (the original code path, only renamed).
- Karpathy precedence rule: when a directory has both `index.md` (Karpathy signal) and numbered files (doctrine signal), the dispatcher chooses Karpathy. Verified by a dedicated test.
- No schema changes to the Karpathy manifest. Doctrine manifests use the same top-level keys.

## Why it's worth merging

Adds first-class support for a markdown convention that's at least as common as the Karpathy pattern (numbered files + prose refs + standard md links are the default for most documentation tools — Hugo, Jekyll, MkDocs, and most ADR/RFC archives). The skill becomes useful on a strictly larger set of corpora with no cost to existing users.
