### PR TITLE
fix(understand): recover batch output when subagent Write tool is denied

### DIFF
--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -336,6 +336,8 @@ Dispatch prompt template (fill in batch-specific values from `batches.json[i]`):
 
 **Output naming is per-batchIndex — no fusion.** If you fuse multiple small batches into a single file-analyzer dispatch for token efficiency, the dispatched agent must STILL write one output file per original `batchIndex` using `batch-<batchIndex>.json` or `batch-<batchIndex>-part-<k>.json`. The merge script's regex (`batch-(\d+)(?:-part-(\d+))?\.json`) silently drops any other naming (e.g., `batch-fused-8-13.json`, `batch-8-13.json`), losing every node and edge in that file. After each dispatch returns, verify each `batchIndex` in the dispatched input has a corresponding `batch-<batchIndex>.json` (or `batch-<batchIndex>-part-*.json`) on disk before proceeding to the next dispatch.
 
+**Write-permission fallback.** If a batch file is missing after the agent returns, do not silently continue — the agent was likely denied the Write tool by the host project's permission settings. In that case, inspect the agent's result message for a JSON object containing `nodes` and `edges` arrays (agents blocked from writing almost always return their output as inline JSON in the result text). If found, write it yourself to the correct `batch-<batchIndex>.json` path using your own Write tool before continuing. If neither the file nor inline JSON is present, log a warning to `$PHASE_WARNINGS` and proceed — the merge script will produce a partial graph, which is better than failing the entire run.
+
 After ALL batches complete, report to the user: `Phase 2 complete. All <totalBatches> batches analyzed.`
 
 Run the merge-and-normalize script bundled with this skill (located next to this SKILL.md file — use the skill directory path, not the project root):


### PR DESCRIPTION
## Problem

In Phase 2 (file analysis), `SKILL.md` instructs the orchestrator to verify that each `batch-<N>.json` file exists after a subagent returns — but provides **no recovery path** when the file is missing.

This silently causes data loss when subagents are denied the `Write` tool, which is a common situation in projects with strict permission settings (e.g. a project `.claude/settings.json` that does not allowlist Write for subagents). The subagent correctly analyzes its batch and returns the graph JSON **in its result message**, but the orchestrator has no instruction to capture it — so the data is lost and the final graph is missing nodes and edges with no error reported to the user.

## Root cause

`skills/understand/SKILL.md`, Phase 2, the verification sentence:

> "After each dispatch returns, verify each `batchIndex` in the dispatched input has a corresponding `batch-<batchIndex>.json`… on disk before proceeding to the next dispatch."

The verification is there. The failure branch is not.

## Fix

One paragraph added immediately after the existing verification sentence:

> **Write-permission fallback.** If a batch file is missing after the agent returns, do not silently continue — the agent was likely denied the Write tool by the host project's permission settings. In that case, inspect the agent's result message for a JSON object containing `nodes` and `edges` arrays (agents blocked from writing almost always return their output as inline JSON in the result text). If found, write it yourself to the correct `batch-<batchIndex>.json` path using your own Write tool before continuing. If neither the file nor inline JSON is present, log a warning to `$PHASE_WARNINGS` and proceed — the merge script will produce a partial graph, which is better than failing the entire run.

**Scope:** `SKILL.md` only — no changes to scripts, packages, or agent definitions.

## How it was discovered

Running `/understand` on a 65-file project (Tax Authority Enterprise RAG) inside a Claude Code session where the project's `.claude/settings.json` had restrictive subagent permissions. **8 of 12 batch agents** were denied the Write tool and returned their batch JSON inline in the result message. The orchestrator had to manually detect the pattern and write each file mid-session. This fix makes that recovery automatic and documented.

## Before / After

| Scenario | Before this fix | After this fix |
|---|---|---|
| Subagent has Write permission | ✅ Works normally | ✅ Works normally |
| Subagent denied Write, returns inline JSON | ❌ Data silently lost | ✅ Orchestrator writes the file itself |
| Subagent denied Write, returns no JSON | ❌ Data silently lost | ⚠️ Warning logged, partial graph saved |

## Testing

Run `/understand` on any project inside a Claude Code session where `.claude/settings.json` restricts the Write tool for subagents. Without this fix, batch files are missing and the graph is incomplete. With this fix, the orchestrator recovers inline JSON and produces a complete graph.