### PR TITLE
fix: restore pnpm.onlyBuiltDependencies in plugin package.json for standalone install

### DIFF
--- a/understand-anything-plugin/package.json
+++ b/understand-anything-plugin/package.json
@@ -17,5 +17,22 @@
     "@types/node": "^22.0.0",
     "typescript": "^5.7.0",
     "vitest": "^3.1.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp",
+      "tree-sitter-c",
+      "tree-sitter-c-sharp",
+      "tree-sitter-cpp",
+      "tree-sitter-go",
+      "tree-sitter-java",
+      "tree-sitter-javascript",
+      "tree-sitter-php",
+      "tree-sitter-python",
+      "tree-sitter-ruby",
+      "tree-sitter-rust",
+      "tree-sitter-typescript"
+    ]
   }
 }


### PR DESCRIPTION
## Problem

When this plugin is installed via Claude Code's plugin marketplace (`/plugin install understand-anything@understand-anything`), only the `understand-anything-plugin/` subdirectory is copied into `~/.claude/plugins/cache/`. The monorepo root `package.json` is **not** part of the installed payload.

Since PR #142's review-feedback fix (commit 20833421) moved `pnpm.onlyBuiltDependencies` from `understand-anything-plugin/package.json` to the monorepo root, end-user installs no longer carry any allowlist for native build scripts. On pnpm v10 (which errors instead of warning on ignored builds), `pnpm install` inside the installed plugin directory fails:

```text
ERR_PNPM_IGNORED_BUILDS Ignored build scripts: esbuild@0.25.12,
  tree-sitter-c-sharp@0.23.5, tree-sitter-c@0.23.6, tree-sitter-cpp@0.23.4,
  tree-sitter-go@0.25.0, tree-sitter-java@0.23.5, tree-sitter-javascript@0.23.1,
  tree-sitter-javascript@0.25.0, tree-sitter-php@0.23.12,
  tree-sitter-python@0.25.0, tree-sitter-ruby@0.23.1, tree-sitter-rust@0.24.0,
  tree-sitter-typescript@0.23.2

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
ERROR Command failed with exit code 1: pnpm install
```

This blocks the `/understand` skill at Phase 0 step 1.5 ("Ensure the plugin is built") — `packages/core/dist/index.js` cannot be produced and the skill aborts with the standard "Install Node.js ≥ 22 and pnpm ≥ 10" hint.

## Repro

1. Fresh machine with pnpm v10+ installed
2. In Claude Code:
   ```
   /plugin marketplace add https://github.com/Lum1104/Understand-Anything
   /plugin install understand-anything@understand-anything
   /understand
   ```
3. Phase 0.5 fails on `pnpm install` due to ignored build scripts.

## Fix

Re-add `pnpm.onlyBuiltDependencies` to `understand-anything-plugin/package.json`, mirroring the list in the monorepo root (plus `sharp`, which is already in the root copy).

This is intentional duplication:

| Consumer | Reads from |
|---|---|
| Contributor running `pnpm install` from monorepo root | root `package.json` |
| End-user installing via CC plugin marketplace (only the subdir is copied) | `understand-anything-plugin/package.json` |

Without this, every fresh CC plugin install hits `ERR_PNPM_IGNORED_BUILDS` until the user manually edits the package.

## Verified

After the change, on a clean pnpm cache:

```text
pnpm install --no-frozen-lockfile
# … node-gyp-build ran for 12 tree-sitter parsers + esbuild postinstall …
# Done in 16.4s using pnpm v11.1.1
pnpm --filter @understand-anything/core build
ls packages/core/dist/index.js  # exists, 2.2KB
```

Then `/understand` proceeds through Phases 0–7 and writes a valid `knowledge-graph.json`.
