### PR TITLE
Fix: run bundled Python scripts on Python 3.9 (macOS system Python) + test on a 3.9/3.13 CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches: [main]
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The bundled merge/parse scripts (skills/**/*.py) are invoked by the
+        # skill tests via `python3`. 3.9 is the floor we support because it is
+        # the Python that ships with macOS (Xcode Command Line Tools); the
+        # upper entry tracks a current release. Keep both green.
+        python-version: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -16,6 +24,10 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: pnpm install

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ An open-source tool combining LLM intelligence + static analysis to produce inte
 ## Prerequisites
 - Node.js >= 22 (developed on v24)
 - pnpm >= 10 (pinned via `packageManager` field in root `package.json`)
+- Python >= 3.9 (bundled skill scripts in `skills/**/*.py`; 3.9 is the floor because it ships with macOS via the Xcode Command Line Tools — keep the scripts 3.9-compatible)
 
 ## Architecture
 - **Monorepo** with pnpm workspaces

--- a/understand-anything-plugin/skills/understand-domain/extract-domain-context.py
+++ b/understand-anything-plugin/skills/understand-domain/extract-domain-context.py
@@ -12,6 +12,8 @@ Output:
     <project-root>/.understand-anything/intermediate/domain-context.json
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py
+++ b/understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py
@@ -15,6 +15,8 @@ Output:
     Writes assembled-graph.json to <wiki-directory>/.understand-anything/intermediate/
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py
+++ b/understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py
@@ -13,6 +13,8 @@ Output:
     Writes scan-manifest.json to <wiki-directory>/.understand-anything/intermediate/
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -18,6 +18,8 @@ Output:
     <project-root>/.understand-anything/intermediate/assembled-graph.json
 """
 
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/understand-anything-plugin/skills/understand/merge-subdomain-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-subdomain-graphs.py
@@ -18,6 +18,8 @@ Output:
     <project-root>/.understand-anything/knowledge-graph.json
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from collections import Counter


### PR DESCRIPTION
## Problem

Three of the bundled skill scripts crash on **Python 3.9** — the interpreter that ships with macOS via the Xcode Command Line Tools (`/usr/bin/python3` → 3.9.6). They use PEP 604 union syntax in annotations that are evaluated at function-definition time, with no `from __future__ import annotations`:

```python
def load_batch(path: Path) -> dict[str, Any] | None:   # 3.10+ only
```

On 3.9 this raises at import:

```
TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'NoneType'
```

Affected scripts (verified to fail on 3.9):

- `skills/understand/merge-batch-graphs.py` — **on the `/understand` happy path** (Phase 2 merge), so a macOS user with stock `python3` hits this on a normal run and the graph never assembles
- `skills/understand/merge-subdomain-graphs.py` — subdomain merge (Phase 0)
- `skills/understand-knowledge/parse-knowledge-base.py` — `/understand-knowledge`

`merge-knowledge-graph.py` and `extract-domain-context.py` happen to import fine on 3.9 today, but nothing prevents them from regressing.

### Why CI didn't catch it

`ci.yml` sets up Node but never pins Python, so the skill tests — which shell out to `python3` (e.g. `merge-recover-imports.test.mjs`, `spawnSync("python3", …)`) — only ever ran on `ubuntu-latest`'s default (3.10+). Notably, the test file `tests/skill/understand/test_merge_batch_graphs.py` already carries `from __future__ import annotations`; the production scripts just didn't.

## Changes

1. **Fix:** add `from __future__ import annotations` to **all five** bundled Python scripts. Annotations are documentation-only here (no `get_type_hints` / dataclasses / runtime union use), so deferring them is purely beneficial and kills the whole failure class regardless of which script later gains modern type-hint syntax.
2. **CI matrix:** add an `actions/setup-python` step under a `["3.9", "3.13"]` matrix so the suite runs on the macOS floor as well as a current release.
3. **CI trigger:** also run on `push` to `main`, not just `pull_request`, so direct pushes and merges to the default branch are gated.
4. **Docs:** declare `Python >= 3.9` in CLAUDE.md Prerequisites, documenting the floor this PR establishes.

## Verification (on Python 3.9.6)

- All five scripts import cleanly
- `tests/skill/understand/test_merge_batch_graphs.py` → 69 passed
- `pnpm test` → **200 passed** (was 6 failed / 194 passed; all 6 failures were `merge-recover-imports.test.mjs` shelling to `python3`)
- `pnpm lint`, core build, skill build, and `pnpm --filter @understand-anything/core test` (670 tests) all still green

## Notes

- The matrix re-runs the full job (incl. lint/build) on both legs for simplicity. If you'd rather not pay the extra minutes, a tighter alternative is a dedicated `python-compat` job that only runs the Python-touching tests across versions — happy to switch if you prefer.
