### PR TITLE
feat(core): add Swift structural analysis via tree-sitter (#226)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
 
   understand-anything-plugin/packages/core:
     dependencies:
+      '@repomix/tree-sitter-wasms':
+        specifier: 0.1.17
+        version: 0.1.17
       '@tree-sitter-grammars/tree-sitter-kotlin':
         specifier: 1.1.0
         version: 1.1.0
@@ -864,6 +867,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@repomix/tree-sitter-wasms@0.1.17':
+    resolution: {integrity: sha512-tc3HnFqdMF1pXhIMzG3aTaBDpIiHK2tPfn3fwqA6P3WTbHa+1EuuTubbKshvmN7xCHP5Ojz0/VW4R+XvR88KOw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -3870,6 +3876,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@repomix/tree-sitter-wasms@0.1.17': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 

--- a/understand-anything-plugin/packages/core/package.json
+++ b/understand-anything-plugin/packages/core/package.json
@@ -37,6 +37,7 @@
     "vitest": "^3.1.0"
   },
   "dependencies": {
+    "@repomix/tree-sitter-wasms": "0.1.17",
     "@tree-sitter-grammars/tree-sitter-kotlin": "1.1.0",
     "fuse.js": "^7.1.0",
     "ignore": "^7.0.5",

--- a/understand-anything-plugin/packages/core/src/languages/configs/swift.ts
+++ b/understand-anything-plugin/packages/core/src/languages/configs/swift.ts
@@ -4,6 +4,10 @@ export const swiftConfig = {
   id: "swift",
   displayName: "Swift",
   extensions: [".swift"],
+  treeSitter: {
+    wasmPackage: "@repomix/tree-sitter-wasms",
+    wasmFile: "out/tree-sitter-swift.wasm",
+  },
   concepts: [
     "optionals",
     "protocols",

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/swift-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/swift-extractor.test.ts
@@ -1,0 +1,590 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { createRequire } from "node:module";
+import { SwiftExtractor } from "../swift-extractor.js";
+
+const require = createRequire(import.meta.url);
+
+// Load tree-sitter + Swift grammar once
+let Parser: any;
+let Language: any;
+let swiftLang: any;
+
+beforeAll(async () => {
+  const mod = await import("web-tree-sitter");
+  Parser = mod.Parser;
+  Language = mod.Language;
+  await Parser.init();
+  const wasmPath = require.resolve(
+    "@repomix/tree-sitter-wasms/out/tree-sitter-swift.wasm",
+  );
+  swiftLang = await Language.load(wasmPath);
+});
+
+function parse(code: string) {
+  const parser = new Parser();
+  parser.setLanguage(swiftLang);
+  const tree = parser.parse(code);
+  const root = tree.rootNode;
+  return { tree, parser, root };
+}
+
+describe("SwiftExtractor", () => {
+  const extractor = new SwiftExtractor();
+
+  it("has correct languageIds", () => {
+    expect(extractor.languageIds).toEqual(["swift"]);
+  });
+
+  // ---- Functions ----
+
+  describe("extractStructure - functions", () => {
+    it("extracts a simple top-level function with params and return type", () => {
+      const { tree, parser, root } = parse(`func add(a: Int, b: Int) -> Int {
+    return a + b
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("add");
+      expect(result.functions[0].params).toEqual(["a", "b"]);
+      expect(result.functions[0].returnType).toBe("Int");
+      expect(result.functions[0].lineRange[0]).toBe(1);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts function with no params and no return type", () => {
+      const { tree, parser, root } = parse(`func noop() {
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("noop");
+      expect(result.functions[0].params).toEqual([]);
+      expect(result.functions[0].returnType).toBeUndefined();
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts generic function", () => {
+      const { tree, parser, root } = parse(`func map<T, U>(value: T, fn: (T) -> U) -> U {
+    return fn(value)
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("map");
+      expect(result.functions[0].params).toEqual(["value", "fn"]);
+      expect(result.functions[0].returnType).toBe("U");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts async throws function", () => {
+      const { tree, parser, root } = parse(`func fetchUser(id: String) async throws -> User {
+    return User()
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("fetchUser");
+      expect(result.functions[0].params).toEqual(["id"]);
+      expect(result.functions[0].returnType).toBe("User");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts parameter names ignoring external argument labels", () => {
+      // In Swift, `func f(_ name: Type)` has no external label; `func f(label name: Type)` has both.
+      // The internal name (`name`) is what's used inside the function body.
+      const { tree, parser, root } = parse(`func greet(_ name: String, with prefix: String) -> String {
+    return prefix + name
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].params).toEqual(["name", "prefix"]);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts multiple top-level functions", () => {
+      const { tree, parser, root } = parse(`func one() {}
+func two(x: Int) -> Int { return x }
+func three() -> String { return "" }
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(3);
+      expect(result.functions.map((f) => f.name)).toEqual([
+        "one",
+        "two",
+        "three",
+      ]);
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  // ---- Classes ----
+
+  describe("extractStructure - classes", () => {
+    it("extracts a simple class with properties and methods", () => {
+      const { tree, parser, root } = parse(`class Foo {
+    let bar: Int
+    var baz: String
+
+    init(bar: Int, baz: String) {
+        self.bar = bar
+        self.baz = baz
+    }
+
+    func compute() -> Int {
+        return bar * 2
+    }
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Foo");
+      expect(result.classes[0].properties).toEqual(["bar", "baz"]);
+      // Both the initializer ("init") and named methods should be listed
+      expect(result.classes[0].methods).toContain("compute");
+      expect(result.classes[0].methods).toContain("init");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts class with no body", () => {
+      const { tree, parser, root } = parse(`class Empty {}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Empty");
+      expect(result.classes[0].methods).toEqual([]);
+      expect(result.classes[0].properties).toEqual([]);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts class with inheritance and protocol conformance", () => {
+      const { tree, parser, root } = parse(`class Service: BaseService, Codable {
+    func run() {}
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Service");
+      expect(result.classes[0].methods).toContain("run");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("class methods appear in functions list too", () => {
+      // Methods inside a class are still functions; the project's GoExtractor does the same.
+      const { tree, parser, root } = parse(`class Foo {
+    func bar() -> Int { return 1 }
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions.map((f) => f.name)).toContain("bar");
+      expect(result.classes[0].methods).toContain("bar");
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - structs", () => {
+    it("extracts a struct with properties", () => {
+      const { tree, parser, root } = parse(`struct Point {
+    var x: Double
+    var y: Double
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Point");
+      expect(result.classes[0].properties).toEqual(["x", "y"]);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a generic struct with methods", () => {
+      const { tree, parser, root } = parse(`struct Stack<T> {
+    private var items: [T] = []
+
+    mutating func push(_ item: T) {
+        items.append(item)
+    }
+
+    mutating func pop() -> T? {
+        return items.popLast()
+    }
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Stack");
+      expect(result.classes[0].properties).toContain("items");
+      expect(result.classes[0].methods).toEqual(
+        expect.arrayContaining(["push", "pop"]),
+      );
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - enums", () => {
+    it("extracts a simple enum with cases", () => {
+      const { tree, parser, root } = parse(`enum Direction {
+    case north
+    case south
+    case east
+    case west
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Direction");
+      // Enum cases are properties (constant values of the type)
+      expect(result.classes[0].properties).toEqual(
+        expect.arrayContaining(["north", "south", "east", "west"]),
+      );
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a generic enum with associated values and methods", () => {
+      const { tree, parser, root } = parse(`enum Result<T, E> {
+    case success(T)
+    case failure(E)
+
+    func isSuccess() -> Bool {
+        switch self {
+        case .success: return true
+        case .failure: return false
+        }
+    }
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Result");
+      expect(result.classes[0].properties).toEqual(
+        expect.arrayContaining(["success", "failure"]),
+      );
+      expect(result.classes[0].methods).toContain("isSuccess");
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - protocols", () => {
+    it("extracts a protocol with required methods and properties", () => {
+      const { tree, parser, root } = parse(`protocol Greeter {
+    var prefix: String { get }
+
+    func greet(name: String) -> String
+    func farewell() -> String
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Greeter");
+      expect(result.classes[0].methods).toEqual(
+        expect.arrayContaining(["greet", "farewell"]),
+      );
+      expect(result.classes[0].properties).toContain("prefix");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a public protocol", () => {
+      const { tree, parser, root } = parse(`public protocol Codec {
+    func encode() -> Data
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Codec");
+      expect(result.exports.map((e) => e.name)).toContain("Codec");
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - actors", () => {
+    it("extracts an actor with isolated state and methods", () => {
+      const { tree, parser, root } = parse(`actor Counter {
+    private var count: Int = 0
+
+    func increment() async {
+        count += 1
+    }
+
+    func value() -> Int {
+        return count
+    }
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("Counter");
+      expect(result.classes[0].properties).toContain("count");
+      expect(result.classes[0].methods).toEqual(
+        expect.arrayContaining(["increment", "value"]),
+      );
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - extensions", () => {
+    it("extracts methods from extension on an external type", () => {
+      // Extension on a type defined elsewhere (e.g., Foundation's String).
+      // The extension itself is recorded as a class-like entry named after the extended type.
+      const { tree, parser, root } = parse(`extension String {
+    func shout() -> String { return self.uppercased() }
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("String");
+      expect(result.classes[0].methods).toContain("shout");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("attaches extension methods to a class declared in the same file", () => {
+      // When the extended type is declared in the same file, the extension's methods
+      // are added to that type's existing class entry instead of creating a duplicate.
+      const { tree, parser, root } = parse(`class Greeter {
+    func greet() -> String { return "hi" }
+}
+
+extension Greeter {
+    func shout() -> String { return greet().uppercased() }
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      // Only one Greeter entry, not two
+      const greeterEntries = result.classes.filter((c) => c.name === "Greeter");
+      expect(greeterEntries).toHaveLength(1);
+      expect(greeterEntries[0].methods).toEqual(
+        expect.arrayContaining(["greet", "shout"]),
+      );
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  // ---- Imports ----
+
+  describe("extractStructure - imports", () => {
+    it("extracts a simple import", () => {
+      const { tree, parser, root } = parse(`import Foundation
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("Foundation");
+      expect(result.imports[0].specifiers).toEqual(["Foundation"]);
+      expect(result.imports[0].lineNumber).toBe(1);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a submodule import like `import struct Combine.AnyPublisher`", () => {
+      const { tree, parser, root } = parse(`import struct Combine.AnyPublisher
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toHaveLength(1);
+      // Source is the dotted module path; specifier is the last component
+      expect(result.imports[0].source).toBe("Combine.AnyPublisher");
+      expect(result.imports[0].specifiers).toEqual(["AnyPublisher"]);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts an attributed import like `@testable import MyModule`", () => {
+      const { tree, parser, root } = parse(`@testable import MyModule
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("MyModule");
+      expect(result.imports[0].specifiers).toEqual(["MyModule"]);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts multiple imports in declaration order", () => {
+      const { tree, parser, root } = parse(`import Foundation
+import UIKit
+import struct Combine.Publishers
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toHaveLength(3);
+      expect(result.imports[0].source).toBe("Foundation");
+      expect(result.imports[1].source).toBe("UIKit");
+      expect(result.imports[2].source).toBe("Combine.Publishers");
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  // ---- Exports / visibility ----
+
+  describe("extractStructure - exports", () => {
+    it("marks public functions as exported", () => {
+      const { tree, parser, root } = parse(`public func greet() {}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.exports).toHaveLength(1);
+      expect(result.exports[0].name).toBe("greet");
+      expect(result.exports[0].lineNumber).toBe(1);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("marks open classes as exported", () => {
+      const { tree, parser, root } = parse(`open class Vehicle {
+    public func drive() {}
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      const exportNames = result.exports.map((e) => e.name);
+      expect(exportNames).toContain("Vehicle");
+      expect(exportNames).toContain("drive");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("does NOT mark internal (default) declarations as exported", () => {
+      const { tree, parser, root } = parse(`func helper() {}
+class Internal {}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.exports).toHaveLength(0);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("does NOT mark fileprivate or private declarations as exported", () => {
+      const { tree, parser, root } = parse(`private func a() {}
+fileprivate class B {}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.exports).toHaveLength(0);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("marks public structs, enums, protocols, and actors", () => {
+      const { tree, parser, root } = parse(`public struct S {}
+public enum E {}
+public protocol P {}
+public actor A {}
+`);
+      const result = extractor.extractStructure(root);
+
+      const exportNames = result.exports.map((e) => e.name);
+      expect(exportNames).toEqual(expect.arrayContaining(["S", "E", "P", "A"]));
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  // ---- Call graph ----
+
+  describe("extractCallGraph", () => {
+    it("extracts simple call from one function to another", () => {
+      const { tree, parser, root } = parse(`func helper() -> Int { return 1 }
+
+func caller() -> Int {
+    return helper()
+}
+`);
+      const entries = extractor.extractCallGraph(root);
+
+      expect(entries).toContainEqual({
+        caller: "caller",
+        callee: "helper",
+        lineNumber: 4,
+      });
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts method calls with navigation expressions", () => {
+      const { tree, parser, root } = parse(`func run() {
+    let s = "hi".uppercased()
+}
+`);
+      const entries = extractor.extractCallGraph(root);
+
+      // For method calls like x.foo(), the callee should be the method name "uppercased"
+      const callees = entries.map((e) => e.callee);
+      expect(callees).toContain("uppercased");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("attributes calls inside class methods to the method, not the file", () => {
+      const { tree, parser, root } = parse(`class Service {
+    func compute() {
+        helper()
+    }
+}
+
+func helper() {}
+`);
+      const entries = extractor.extractCallGraph(root);
+
+      const helperCall = entries.find((e) => e.callee === "helper");
+      expect(helperCall).toBeDefined();
+      expect(helperCall!.caller).toBe("compute");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("returns an empty array when there are no calls", () => {
+      const { tree, parser, root } = parse(`func a() { return }
+`);
+      const entries = extractor.extractCallGraph(root);
+      // No calls in this function body
+      expect(entries).toEqual([]);
+      tree.delete();
+      parser.delete();
+    });
+  });
+});

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/index.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/index.ts
@@ -10,6 +10,7 @@ export { PhpExtractor } from "./php-extractor.js";
 export { CppExtractor } from "./cpp-extractor.js";
 export { CSharpExtractor } from "./csharp-extractor.js";
 export { KotlinExtractor } from "./kotlin-extractor.js";
+export { SwiftExtractor } from "./swift-extractor.js";
 
 import type { LanguageExtractor } from "./types.js";
 import { TypeScriptExtractor } from "./typescript-extractor.js";
@@ -22,6 +23,7 @@ import { PhpExtractor } from "./php-extractor.js";
 import { CppExtractor } from "./cpp-extractor.js";
 import { CSharpExtractor } from "./csharp-extractor.js";
 import { KotlinExtractor } from "./kotlin-extractor.js";
+import { SwiftExtractor } from "./swift-extractor.js";
 
 export const builtinExtractors: LanguageExtractor[] = [
   new TypeScriptExtractor(),
@@ -34,4 +36,5 @@ export const builtinExtractors: LanguageExtractor[] = [
   new CppExtractor(),
   new CSharpExtractor(),
   new KotlinExtractor(),
+  new SwiftExtractor(),
 ];

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/swift-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/swift-extractor.ts
@@ -1,0 +1,468 @@
+import type { StructuralAnalysis, CallGraphEntry } from "../../types.js";
+import type { LanguageExtractor, TreeSitterNode } from "./types.js";
+import { findChild, findChildren } from "./base-extractor.js";
+
+/**
+ * Set of Swift visibility modifier keywords that count as exported across
+ * module boundaries. `internal` (the default) is module-private, so it is
+ * not in this set.
+ */
+const EXPORTED_VISIBILITIES = new Set(["public", "open"]);
+
+/**
+ * Tree-sitter `class_declaration` is overloaded for several Swift declarations
+ * distinguished by the `declaration_kind` field. We treat all of them as
+ * `class`-like entries in the StructuralAnalysis output.
+ */
+type SwiftTypeKind = "class" | "struct" | "enum" | "actor" | "extension";
+
+/**
+ * Extract the visibility keyword text (e.g., "public", "private") from a
+ * declaration's `modifiers` child, or return null when no modifier is present.
+ */
+function extractVisibility(declNode: TreeSitterNode): string | null {
+  const modifiers = findChild(declNode, "modifiers");
+  if (!modifiers) return null;
+  const visibility = findChild(modifiers, "visibility_modifier");
+  if (!visibility) return null;
+  return visibility.text;
+}
+
+function isExported(declNode: TreeSitterNode): boolean {
+  const visibility = extractVisibility(declNode);
+  return visibility !== null && EXPORTED_VISIBILITIES.has(visibility);
+}
+
+/**
+ * Extract the parameter name from a Swift `parameter` node.
+ *
+ * Swift parameters can take several forms:
+ * - `name: Type`            → internal name = "name"
+ * - `_ name: Type`          → internal name = "name" (no external label)
+ * - `label name: Type`      → internal name = "name" (external label = "label")
+ *
+ * The internal name is what's used inside the function body, so that's what
+ * we return. It is always the last `simple_identifier` that appears before
+ * the `:` separator.
+ */
+function extractParamName(paramNode: TreeSitterNode): string | null {
+  let lastBeforeColon: string | null = null;
+  for (let i = 0; i < paramNode.childCount; i++) {
+    const child = paramNode.child(i);
+    if (!child) continue;
+    if (child.type === ":") break;
+    if (child.type === "simple_identifier") {
+      lastBeforeColon = child.text;
+    }
+  }
+  return lastBeforeColon;
+}
+
+function extractParams(declNode: TreeSitterNode): string[] {
+  const params: string[] = [];
+  for (const param of findChildren(declNode, "parameter")) {
+    const name = extractParamName(param);
+    if (name) params.push(name);
+  }
+  return params;
+}
+
+/**
+ * Extract the return type text from a `function_declaration` by finding the
+ * `->` token and taking the next named child. Returns undefined for `Void`
+ * functions and initializers (which never have a return arrow).
+ */
+function extractReturnType(declNode: TreeSitterNode): string | undefined {
+  for (let i = 0; i < declNode.childCount - 1; i++) {
+    const child = declNode.child(i);
+    if (child && child.type === "->") {
+      // Find the next non-anonymous child, which is the return type node
+      for (let j = i + 1; j < declNode.childCount; j++) {
+        const next = declNode.child(j);
+        if (next && next.isNamed) return next.text;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Extract the function's own `simple_identifier` name. This is the first
+ * `simple_identifier` child (the one immediately following `func`); later
+ * `simple_identifier`s belong to type parameters or the return type.
+ */
+function extractFunctionName(declNode: TreeSitterNode): string | null {
+  for (let i = 0; i < declNode.childCount; i++) {
+    const child = declNode.child(i);
+    if (child && child.type === "simple_identifier") return child.text;
+  }
+  return null;
+}
+
+/**
+ * Resolve the user-facing type name for a `class_declaration` node, handling
+ * the fact that `extension`s use a `user_type` child while named types use a
+ * bare `type_identifier`.
+ */
+function extractTypeName(declNode: TreeSitterNode): string | null {
+  for (let i = 0; i < declNode.childCount; i++) {
+    const child = declNode.child(i);
+    if (!child) continue;
+    if (child.type === "type_identifier") return child.text;
+    if (child.type === "user_type") {
+      const inner = findChild(child, "type_identifier");
+      if (inner) return inner.text;
+      return child.text.trim();
+    }
+  }
+  return null;
+}
+
+function getSwiftTypeKind(declNode: TreeSitterNode): SwiftTypeKind {
+  // declaration_kind is the keyword token (class/struct/enum/actor/extension)
+  for (let i = 0; i < declNode.childCount; i++) {
+    const child = declNode.child(i);
+    if (!child) continue;
+    if (
+      child.type === "class" ||
+      child.type === "struct" ||
+      child.type === "enum" ||
+      child.type === "actor" ||
+      child.type === "extension"
+    ) {
+      return child.type as SwiftTypeKind;
+    }
+  }
+  // Fallback — should never hit because the grammar guarantees one of these
+  return "class";
+}
+
+/**
+ * Swift extractor for tree-sitter structural analysis and call graph extraction.
+ *
+ * Maps Swift's many type-like declarations (class, struct, enum, actor,
+ * extension, protocol) to the project's shared `StructuralAnalysis.classes`
+ * array. Extension methods on a type declared in the same file are merged
+ * onto the existing entry rather than creating a duplicate.
+ */
+export class SwiftExtractor implements LanguageExtractor {
+  readonly languageIds = ["swift"];
+
+  extractStructure(rootNode: TreeSitterNode): StructuralAnalysis {
+    const functions: StructuralAnalysis["functions"] = [];
+    const classes: StructuralAnalysis["classes"] = [];
+    const imports: StructuralAnalysis["imports"] = [];
+    const exports: StructuralAnalysis["exports"] = [];
+
+    // Index of classes by name so extensions can merge into the existing entry
+    const classByName = new Map<string, StructuralAnalysis["classes"][number]>();
+
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const node = rootNode.child(i);
+      if (!node) continue;
+
+      switch (node.type) {
+        case "function_declaration":
+          this.extractTopLevelFunction(node, functions, exports);
+          break;
+
+        case "class_declaration":
+          this.extractClassLike(node, classes, classByName, functions, exports);
+          break;
+
+        case "protocol_declaration":
+          this.extractProtocol(node, classes, classByName, exports);
+          break;
+
+        case "import_declaration":
+          this.extractImport(node, imports);
+          break;
+      }
+    }
+
+    return { functions, classes, imports, exports };
+  }
+
+  extractCallGraph(rootNode: TreeSitterNode): CallGraphEntry[] {
+    const entries: CallGraphEntry[] = [];
+    const functionStack: string[] = [];
+
+    const walk = (node: TreeSitterNode) => {
+      let pushed = false;
+
+      // Track entering function-bearing declarations so calls inside are
+      // attributed to the enclosing function name.
+      if (
+        node.type === "function_declaration" ||
+        node.type === "protocol_function_declaration"
+      ) {
+        const name = extractFunctionName(node);
+        if (name) {
+          functionStack.push(name);
+          pushed = true;
+        }
+      } else if (node.type === "init_declaration") {
+        functionStack.push("init");
+        pushed = true;
+      }
+
+      if (node.type === "call_expression" && functionStack.length > 0) {
+        const callee = this.extractCalleeName(node);
+        if (callee) {
+          entries.push({
+            caller: functionStack[functionStack.length - 1],
+            callee,
+            lineNumber: node.startPosition.row + 1,
+          });
+        }
+      }
+
+      for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i);
+        if (child) walk(child);
+      }
+
+      if (pushed) functionStack.pop();
+    };
+
+    walk(rootNode);
+    return entries;
+  }
+
+  // ---- Top-level helpers ----
+
+  private extractTopLevelFunction(
+    declNode: TreeSitterNode,
+    functions: StructuralAnalysis["functions"],
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    const fn = this.buildFunctionEntry(declNode);
+    if (!fn) return;
+    functions.push(fn);
+    if (isExported(declNode)) {
+      exports.push({ name: fn.name, lineNumber: fn.lineRange[0] });
+    }
+  }
+
+  private buildFunctionEntry(
+    declNode: TreeSitterNode,
+  ): StructuralAnalysis["functions"][number] | null {
+    const name = extractFunctionName(declNode);
+    if (!name) return null;
+    return {
+      name,
+      lineRange: [
+        declNode.startPosition.row + 1,
+        declNode.endPosition.row + 1,
+      ],
+      params: extractParams(declNode),
+      returnType: extractReturnType(declNode),
+    };
+  }
+
+  private extractClassLike(
+    declNode: TreeSitterNode,
+    classes: StructuralAnalysis["classes"],
+    classByName: Map<string, StructuralAnalysis["classes"][number]>,
+    functions: StructuralAnalysis["functions"],
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    const kind = getSwiftTypeKind(declNode);
+    const name = extractTypeName(declNode);
+    if (!name) return;
+
+    const body = findChild(declNode, "class_body") ?? findChild(declNode, "enum_class_body");
+    const methods: string[] = [];
+    const properties: string[] = [];
+
+    if (body) {
+      this.collectBodyMembers(body, methods, properties, functions, exports);
+    }
+
+    if (kind === "extension") {
+      // Merge into existing entry if the extended type was declared earlier
+      // in the same file; otherwise create a synthetic entry.
+      const existing = classByName.get(name);
+      if (existing) {
+        existing.methods.push(...methods);
+        existing.properties.push(...properties);
+        // Extension methods exported by the extended type's visibility — but
+        // explicit `public` modifiers on the extension's members are already
+        // captured in `collectBodyMembers`.
+        return;
+      }
+    }
+
+    const entry = {
+      name,
+      lineRange: [
+        declNode.startPosition.row + 1,
+        declNode.endPosition.row + 1,
+      ] as [number, number],
+      methods,
+      properties,
+    };
+    classes.push(entry);
+    classByName.set(name, entry);
+
+    if (isExported(declNode)) {
+      exports.push({ name, lineNumber: entry.lineRange[0] });
+    }
+  }
+
+  private extractProtocol(
+    declNode: TreeSitterNode,
+    classes: StructuralAnalysis["classes"],
+    classByName: Map<string, StructuralAnalysis["classes"][number]>,
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    const name = extractTypeName(declNode);
+    if (!name) return;
+
+    const body = findChild(declNode, "protocol_body");
+    const methods: string[] = [];
+    const properties: string[] = [];
+
+    if (body) {
+      // Protocol method requirements live in `protocol_function_declaration`;
+      // property requirements live in `protocol_property_declaration`.
+      for (const fn of findChildren(body, "protocol_function_declaration")) {
+        const fnName = extractFunctionName(fn);
+        if (fnName) methods.push(fnName);
+      }
+      for (const prop of findChildren(body, "protocol_property_declaration")) {
+        const propName = this.extractPropertyName(prop);
+        if (propName) properties.push(propName);
+      }
+    }
+
+    const entry = {
+      name,
+      lineRange: [
+        declNode.startPosition.row + 1,
+        declNode.endPosition.row + 1,
+      ] as [number, number],
+      methods,
+      properties,
+    };
+    classes.push(entry);
+    classByName.set(name, entry);
+
+    if (isExported(declNode)) {
+      exports.push({ name, lineNumber: entry.lineRange[0] });
+    }
+  }
+
+  private collectBodyMembers(
+    body: TreeSitterNode,
+    methods: string[],
+    properties: string[],
+    functions: StructuralAnalysis["functions"],
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    for (let i = 0; i < body.childCount; i++) {
+      const member = body.child(i);
+      if (!member) continue;
+
+      if (member.type === "function_declaration") {
+        const fn = this.buildFunctionEntry(member);
+        if (fn) {
+          functions.push(fn);
+          methods.push(fn.name);
+          if (isExported(member)) {
+            exports.push({ name: fn.name, lineNumber: fn.lineRange[0] });
+          }
+        }
+      } else if (member.type === "init_declaration") {
+        // Swift initializers don't have a `simple_identifier` name; record as "init"
+        methods.push("init");
+        functions.push({
+          name: "init",
+          lineRange: [
+            member.startPosition.row + 1,
+            member.endPosition.row + 1,
+          ],
+          params: extractParams(member),
+          returnType: undefined,
+        });
+        if (isExported(member)) {
+          exports.push({
+            name: "init",
+            lineNumber: member.startPosition.row + 1,
+          });
+        }
+      } else if (member.type === "property_declaration") {
+        const name = this.extractPropertyName(member);
+        if (name) properties.push(name);
+        if (name && isExported(member)) {
+          exports.push({
+            name,
+            lineNumber: member.startPosition.row + 1,
+          });
+        }
+      } else if (member.type === "enum_entry") {
+        // Each `case` in an enum can declare multiple comma-separated cases;
+        // we record the simple identifier for each.
+        for (const id of findChildren(member, "simple_identifier")) {
+          properties.push(id.text);
+        }
+      }
+    }
+  }
+
+  private extractPropertyName(propNode: TreeSitterNode): string | null {
+    // property_declaration -> pattern -> simple_identifier (bound_identifier field)
+    const pattern = findChild(propNode, "pattern");
+    if (!pattern) return null;
+    const id = findChild(pattern, "simple_identifier");
+    return id ? id.text : null;
+  }
+
+  private extractImport(
+    declNode: TreeSitterNode,
+    imports: StructuralAnalysis["imports"],
+  ): void {
+    // The module path lives in the `identifier` child; e.g. for
+    // `import struct Combine.AnyPublisher` it contains both "Combine" and "AnyPublisher".
+    const identifier = findChild(declNode, "identifier");
+    if (!identifier) return;
+
+    const parts: string[] = [];
+    for (const id of findChildren(identifier, "simple_identifier")) {
+      parts.push(id.text);
+    }
+    if (parts.length === 0) return;
+
+    const source = parts.join(".");
+    const specifier = parts[parts.length - 1];
+    imports.push({
+      source,
+      specifiers: [specifier],
+      lineNumber: declNode.startPosition.row + 1,
+    });
+  }
+
+  /**
+   * Extract the callee name from a `call_expression`. Swift call expressions
+   * can take two shapes:
+   * - `foo(...)`           → first child is `simple_identifier "foo"`
+   * - `target.method(...)` → first child is `navigation_expression`; the
+   *                          method name is the trailing `navigation_suffix`'s
+   *                          `simple_identifier`.
+   */
+  private extractCalleeName(callNode: TreeSitterNode): string | null {
+    const first = callNode.child(0);
+    if (!first) return null;
+
+    if (first.type === "simple_identifier") return first.text;
+
+    if (first.type === "navigation_expression") {
+      const suffix = findChild(first, "navigation_suffix");
+      if (suffix) {
+        const id = findChild(suffix, "simple_identifier");
+        if (id) return id.text;
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Swift tree-sitter extractor so `/understand` produces structural analysis (functions, classes, structs, enums, protocols, actors, imports, exports, call graph) for `.swift` files — addressing the Swift portion of #226.

`swiftConfig` already existed as a stub with no `treeSitter` field, which is exactly why iOS repositories (#226) currently produce no edges between Swift files. This PR adds the `treeSitter` field and the extractor; the existing plugin loader picks it up unchanged.

## Why `@repomix/tree-sitter-wasms`

The project's plugin loads grammars via `require.resolve("${pkg}/${file}.wasm")` (web-tree-sitter). No `tree-sitter-swift*` npm package ships a usable `.wasm` for this loader:

| Package | Ships `.wasm`? | Works with `web-tree-sitter@^0.26.6`? |
|---|---|---|
| `tree-sitter-swift` (official) | ❌ | n/a |
| `@sengac/tree-sitter-swift` | ❌ | n/a |
| `tree-sitter-wasms@0.1.13` | ✅ | ❌ (`getDylinkMetadata` error — older ABI) |
| **`@repomix/tree-sitter-wasms@0.1.17`** | ✅ | ✅ |

`@repomix/tree-sitter-wasms` is Unlicense (public domain), maintained by the `repomix` author, and bundles WASM grammars for several other languages this project doesn't yet handle (Dart, Solidity, Vue, …) — follow-ups to add those only need an extractor, no dependency churn.

## What's in the extractor

- **Functions**: top-level + methods + initializers. Params (handles `_ name:`, `label name:`, and plain `name:`), return type, line range.
- **Type-like declarations**: `class`, `struct`, `enum`, `actor`, `extension`. tree-sitter-swift overloads `class_declaration` for all of them with a `declaration_kind` field — the extractor resolves the kind and the name correctly for each.
- **Protocols**: `protocol_declaration` with `protocol_function_declaration` / `protocol_property_declaration` requirements.
- **Extensions**: methods are merged into the extended type's existing entry if that type was declared earlier in the same file (avoids duplicate class nodes). For extensions on imported types (e.g. `extension String`) a synthetic entry is created.
- **Imports**: simple (`import Foundation`), kind-qualified (`import struct Combine.AnyPublisher`), and attributed (`@testable import MyModule`).
- **Visibility / exports**: `public` and `open` → exported. `internal` (default), `fileprivate`, `private` → not exported.
- **Call graph**: top-level calls and method calls (resolves `x.foo()` to `foo`), attributed to the enclosing function name (or `init` for initializers).

## Scope

This PR addresses the **Swift** portion of #226. Objective-C and Dart (also requested in that issue) are intentional follow-ups — the WASM grammars are already bundled, so each follow-up is just `<lang>-extractor.ts` + tests.

## Verification

- ✅ `pnpm lint` clean
- ✅ `pnpm --filter @understand-anything/core build` clean
- ✅ `pnpm --filter @understand-anything/skill build` clean
- ✅ `pnpm --filter @understand-anything/core test`: **703/703** passing (+33 new Swift tests, matching the bar set by `go-extractor.test.ts`)
- ✅ `pnpm test`: 196/196 passing (no regressions)
- ✅ End-to-end smoke test against a real Swift file with class + protocol + extension + imports — structure, exports, and call graph all populated correctly via the actual plugin pipeline.

## Test plan

- [ ] Reviewer runs `pnpm install` to pull the new dep
- [ ] `pnpm --filter @understand-anything/core test` passes (703 tests, includes 33 new Swift cases)
- [ ] `pnpm lint` clean
- [ ] Spot check: run `/understand --full` against an iOS/Swift project and confirm relationship edges now appear between `.swift` files (the symptom reported in #226)

Refs #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)