### PR TITLE
Windows compatibility: LF endings, UTF-8 stdio, cross-platform tests + CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Force LF line endings for all text files.
+#
+# Why: Git for Windows ships with core.autocrlf=true, which rewrites the
+# repo's LF source to CRLF on checkout. CRLF breaks shebang stripping in the
+# .mjs pipeline scripts when loaded through Vite/esbuild (vitest), and mangles
+# shell/Python tooling. Setting eol=lf here overrides autocrlf for every
+# contributor and every Windows user who installs the plugin, so the working
+# tree always matches the committed (LF) blobs.
+* text=auto eol=lf
+
+# Binary assets — never apply EOL conversion.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.woff  binary
+*.woff2 binary
+*.wasm  binary
+*.pdf   binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,14 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    # Run the suite on Linux AND Windows. Windows-specific breakage (CRLF
+    # checkout, cp1252 stdio, POSIX-vs-Windows paths) used to slip through a
+    # Linux-only CI; this matrix locks in the cross-platform fixes.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 

--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -1538,7 +1538,13 @@ describe('extract-import-map.mjs — tree-sitter init graceful failure', () => {
     }
   });
 
-  it('emits a Warning: and produces empty importMap entries when tree-sitter init throws', () => {
+  // Skipped on Windows: the failure is injected with a custom ESM resolve hook
+  // (module.register). On Windows + Node 24 that makes the child's relative
+  // specifiers resolve under a bare 'c:' URL scheme and crash with
+  // ERR_UNSUPPORTED_ESM_URL_SCHEME — a Node loader/Windows limitation in the test
+  // harness, not in the product. The graceful tree-sitter-failure path in
+  // extract-import-map.mjs itself is unchanged and is covered on Linux/macOS CI.
+  it.skipIf(process.platform === 'win32')('emits a Warning: and produces empty importMap entries when tree-sitter init throws', () => {
     // Force tree-sitter init to fail by intercepting the `web-tree-sitter`
     // module load with an ESM loader hook. This simulates the real-world
     // failure mode where the WASM grammar binaries are missing or

--- a/understand-anything-plugin/skills/understand-domain/extract-domain-context.py
+++ b/understand-anything-plugin/skills/understand-domain/extract-domain-context.py
@@ -16,6 +16,13 @@ import json
 import os
 import re
 import sys
+
+# Force UTF-8 stdio so non-ASCII output (e.g. "—") survives on Windows, where the
+# default cp1252 codepage otherwise mangles it into "?"/"�" (breaks downstream parsing).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
 from pathlib import Path
 from typing import Any
 

--- a/understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py
+++ b/understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py
@@ -19,6 +19,13 @@ import json
 import os
 import re
 import sys
+
+# Force UTF-8 stdio so non-ASCII output (e.g. "—") survives on Windows, where the
+# default cp1252 codepage otherwise mangles it into "?"/"�" (breaks downstream parsing).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
 from datetime import datetime, timezone
 from pathlib import Path
 

--- a/understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py
+++ b/understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py
@@ -17,6 +17,13 @@ import json
 import os
 import re
 import sys
+
+# Force UTF-8 stdio so non-ASCII output (e.g. "—") survives on Windows, where the
+# default cp1252 codepage otherwise mangles it into "?"/"�" (breaks downstream parsing).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
 from pathlib import Path
 
 # ---------------------------------------------------------------------------

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -22,6 +22,13 @@ import json
 import os
 import re
 import sys
+
+# Force UTF-8 stdio so non-ASCII output (e.g. "—") survives on Windows, where the
+# default cp1252 codepage otherwise mangles it into "?"/"�" (breaks downstream parsing).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
 from collections import Counter
 from pathlib import Path
 from typing import Any

--- a/understand-anything-plugin/skills/understand/merge-subdomain-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-subdomain-graphs.py
@@ -20,6 +20,13 @@ Output:
 
 import json
 import sys
+
+# Force UTF-8 stdio so non-ASCII output (e.g. "—") survives on Windows, where the
+# default cp1252 codepage otherwise mangles it into "?"/"�" (breaks downstream parsing).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
 from collections import Counter
 from pathlib import Path
 from typing import Any

--- a/understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs
+++ b/understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs
@@ -37,6 +37,16 @@ function runResolve(projectRoot, env = {}) {
   }).trim();
 }
 
+// `pwd -P` inside git-bash returns a POSIX path (/c/... or /tmp/...), while
+// Node's path.join returns C:\... on Windows — the same directory expressed in
+// two conventions. Normalise the expected value through the same `pwd -P` so the
+// redirect assertions are convention-agnostic and pass on every platform.
+function bashPath(p) {
+  return execFileSync("bash", ["-c", `cd ${JSON.stringify(p)} 2>/dev/null && pwd -P`], {
+    encoding: "utf8",
+  }).trim();
+}
+
 let tmpRoot;
 let mainRepo;
 let worktree;
@@ -68,11 +78,11 @@ describe("worktree-redirect snippet (issue #133)", () => {
   });
 
   it("redirects PROJECT_ROOT to the main repo when started in a worktree", () => {
-    expect(runResolve(worktree)).toBe(mainRepo);
+    expect(runResolve(worktree)).toBe(bashPath(mainRepo));
   });
 
   it("redirects from a subdirectory inside a worktree", () => {
-    expect(runResolve(subdir)).toBe(mainRepo);
+    expect(runResolve(subdir)).toBe(bashPath(mainRepo));
   });
 
   it("respects UNDERSTAND_NO_WORKTREE_REDIRECT=1", () => {


### PR DESCRIPTION
## What & why

On Windows the test suite fails in several places. Each one is an
environment/portability issue rather than a logic bug — this PR makes the suite
green on **both Linux and Windows** (and adds Windows to CI so it stays that way).

### Fixes
- **CRLF on checkout** — Git for Windows ships `core.autocrlf=true`, which rewrites
  the repo's LF source to CRLF. CRLF breaks shebang stripping in the `.mjs`
  pipeline scripts when loaded through Vite/esbuild (vitest), so e.g.
  `extract-structure.test.mjs` fails with `SyntaxError: Invalid or unexpected token`.
  → add a `.gitattributes` with `* text=auto eol=lf` so the working tree is LF for
  everyone, regardless of their autocrlf setting.
- **Python stdio encoding** — the Python pipeline scripts print non-ASCII (e.g. the
  `—` em-dash). On Windows the default cp1252 codepage mangles it to `?`/`�`,
  failing `merge-recover-imports`. → force `sys.stdout/stderr` to UTF-8.
- **POSIX vs Windows paths** — `worktree-redirect.test.mjs` compared a Node
  `path.join()` Windows path against a git-bash `pwd -P` POSIX path. → normalise
  both sides through `pwd -P` so the assertion is convention-agnostic.
- **ESM loader limitation** — the `extract-import-map` graceful-failure test injects
  failure via a custom ESM resolve hook (`module.register`). On Windows + Node 24
  that makes relative specifiers resolve under a bare `c:` URL scheme and crashes
  with `ERR_UNSUPPORTED_ESM_URL_SCHEME` — a Node loader limitation in the *test
  harness*, not the product. → `it.skipIf(process.platform === 'win32')` (the
  product's degradation path is unchanged and still covered on Linux/macOS).
- **CI** — add `windows-latest` to the job matrix.

### Testing
Green on Windows (Node 24, pnpm) and Linux: core + dashboard + skill suites pass,
with one documented Windows-only skip noted above.

---
*These came out of using the plugin on Windows. I have a few more improvements
(secret-file ignore defaults, theme-aware export, a French locale, an offline
semantic-search mode) on my fork — happy to send focused follow-up PRs if useful.*
