### PR TITLE
feat(core): per-function cyclomatic complexity for TS/Python/Go (#273)

### DIFF
--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cyclomatic-complexity.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cyclomatic-complexity.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import type { TreeSitterNode } from "../types.js";
+import {
+  computeCyclomaticComplexity,
+  branchTypeMatcher,
+} from "../base-extractor.js";
+
+/**
+ * Minimal in-memory TreeSitterNode-shaped fixture so we can unit-test the
+ * cyclomatic-complexity helper without standing up an actual tree-sitter
+ * grammar. We only need `.type`, `.child(i)`, and `.childCount` —
+ * `computeCyclomaticComplexity` doesn't touch position/text/parent fields.
+ */
+function node(type: string, ...children: TreeSitterNode[]): TreeSitterNode {
+  return {
+    type,
+    childCount: children.length,
+    child(i: number) {
+      return children[i] ?? null;
+    },
+  } as unknown as TreeSitterNode;
+}
+
+describe("computeCyclomaticComplexity", () => {
+  const isBranch = branchTypeMatcher(
+    new Set(["if_statement", "for_statement", "boolean_operator"]),
+  );
+
+  it("returns 1 for a function with no branches (single linear path)", () => {
+    // McCabe baseline: a function with no decision points has complexity 1.
+    const root = node("function_body", node("return_statement"));
+    expect(computeCyclomaticComplexity(root, isBranch)).toBe(1);
+  });
+
+  it("adds 1 for each branch node found in the subtree", () => {
+    const root = node(
+      "function_body",
+      node("if_statement"),
+      node("for_statement"),
+    );
+    expect(computeCyclomaticComplexity(root, isBranch)).toBe(3);
+  });
+
+  it("counts branches at any depth, not just direct children", () => {
+    // if { if { ... } } — two decisions even though they're nested.
+    const root = node(
+      "function_body",
+      node("if_statement", node("block", node("if_statement"))),
+    );
+    expect(computeCyclomaticComplexity(root, isBranch)).toBe(3);
+  });
+
+  it("counts boolean operators (`and`/`or`) — McCabe-strict", () => {
+    // if (a and b) → if_statement contains a boolean_operator: complexity = 3.
+    const root = node(
+      "function_body",
+      node("if_statement", node("boolean_operator")),
+    );
+    expect(computeCyclomaticComplexity(root, isBranch)).toBe(3);
+  });
+
+  it("does not count nodes outside the configured branch type set", () => {
+    const root = node(
+      "function_body",
+      node("call_expression"),
+      node("variable_declaration"),
+      node("return_statement"),
+    );
+    expect(computeCyclomaticComplexity(root, isBranch)).toBe(1);
+  });
+
+  it("supports a predicate that inspects child nodes (for binary_expression operators)", () => {
+    // Mirror the TypeScript case: `binary_expression` only counts when one of
+    // its children is `&&` / `||` / `??`. Arithmetic `+` should not count.
+    const shortCircuit = new Set(["&&", "||"]);
+    const isTypescriptBranchLike = (n: TreeSitterNode): boolean => {
+      if (n.type === "if_statement") return true;
+      if (n.type === "binary_expression") {
+        for (let i = 0; i < n.childCount; i++) {
+          const child = n.child(i);
+          if (child && shortCircuit.has(child.type)) return true;
+        }
+      }
+      return false;
+    };
+
+    // (a && b) under an if — should count: if=1, && via binary_expression=1, base=1 → 3
+    const root = node(
+      "function_body",
+      node(
+        "if_statement",
+        node(
+          "binary_expression",
+          node("identifier"),
+          node("&&"),
+          node("identifier"),
+        ),
+      ),
+    );
+    expect(computeCyclomaticComplexity(root, isTypescriptBranchLike)).toBe(3);
+
+    // (a + b) — should NOT count the binary_expression. base=1.
+    const arithmeticOnly = node(
+      "function_body",
+      node(
+        "binary_expression",
+        node("identifier"),
+        node("+"),
+        node("identifier"),
+      ),
+    );
+    expect(computeCyclomaticComplexity(arithmeticOnly, isTypescriptBranchLike)).toBe(1);
+  });
+});

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts
@@ -596,4 +596,87 @@ func helper(x int) string {
       parser.delete();
     });
   });
