### PR TITLE
docs(core): correct DEFAULT_IGNORE_PATTERNS comment about bin/

### DIFF
--- a/understand-anything-plugin/packages/core/src/ignore-filter.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-filter.ts
@@ -4,7 +4,12 @@ import { join } from "node:path";
 
 /**
  * Hardcoded default ignore patterns matching the project-scanner agent's
- * exclusion rules, plus bin/obj for .NET projects.
+ * exclusion rules, plus obj/ for .NET build output.
+ *
+ * Note: bin/ is intentionally NOT excluded. Although it holds .NET build
+ * output, it doubles as the conventional location for CLI entrypoint source
+ * in Node and Ruby projects, which should still be analyzed. See the
+ * "does not contain bin" case in ignore-filter.test.ts.
  */
 export const DEFAULT_IGNORE_PATTERNS: string[] = [
   // Dependency directories


### PR DESCRIPTION
## What

The block comment above `DEFAULT_IGNORE_PATTERNS` in `packages/core/src/ignore-filter.ts` says the defaults add "bin/obj for .NET projects", but only `obj/` is actually included.

## Why

`bin/` is intentionally excluded — in Node and Ruby projects `bin/` is the conventional location for CLI entrypoint **source**, which should still be analyzed. This is already enforced by the `"does not contain bin (used by Node/Ruby CLI launchers)"` test in `ignore-filter.test.ts`. Only `obj/` is pure .NET intermediate build output that's safe to blanket-ignore.

The inaccurate comment is what led to the confusion in #76, where it looked like `bin/` had simply been forgotten. This documents the exclusion as intentional and points at the test so the next reader doesn't try to "fix" it by adding `bin/` (which would break the test and start analyzing source as build output).

## Change

Comment-only. No behavior change.

```
- * exclusion rules, plus bin/obj for .NET projects.
+ * exclusion rules, plus obj/ for .NET build output.
+ *
+ * Note: bin/ is intentionally NOT excluded. Although it holds .NET build
+ * output, it doubles as the conventional location for CLI entrypoint source
+ * in Node and Ruby projects, which should still be analyzed. See the
+ * "does not contain bin" case in ignore-filter.test.ts.
```

## Testing

`pnpm test` in `packages/core` — all 670 tests pass (33 files), including the full `ignore-filter` suite.

Refs #76