### PR TITLE
fix(dashboard): make port configurable + fail loud on collision (#234)

### DIFF
--- a/understand-anything-plugin/packages/dashboard/vite.config.ts
+++ b/understand-anything-plugin/packages/dashboard/vite.config.ts
@@ -184,9 +184,27 @@ export default defineConfig({
 
   // FIX 1 — bind only to localhost, not 0.0.0.0
   // This blocks access from any other device on the same LAN / WiFi.
+  //
+  // FIX 2 (#234) — port is configurable via UNDERSTAND_DASHBOARD_PORT and
+  // we set `strictPort: true`. The combination matters:
+  //
+  //   * Without strictPort, Vite silently falls back to the next free port
+  //     when 5173 is taken. The skill prints the *intended* token URL, but
+  //     the user opens it and gets whatever other app already owns 5173 —
+  //     usually some unrelated Vite project. The token endpoint isn't on
+  //     that server, so the dashboard fails to load with no clear error.
+  //
+  //   * strictPort makes the collision a hard failure (`Port 5173 is in use`)
+  //     instead of a silent foot-gun. The user then knows to either kill
+  //     the other process or rerun with `UNDERSTAND_DASHBOARD_PORT=5180`.
+  //
+  // We still default to 5173 so existing flows keep working unchanged when
+  // the port is free. Env-var override matches the existing GRAPH_DIR
+  // pattern in this skill.
   server: {
     host: "127.0.0.1",
-    port: 5173,
+    port: Number(process.env.UNDERSTAND_DASHBOARD_PORT) || 5173,
+    strictPort: true,
     open: `/?token=${ACCESS_TOKEN}`,
   },
 

--- a/understand-anything-plugin/skills/understand-dashboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-dashboard/SKILL.md
@@ -101,5 +101,15 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
 ## Notes
 
 - The dashboard auto-opens in the default browser via `--open`
-- If port 5173 is already in use, Vite will pick the next available port
+- The dashboard binds to port **5173** by default. If that port is taken
+  (very common — every other Vite project defaults to it too), the dev
+  server will **fail loudly** with `Port 5173 is already in use` instead
+  of silently falling back to the next free port and serving the wrong
+  app at the URL you just printed.
+
+  Override the port via the `UNDERSTAND_DASHBOARD_PORT` environment
+  variable, e.g.:
+  ```bash
+  UNDERSTAND_DASHBOARD_PORT=5180 GRAPH_DIR=<project-dir> npx vite --host 127.0.0.1
+  ```
 - The `GRAPH_DIR` environment variable tells the dashboard where to find the knowledge graph


### PR DESCRIPTION
## Summary

Closes #234 — the silent-failure foot-gun where the dashboard prints \`Dashboard URL: http://127.0.0.1:5173/?token=...\`, the user opens the URL, and lands on whatever *other* Vite project already owned 5173 (almost every Vite project defaults to 5173).

## The fix

Two-line behavioral change in \`packages/dashboard/vite.config.ts\`:

1. \`server.port\` now reads \`process.env.UNDERSTAND_DASHBOARD_PORT\` (default 5173). Matches the existing \`GRAPH_DIR\` env-var pattern the skill already uses.

2. \`server.strictPort: true\` so a collision is a hard failure (\"Port 5173 is already in use\") instead of Vite silently picking the next free port and serving the wrong app at the URL the skill just printed.

The combination is what matters — the issue author called out exactly this pair as their preferred fix in the original report.

## Behavior diff

| Scenario | Before | After |
|---|---|---|
| 5173 free | Binds 5173, prints token URL | Same |
| 5173 taken | Silently binds next free port; printed URL points at the *wrong* app | Hard fail with \`Port 5173 is in use\`, user knows immediately |
| 5173 taken + \`UNDERSTAND_DASHBOARD_PORT=5180\` | Same broken behavior (env var ignored) | Binds 5180, prints correct token URL |

## Skill docs updated

Updated \`skills/understand-dashboard/SKILL.md\` Notes section — the old line *\"If port 5173 is already in use, Vite will pick the next available port\"* described the behavior that *caused* the bug. New text documents the env-var override and the hard-fail.

## Verification

- \`pnpm lint\` ✅
- \`pnpm --filter @understand-anything/dashboard build\` ✅
- \`pnpm test\` — 196/196 ✅
- Manual smoke test: started a separate Vite dev server on 5173, then ran the dashboard — got an immediate \`Port 5173 is already in use\` error (previously it would silently fall back to 5174 and the printed URL would lie). Re-ran with \`UNDERSTAND_DASHBOARD_PORT=5180\` and got the correct token URL.

## Versioning

N/A — bug fix only, no API change. (Maintainer can bump on merge if they want a patch release.)

Closes #234