### PR TITLE
fix: add missing skills and agents fields to plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,6 +8,8 @@
   "homepage": "https://github.com/Lum1104/Understand-Anything",
   "repository": "https://github.com/Lum1104/Understand-Anything",
   "license": "MIT",
+  "skills": "./skills",
+  "agents": "./agents",
   "keywords": [
     "codebase-analysis",
     "knowledge-graph",

--- a/understand-anything-plugin/.claude-plugin/plugin.json
+++ b/understand-anything-plugin/.claude-plugin/plugin.json
@@ -8,6 +8,8 @@
   "homepage": "https://github.com/Lum1104/Understand-Anything",
   "repository": "https://github.com/Lum1104/Understand-Anything",
   "license": "MIT",
+  "skills": "./skills",
+  "agents": "./agents",
   "keywords": [
     "codebase-analysis",
     "knowledge-graph",


### PR DESCRIPTION
## Problem

The `plugin.json` is missing `skills` and `agents` field declarations, so Claude Code cannot discover the plugin's skills and agents.

- `skills/` directory exists with 8 skills (understand, understand-chat, understand-dashboard, understand-diff, understand-domain, understand-explain, understand-knowledge, understand-onboard) but the plugin system doesn't know to look there
- `agents/` directory exists but isn't registered

## Fix

Added two lines to `.claude-plugin/plugin.json`:
```json
"skills": "./skills",
"agents": "./agents"
```

## Comparison

Other plugins like `agent-skills` explicitly declare these fields and work correctly. Without them, skills placed in a `skills/` subdirectory are invisible to the plugin loader.

---
?? Generated with [Claude Code](https://claude.com/claude-code)