### PR TITLE
fix(dashboard): make graph nodes draggable in code structure and   domain views

### DIFF
--- a/understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   ReactFlow,
   ReactFlowProvider,
@@ -6,8 +6,9 @@ import {
   BackgroundVariant,
   Controls,
   MiniMap,
+  applyNodeChanges,
 } from "@xyflow/react";
-import type { Edge, Node } from "@xyflow/react";
+import type { Edge, Node, NodeChange } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 
 import DomainClusterNode from "./DomainClusterNode";
@@ -220,6 +221,10 @@ function DomainGraphViewInner() {
 
   const { nodes, edges } = layout;
 
+  const onNodesChange = useCallback((changes: NodeChange[]) => {
+    setLayout((prev) => ({ ...prev, nodes: applyNodeChanges(changes, prev.nodes) }));
+  }, []);
+
   // Double-click is handled by individual node components (e.g. DomainClusterNode)
 
   if (!domainGraph) {
@@ -246,6 +251,7 @@ function DomainGraphViewInner() {
       <ReactFlow
         nodes={nodes}
         edges={edges}
+        onNodesChange={onNodesChange}
         nodeTypes={nodeTypes}
         fitView
         fitViewOptions={{ padding: 0.2 }}

--- a/understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx
@@ -1529,7 +1529,7 @@ function GraphViewInner() {
         onMove={navigationLevel === "layer-detail" ? onMove : undefined}
         onInit={setReactFlowInstance}
         nodeTypes={nodeTypes}
-        nodesDraggable={false}
+        nodesDraggable={true}
         nodesConnectable={false}
         edgesFocusable={false}
         edgesReconnectable={false}


### PR DESCRIPTION
## Summary

  Two graph views in the dashboard had nodes that couldn't be dragged. This PR
  enables drag in both with a minimal change.

  - **`GraphView` (code structure)**: drag was explicitly disabled via a prop.
  - **`DomainGraphView` (domain overview / detail)**: drag was "enabled" by
  default but silently broken because the component is fully controlled and
  never wired an `onNodesChange` handler.

  ## Problem

  ### `GraphView.tsx`
  `nodesDraggable={false}` was hard-coded on `<ReactFlow>`, so React Flow
  disabled drag at the prop level.

  ### `DomainGraphView.tsx`
  `nodes` come from local `useState` (the result of the ELK layout pass). React
  Flow v12 in controlled mode requires the parent to acknowledge node changes
  via `onNodesChange`; otherwise drag events visually move the node for one
  frame and then the next render snaps it back to its prop position. Result: the
   node appears "stuck" or "jumps and reverts" with no error in the console.

  ### Repro
  1. Run `/understand` and `/understand-domain` on any project, then
  `/understand-dashboard`.
  2. Try to drag any node in the **Structure** view → doesn't move.
  3. Try to drag any node in the **Domain** view → flickers and snaps back.

  ## Fix

  **`GraphView.tsx`** — flip the prop. `onNodesChange` was already wired, so
  this is the only change needed.

  ```diff
  - nodesDraggable={false}
  + nodesDraggable={true}
  ```

  **`DomainGraphView.tsx`** — wire `onNodesChange` using React Flow's
  `applyNodeChanges` helper, so drag positions get written back into the
  `layout` state.

  ```diff
  - import { useEffect, useMemo, useState } from "react";
  + import { useCallback, useEffect, useMemo, useState } from "react";
    import {
      ReactFlow,
      ...
      MiniMap,
  +   applyNodeChanges,
    } from "@xyflow/react";
  - import type { Edge, Node } from "@xyflow/react";
  + import type { Edge, Node, NodeChange } from "@xyflow/react";
  ```

  ```diff
    const { nodes, edges } = layout;

  + const onNodesChange = useCallback((changes: NodeChange[]) => {
  +   setLayout((prev) => ({ ...prev, nodes: applyNodeChanges(changes,
  prev.nodes) }));
  + }, []);
  ```

  ```diff
    <ReactFlow
      nodes={nodes}
      edges={edges}
  +   onNodesChange={onNodesChange}
      nodeTypes={nodeTypes}
  ```

  Both views run their layout pass (d3-force in `GraphView`, ELK in
  `DomainGraphView`) once at mount and don't re-simulate continuously, so
  user-positioned nodes won't be pulled back by an active simulation.

  ## Not in scope (follow-up)

  `KnowledgeGraphView.tsx` has the same controlled-but-unwired root cause, but
  its `nodes` are derived via `useMemo` from selection / search / tour state. A
  clean fix there needs a separate `positionOverrides: Map<id, {x, y}>` state so
   that user-dragged positions persist without breaking the reactive
  highlighting. Happy to send a follow-up PR if you'd like.

  ## Test plan

  - [ ] Structure view (`/understand`): drag a node — moves freely, stays where
  dropped.
  - [ ] Domain overview view (`/understand-domain`): same.
  - [ ] Domain detail view (drill into a domain cluster): same.
  - [ ] Pan / zoom / fit-view / node click / neighborhood highlighting still
  work.
  - [ ] Re-applying a filter or selection recomputes the layout as before (drag
  state isn't expected to persist across layout recomputes — same as before this
   PR).