+
+  describe("cyclomaticComplexity", () => {
+    it("returns 1 for a straight-line function", () => {
+      const { root, tree, parser } = parse(`
+package main
+
+func add(a, b int) int {
+  return a + b
+}`);
+      const result = extractor.extractStructure(root);
+      expect(result.functions[0].cyclomaticComplexity).toBe(1);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("counts if + for + select branches", () => {
+      const { root, tree, parser } = parse(`
+package main
+
+func decide(x int) int {
+  if x > 0 {       // +1
+    for i := 0; i < x; i++ {  // +1
+      if i == 5 { return i }  // +1
+    }
+  }
+  return 0
+}`);
+      const result = extractor.extractStructure(root);
+      // base 1 + if + for + nested if = 4
+      expect(result.functions[0].cyclomaticComplexity).toBe(4);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("counts short-circuit && / || operators", () => {
+      const { root, tree, parser } = parse(`
+package main
+
+func gate(a, b, c bool) bool {
+  if a && b || c {  // if + && + ||  = +3
+    return true
+  }
+  return false
+}`);
+      const result = extractor.extractStructure(root);
+      // base 1 + if + && + || = 4
+      expect(result.functions[0].cyclomaticComplexity).toBe(4);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("ignores arithmetic binary expressions", () => {
+      const { root, tree, parser } = parse(`
+package main
+
+func compute(a, b int) int {
+  return a + b * 2 - 1  // arithmetic only — no branches
+}`);
+      const result = extractor.extractStructure(root);
+      expect(result.functions[0].cyclomaticComplexity).toBe(1);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("populates complexity on methods, not just top-level functions", () => {
+      const { root, tree, parser } = parse(`
+package main
+
+type Server struct{}
+
+func (s *Server) Handle(req string) error {
+  if req == "" {        // +1
+    return nil
+  }
+  return nil
+}`);
+      const result = extractor.extractStructure(root);
+      const handle = result.functions.find((f) => f.name === "Handle");
+      expect(handle?.cyclomaticComplexity).toBe(2);
+      tree.delete();
+      parser.delete();
+    });
+  });
 });

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts
@@ -50,3 +50,45 @@ export function hasChildOfType(node: TreeSitterNode, type: string): boolean {
   }
   return false;
 }
+
+/**
+ * Compute McCabe-style cyclomatic complexity for a syntax subtree.
+ *
+ * Counts the number of linearly-independent paths through the code by
+ * starting at 1 and adding 1 for every "branching" AST node — `if`, `for`,
+ * `while`, `case`, `catch`, ternary, short-circuit boolean operator, etc.
+ * The exact set of node types is language-specific, so the caller supplies
+ * an `isBranch` predicate that knows its grammar's terminology.
+ *
+ * Per the original McCabe definition, short-circuit boolean operators
+ * (`&&`, `||`, `and`, `or`) DO count, because each one introduces an
+ * additional decision point at runtime. Languages where these are exposed
+ * as a dedicated AST node (e.g. tree-sitter-python's `boolean_operator`)
+ * can include the type by name. Languages where they share a `binary_expression`
+ * node with arithmetic operators have to inspect the operator child — which
+ * is why this helper takes a predicate, not just a Set of type names.
+ *
+ * Side-effect-free and O(N) over the subtree; passing the function body
+ * (not the entire file) keeps it cheap even for large source files.
+ */
+export function computeCyclomaticComplexity(
+  node: TreeSitterNode,
+  isBranch: (node: TreeSitterNode) => boolean,
+): number {
+  let count = 1;
+  traverse(node, (n) => {
+    if (isBranch(n)) count++;
+  });
+  return count;
+}
+
+/**
+ * Convenience wrapper: build an `isBranch` predicate from a plain Set of
+ * node type names. The common case for languages whose grammar exposes
+ * branches as distinct node types (Go, Python via `boolean_operator`, etc.).
+ */
+export function branchTypeMatcher(
+  branchTypes: ReadonlySet<string>,
+): (node: TreeSitterNode) => boolean {
+  return (node) => branchTypes.has(node.type);
+}

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts
@@ -1,6 +1,40 @@
 import type { StructuralAnalysis, CallGraphEntry } from "../../types.js";
 import type { LanguageExtractor, TreeSitterNode } from "./types.js";
-import { findChild, findChildren } from "./base-extractor.js";
+import {
+  computeCyclomaticComplexity,
+  findChild,
+  findChildren,
+} from "./base-extractor.js";
+
+/**
+ * AST node types that introduce a decision point in Go. tree-sitter-go
+ * represents short-circuit operators (`&&`, `||`) as `binary_expression`
+ * sharing the type with arithmetic operators, so those are detected by
+ * inspecting the operator child rather than by name.
+ */
+const GO_BRANCH_NODE_TYPES = new Set<string>([
+  "if_statement",
+  "for_statement",
+  "type_switch_statement",
+  "expression_case",
+  "type_case",
+  "default_case",
+  "communication_case", // select statement cases
+  "select_statement",
+]);
+
+const GO_SHORT_CIRCUIT_OPS = new Set<string>(["&&", "||"]);
+
+function isGoBranch(node: TreeSitterNode): boolean {
+  if (GO_BRANCH_NODE_TYPES.has(node.type)) return true;
+  if (node.type === "binary_expression") {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child && GO_SHORT_CIRCUIT_OPS.has(child.type)) return true;
+    }
+  }
+  return false;
+}
 
 /**
  * Extract parameter names from a Go `parameter_list` node.
@@ -203,6 +237,7 @@ export class GoExtractor implements LanguageExtractor {
       ],
       params,
       returnType,
+      cyclomaticComplexity: computeCyclomaticComplexity(node, isGoBranch),
     });
 
     if (isExported(nameNode.text)) {
@@ -234,6 +269,7 @@ export class GoExtractor implements LanguageExtractor {
       ],
       params,
       returnType,
+      cyclomaticComplexity: computeCyclomaticComplexity(node, isGoBranch),
     });
 
     // Track receiver type for struct association

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts
@@ -1,6 +1,30 @@
 import type { StructuralAnalysis, CallGraphEntry } from "../../types.js";
 import type { LanguageExtractor, TreeSitterNode } from "./types.js";
-import { findChild, findChildren } from "./base-extractor.js";
+import {
+  branchTypeMatcher,
+  computeCyclomaticComplexity,
+  findChild,
+  findChildren,
+} from "./base-extractor.js";
+
+/**
+ * AST node types that introduce a decision point in Python. Includes
+ * `boolean_operator` for `and`/`or` (which tree-sitter-python exposes as a
+ * dedicated node type, unlike TypeScript) so short-circuit `if a and b:`
+ * counts the same as `if a: if b:`.
+ */
+const PYTHON_BRANCH_NODE_TYPES = new Set<string>([
+  "if_statement",
+  "elif_clause",
+  "while_statement",
+  "for_statement",
+  "except_clause",
+  "conditional_expression", // `a if cond else b`
+  "case_clause",
+  "boolean_operator",
+]);
+
+const isPythonBranch = branchTypeMatcher(PYTHON_BRANCH_NODE_TYPES);
 
 /**
  * Extract parameter names from a Python `parameters` node.
@@ -209,6 +233,7 @@ export class PythonExtractor implements LanguageExtractor {
       ],
       params,
       returnType,
+      cyclomaticComplexity: computeCyclomaticComplexity(node, isPythonBranch),
     });
   }
 

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts
@@ -1,6 +1,46 @@
 import type { StructuralAnalysis, CallGraphEntry } from "../../types.js";
 import type { LanguageExtractor, TreeSitterNode } from "./types.js";
-import { getStringValue } from "./base-extractor.js";
+import { computeCyclomaticComplexity, getStringValue } from "./base-extractor.js";
+
+/**
+ * AST node types that introduce an additional decision point in TypeScript /
+ * JavaScript / TSX / JSX source. Used to compute McCabe cyclomatic
+ * complexity per function.
+ *
+ * Short-circuit operators (`&&`, `||`, `??`) are not in this set because
+ * tree-sitter-typescript represents them as `binary_expression` nodes
+ * sharing the same type with arithmetic operators — we detect those in
+ * `isTypeScriptBranch` below by inspecting the operator child.
+ */
+const TS_BRANCH_NODE_TYPES = new Set<string>([
+  "if_statement",
+  "while_statement",
+  "do_statement",
+  "for_statement",
+  "for_in_statement",
+  "for_of_statement",
+  "catch_clause",
+  "ternary_expression",
+  "switch_case",
+  "switch_default",
+]);
+
+/** Short-circuit binary operators that count as McCabe decision points. */
+const TS_SHORT_CIRCUIT_OPS = new Set<string>(["&&", "||", "??"]);
+
+function isTypeScriptBranch(node: TreeSitterNode): boolean {
+  if (TS_BRANCH_NODE_TYPES.has(node.type)) return true;
+  if (node.type === "binary_expression") {
+    // tree-sitter-typescript exposes the operator as a child token whose
+    // type IS the operator text (e.g. "&&"). Look at the second child
+    // (left operand, operator, right operand).
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child && TS_SHORT_CIRCUIT_OPS.has(child.type)) return true;
+    }
+  }
+  return false;
+}
 
 /**
  * Extract parameter names from a formal_parameters node.
@@ -260,6 +300,7 @@ export class TypeScriptExtractor implements LanguageExtractor {
       ],
       params,
       returnType,
+      cyclomaticComplexity: computeCyclomaticComplexity(node, isTypeScriptBranch),
     });
   }
 
@@ -347,6 +388,9 @@ export class TypeScriptExtractor implements LanguageExtractor {
           ],
           params,
           returnType,
+          // For arrow functions / function expressions, complexity is
+          // measured over the function body, not the surrounding declarator.
+          cyclomaticComplexity: computeCyclomaticComplexity(valueNode, isTypeScriptBranch),
         });
       }
     }

--- a/understand-anything-plugin/packages/core/src/types.ts
+++ b/understand-anything-plugin/packages/core/src/types.ts
@@ -167,7 +167,15 @@ export interface ReferenceResolution {
 
 // Plugin interfaces
 export interface StructuralAnalysis {
-  functions: Array<{ name: string; lineRange: [number, number]; params: string[]; returnType?: string }>;
+  /**
+   * `cyclomaticComplexity` is optional and only populated by extractors that
+   * have wired up the per-language branch-node-type list (see
+   * `computeCyclomaticComplexity` in base-extractor.ts). When absent it
+   * means "extractor doesn't compute this yet", not "complexity is 0";
+   * downstream code (graph nodes, dashboard, complexity-based scoring)
+   * must treat the field as `number | undefined`.
+   */
+  functions: Array<{ name: string; lineRange: [number, number]; params: string[]; returnType?: string; cyclomaticComplexity?: number }>;
   classes: Array<{ name: string; lineRange: [number, number]; methods: string[]; properties: string[] }>;
   imports: Array<{ source: string; specifiers: string[]; lineNumber: number }>;
   exports: Array<{ name: string; lineNumber: number; isDefault?: boolean }>;


### PR DESCRIPTION
## Summary

Closes #273 — adds deterministic, AST-derived per-function cyclomatic complexity to TypeScript, Python, and Go extractors. Computed once during structural extraction (no LLM call), exposed as the optional \`StructuralAnalysis.functions[].cyclomaticComplexity?: number\` field.

The existing qualitative \`complexity\` label (\`simple\`/\`moderate\`/\`complex\`) stays — the numeric score complements it rather than replacing it. Human readers keep the quick label; programmatic consumers (refactoring-candidate scoring, dashboard metrics, external tooling) get the deterministic number.

## Design decisions (mapped to the issue's open questions)

| Question | Decision |
|---|---|
| Replace or complement the LLM-assigned \`complexity\`? | **Complement.** Per issue author's stated preference. |
| Count short-circuit \`&&\` / \`\|\|\` / \`and\` / \`or\`? | **Yes — McCabe-strict.** Without this the same logical code scores differently across languages: Python's \`if a and b:\` already exposes \`boolean_operator\` as a dedicated AST node, while TypeScript hides \`&&\` inside a generic \`binary_expression\`. Picking one consistent rule across languages matters more than minimal node-type lists. |
| Function-level only or file-level aggregation? | **Function-level only in this PR.** File-level aggregation needs per-method records, which the schema currently doesn't track. Easy follow-up. |

## What's in here

### Shared helper

\`base-extractor.ts\` gains:

\`\`\`ts
computeCyclomaticComplexity(node, isBranch: (n) => boolean): number
branchTypeMatcher(branchTypes: ReadonlySet<string>): (n) => boolean  // convenience for simple cases
\`\`\`

The predicate (not just a Set of type names) is the key choice — languages like TS/Go that hide short-circuit operators inside generic \`binary_expression\` nodes need to inspect the operator child, which a flat Set can't express.

### Type extension

\`StructuralAnalysis.functions[].cyclomaticComplexity?: number\` — optional so older extractors stay valid. Downstream consumers must treat absence as *\"extractor doesn't compute this yet\"*, not *\"complexity is 0\"*.

### Wired extractors

- **TypeScript / JavaScript / TSX**: top-level functions + arrow-function declarators. Short-circuit \`&&\` \`\|\|\` \`??\` detected by walking \`binary_expression\` operator children.
- **Python**: uses \`boolean_operator\` as a dedicated branch node type (no operator-child inspection needed).
- **Go**: top-level functions + methods. Branch set includes Go-specific shapes (\`type_switch_statement\`, \`select_statement\`, \`expression_case\`, \`type_case\`, \`default_case\`, \`communication_case\`); short-circuit \`&&\` \`\|\|\` via operator-child inspection.

Other 38 extractors are unaffected — they continue to return \`functions[]\` without the field, and downstream code already handles \`undefined\` because the field is optional.

## Tests

- **\`cyclomatic-complexity.test.ts\`** (new, 6 tests): unit-tests the helper over in-memory TreeSitterNode fixtures. No grammar dependency, so these run in every environment. Covers: base case = 1, additive branches, deep nesting, boolean operators counted, non-branch nodes ignored, predicate-with-operator-child works for the binary_expression case.
- **\`go-extractor.test.ts\`** (+5 tests): integration tests through the real tree-sitter Go grammar. Covers straight-line=1, nested if+for+if=4, \`&&\`+\`\|\|\`=4, arithmetic-only=1, methods get complexity too.

## Verification

- \`pnpm lint\` ✅
- \`pnpm --filter @understand-anything/core test\` — 681/681 ✅ (was 670)
- \`pnpm --filter @understand-anything/core build\` ✅
- \`pnpm --filter @understand-anything/skill build\` ✅
- \`pnpm test\` — 196/196 ✅

## Follow-ups (deliberately not in this PR)

- Wire the other 38 extractors (Rust, Java, C#, C++, Swift, Kotlin, Dart, Solidity, …) using the same helper. Mechanical work — each one is +1 branch-type set + 1 line at the \`functions.push\` site.
- Propagate \`cyclomaticComplexity\` to \`GraphNode\` (currently the field is on the structural analysis only) so the dashboard can render it and the refactor-candidate scoring formula from the issue works end-to-end.
- File-level aggregation (max / sum of function complexities).

Refs #273