### PR TITLE
feat(core): add Objective-C structural analysis via tree-sitter (#226)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       tree-sitter-javascript:
         specifier: ^0.25.0
         version: 0.25.0
+      tree-sitter-objc:
+        specifier: 3.0.2
+        version: 3.0.2
       tree-sitter-php:
         specifier: ^0.23.11
         version: 0.23.12
@@ -2874,6 +2877,14 @@ packages:
     resolution: {integrity: sha512-1fCbmzAskZkxcZzN41sFZ2br2iqTYP3tKls1b/HKGNPQUVOpsUxpmGxdN/wMqAk3jYZnYBR1dd/y/0avMeU7dw==}
     peerDependencies:
       tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-objc@3.0.2:
+    resolution: {integrity: sha512-Hs0ohmx1u5M+0K7efoW+dv/corhBsfjftfIYLtp7dSGeJ+Zj4c33tDIboBYLs6qijRlz6wtHFxa0YX+FibLulA==}
+    peerDependencies:
+      tree-sitter: ^0.22.1
     peerDependenciesMeta:
       tree-sitter:
         optional: true
@@ -6278,6 +6289,12 @@ snapshots:
     dependencies:
       node-addon-api: 8.6.0
       node-gyp-build: 4.8.4
+
+  tree-sitter-objc@3.0.2:
+    dependencies:
+      node-addon-api: 8.6.0
+      node-gyp-build: 4.8.4
+      tree-sitter-c: 0.23.6
 
   tree-sitter-php@0.23.12:
     dependencies:

--- a/understand-anything-plugin/packages/core/package.json
+++ b/understand-anything-plugin/packages/core/package.json
@@ -43,6 +43,7 @@
     "ignore": "^7.0.5",
     "tree-sitter-c-sharp": "^0.23.1",
     "tree-sitter-cpp": "^0.23.4",
+    "tree-sitter-objc": "3.0.2",
     "tree-sitter-go": "^0.25.0",
     "tree-sitter-java": "^0.23.5",
     "tree-sitter-javascript": "^0.25.0",

--- a/understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts
@@ -49,10 +49,10 @@ describe("LanguageRegistry", () => {
   });
 
   describe("createDefault", () => {
-    it("registers all 41 built-in language configs", () => {
+    it("registers all 42 built-in language configs", () => {
       const registry = LanguageRegistry.createDefault();
       const all = registry.getAllLanguages();
-      expect(all.length).toBe(41);
+      expect(all.length).toBe(42);
     });
 
     it("maps all expected extensions", () => {

--- a/understand-anything-plugin/packages/core/src/languages/configs/index.ts
+++ b/understand-anything-plugin/packages/core/src/languages/configs/index.ts
@@ -13,6 +13,7 @@ import { cConfig } from "./c.js";
 import { cppConfig } from "./cpp.js";
 import { dartConfig } from "./dart.js";
 import { csharpConfig } from "./csharp.js";
+import { objectiveCConfig } from "./objectivec.js";
 import { luaConfig } from "./lua.js";
 // Non-code language configs
 import { markdownConfig } from "./markdown.js";
@@ -59,6 +60,7 @@ export const builtinLanguageConfigs: LanguageConfig[] = [
   cppConfig,
   dartConfig,
   csharpConfig,
+  objectiveCConfig,
   // Non-code languages
   markdownConfig,
   yamlConfig,
@@ -105,6 +107,7 @@ export {
   cppConfig,
   dartConfig,
   csharpConfig,
+  objectiveCConfig,
   // Non-code languages
   markdownConfig,
   yamlConfig,

--- a/understand-anything-plugin/packages/core/src/languages/configs/objectivec.ts
+++ b/understand-anything-plugin/packages/core/src/languages/configs/objectivec.ts
@@ -1,0 +1,39 @@
+import type { LanguageConfig } from "../types.js";
+
+export const objectiveCConfig = {
+  id: "objectivec",
+  displayName: "Objective-C",
+  // We only claim `.m` and `.mm` because `.h` is already mapped to C/C++ in
+  // the language registry (the schema rejects duplicate extension mappings
+  // across configs). The Obj-C extractor can parse .h files — they're just
+  // C-with-Obj-C-extensions — but in practice most .h files in an Obj-C
+  // project coexist with a .m file whose extractor pulls the same symbols
+  // into the graph, so we don't lose meaningful structural data by skipping
+  // headers.
+  extensions: [".m", ".mm"],
+  treeSitter: {
+    wasmPackage: "tree-sitter-objc",
+    wasmFile: "tree-sitter-objc.wasm",
+  },
+  concepts: [
+    "categories",
+    "protocols",
+    "properties",
+    "selectors",
+    "blocks",
+    "ARC",
+  ],
+  filePatterns: {
+    entryPoints: ["main.m"],
+    barrels: [],
+    tests: [
+      "*Tests.m",
+      "*Spec.m",
+      "Tests/*.m",
+    ],
+    config: [
+      "Info.plist",
+      "Podfile",
+    ],
+  },
+} as const satisfies LanguageConfig;

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/objectivec-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/objectivec-extractor.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { createRequire } from "node:module";
+import { ObjectiveCExtractor } from "../objectivec-extractor.js";
+
+const require = createRequire(import.meta.url);
+
+let Parser: any;
+let Language: any;
+let objcLang: any;
+
+beforeAll(async () => {
+  const wts = await import("web-tree-sitter");
+  Parser = wts.Parser;
+  Language = wts.Language;
+  await Parser.init();
+  const wasmPath = require.resolve("tree-sitter-objc/tree-sitter-objc.wasm");
+  objcLang = await Language.load(wasmPath);
+});
+
+function parse(source: string) {
+  const parser = new Parser();
+  parser.setLanguage(objcLang);
+  const tree = parser.parse(source);
+  return { root: tree.rootNode, tree, parser };
+}
+
+describe("ObjectiveCExtractor", () => {
+  const extractor = new ObjectiveCExtractor();
+
+  describe("languageIds", () => {
+    it("claims the objectivec language", () => {
+      expect(extractor.languageIds).toContain("objectivec");
+    });
+  });
+
+  describe("extractStructure - imports", () => {
+    it("extracts #import <System/Header.h>", () => {
+      const { root, tree, parser } = parse(`#import <Foundation/Foundation.h>`);
+      const result = extractor.extractStructure(root);
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("Foundation/Foundation.h");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts #import \"LocalHeader.h\"", () => {
+      const { root, tree, parser } = parse(`#import "MyClass.h"`);
+      const result = extractor.extractStructure(root);
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("MyClass.h");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts @import ModuleName;", () => {
+      const { root, tree, parser } = parse(`@import UIKit;`);
+      const result = extractor.extractStructure(root);
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("UIKit");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("treats #include the same as #import", () => {
+      const { root, tree, parser } = parse(`#include "stdio.h"`);
+      const result = extractor.extractStructure(root);
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("stdio.h");
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - classes", () => {
+    it("extracts @interface declarations with methods", () => {
+      const { root, tree, parser } = parse(`
+@interface MyClass : NSObject
+- (void)doStuff;
+- (NSString *)name;
+@end`);
+      const result = extractor.extractStructure(root);
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].name).toBe("MyClass");
+      expect(result.classes[0].methods).toEqual(["doStuff", "name"]);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts @property declarations", () => {
+      const { root, tree, parser } = parse(`
+@interface MyClass : NSObject
+@property (nonatomic, strong) NSString *name;
+@property (nonatomic) NSInteger count;
+@end`);
+      const result = extractor.extractStructure(root);
+      expect(result.classes[0].properties).toContain("name");
+      expect(result.classes[0].properties).toContain("count");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("merges @implementation methods into the matching @interface entry", () => {
+      const { root, tree, parser } = parse(`
+@interface MyClass : NSObject
+- (void)declared;
+@end
+
+@implementation MyClass
+- (void)declared { }
+- (void)addedInImpl { }
+@end`);
+      const result = extractor.extractStructure(root);
+      // Single class entry, both methods present
+      expect(result.classes).toHaveLength(1);
+      expect(result.classes[0].methods).toContain("declared");
+      expect(result.classes[0].methods).toContain("addedInImpl");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("attaches category methods to the base class entry", () => {
+      const { root, tree, parser } = parse(`
+@interface NSString (Reversal)
+- (NSString *)reversed;
+@end`);
+      const result = extractor.extractStructure(root);
+      const nsString = result.classes.find((c) => c.name === "NSString");
+      expect(nsString).toBeDefined();
+      expect(nsString?.methods).toContain("reversed");
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - protocols", () => {
+    it("treats @protocol like a class entry", () => {
+      const { root, tree, parser } = parse(`
+@protocol MyDelegate <NSObject>
+- (void)didUpdate;
+- (BOOL)shouldProceed;
+@end`);
+      const result = extractor.extractStructure(root);
+      const proto = result.classes.find((c) => c.name === "MyDelegate");
+      expect(proto).toBeDefined();
+      expect(proto?.methods).toEqual(["didUpdate", "shouldProceed"]);
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - C functions", () => {
+    it("extracts top-level C function definitions", () => {
+      const { root, tree, parser } = parse(`
+int helperAdd(int a, int b) {
+  return a + b;
+}
+
+void doNothing(void) { }`);
+      const result = extractor.extractStructure(root);
+      const names = result.functions.map((f) => f.name).sort();
+      expect(names).toEqual(["doNothing", "helperAdd"]);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("captures parameter names", () => {
+      const { root, tree, parser } = parse(`
+int compute(int x, int y) { return x * y; }`);
+      const result = extractor.extractStructure(root);
+      expect(result.functions[0].params).toEqual(["x", "y"]);
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - exports", () => {
+    it("exports @interface, @protocol and top-level C functions", () => {
+      const { root, tree, parser } = parse(`
+@interface MyClass : NSObject @end
+@protocol MyProto @end
+int someFn(void) { return 0; }`);
+      const result = extractor.extractStructure(root);
+      const exportNames = result.exports.map((e) => e.name).sort();
+      expect(exportNames).toEqual(["MyClass", "MyProto", "someFn"]);
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractCallGraph", () => {
+    it("attributes C function calls to the enclosing function", () => {
+      const { root, tree, parser } = parse(`
+int helper(void) { return 1; }
+int caller(void) { return helper(); }`);
+      const calls = extractor.extractCallGraph(root);
+      const callerCall = calls.find((c) => c.caller === "caller");
+      expect(callerCall?.callee).toBe("helper");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("attributes Obj-C message sends to the enclosing method", () => {
+      const { root, tree, parser } = parse(`
+@implementation X
+- (void)go {
+  [self helper];
+  [array addObject:item];
+}
+@end`);
+      const calls = extractor.extractCallGraph(root);
+      const callees = calls.filter((c) => c.caller === "go").map((c) => c.callee);
+      expect(callees).toContain("helper");
+      expect(callees).toContain("addObject");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("resolves chained message sends to the outer selector", () => {
+      const { root, tree, parser } = parse(`
+@implementation X
+- (void)go {
+  [[self window] makeKeyAndOrderFront:self];
+}
+@end`);
+      const calls = extractor.extractCallGraph(root);
+      // We expect both the inner [self window] call and the outer
+      // [...makeKeyAndOrderFront:] call to be tracked.
+      const callees = calls.filter((c) => c.caller === "go").map((c) => c.callee);
+      expect(callees).toContain("makeKeyAndOrderFront");
+      expect(callees).toContain("window");
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("comprehensive Obj-C file", () => {
+    it("extracts a realistic mix of constructs", () => {
+      const { root, tree, parser } = parse(`
+#import <Foundation/Foundation.h>
+#import "MyDelegate.h"
+@import UIKit;
+
+@interface Calculator : NSObject <MyDelegate>
+@property (nonatomic, assign) NSInteger total;
+- (void)addValue:(NSInteger)value;
+- (NSInteger)result;
+@end
+
+@implementation Calculator
+- (void)addValue:(NSInteger)value {
+  self.total += value;
+}
+- (NSInteger)result {
+  return self.total;
+}
+- (void)logResult {
+  NSLog(@"%ld", (long)[self result]);
+}
+@end
+
+int main(int argc, char *argv[]) {
+  Calculator *c = [[Calculator alloc] init];
+  [c addValue:5];
+  return 0;
+}`);
+      const result = extractor.extractStructure(root);
+
+      // Imports
+      expect(result.imports).toHaveLength(3);
+      expect(result.imports.map((i) => i.source).sort()).toEqual([
+        "Foundation/Foundation.h",
+        "MyDelegate.h",
+        "UIKit",
+      ]);
+
+      // Single Calculator class, methods from both interface and impl
+      const calc = result.classes.find((c) => c.name === "Calculator");
+      expect(calc).toBeDefined();
+      expect(calc?.methods).toContain("addValue");
+      expect(calc?.methods).toContain("result");
+      expect(calc?.methods).toContain("logResult");
+      expect(calc?.properties).toContain("total");
+
+      // C function
+      expect(result.functions.find((f) => f.name === "main")).toBeDefined();
+
+      // Exports include Calculator and main
+      const exportNames = result.exports.map((e) => e.name);
+      expect(exportNames).toContain("Calculator");
+      expect(exportNames).toContain("main");
+
+      // Call graph: main calls alloc + init + addValue
+      const calls = extractor.extractCallGraph(root);
+      const fromMain = calls.filter((c) => c.caller === "main").map((c) => c.callee);
+      expect(fromMain).toContain("addValue");
+
+      tree.delete();
+      parser.delete();
+    });
+  });
+});

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/index.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/index.ts
@@ -11,6 +11,7 @@ export { CppExtractor } from "./cpp-extractor.js";
 export { CSharpExtractor } from "./csharp-extractor.js";
 export { DartExtractor } from "./dart-extractor.js";
 export { KotlinExtractor } from "./kotlin-extractor.js";
+export { ObjectiveCExtractor } from "./objectivec-extractor.js";
 
 import type { LanguageExtractor } from "./types.js";
 import { TypeScriptExtractor } from "./typescript-extractor.js";
@@ -24,6 +25,7 @@ import { CppExtractor } from "./cpp-extractor.js";
 import { CSharpExtractor } from "./csharp-extractor.js";
 import { DartExtractor } from "./dart-extractor.js";
 import { KotlinExtractor } from "./kotlin-extractor.js";
+import { ObjectiveCExtractor } from "./objectivec-extractor.js";
 
 export const builtinExtractors: LanguageExtractor[] = [
   new TypeScriptExtractor(),
@@ -37,4 +39,5 @@ export const builtinExtractors: LanguageExtractor[] = [
   new CSharpExtractor(),
   new DartExtractor(),
   new KotlinExtractor(),
+  new ObjectiveCExtractor(),
 ];

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/objectivec-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/objectivec-extractor.ts
@@ -1,0 +1,337 @@
+import type { StructuralAnalysis, CallGraphEntry } from "../../types.js";
+import type { LanguageExtractor, TreeSitterNode } from "./types.js";
+import { findChild, findChildren } from "./base-extractor.js";
+
+export class ObjectiveCExtractor implements LanguageExtractor {
+  readonly name = "objectivec-extractor";
+  readonly languageIds = ["objectivec"];
+
+  extractStructure(rootNode: TreeSitterNode): StructuralAnalysis {
+    const functions: StructuralAnalysis["functions"] = [];
+    const classes: StructuralAnalysis["classes"] = [];
+    const imports: StructuralAnalysis["imports"] = [];
+    const exports: StructuralAnalysis["exports"] = [];
+
+    // Per-class accumulator so an @interface header and its later
+    // @implementation can contribute methods to the same class entry.
+    const classByName = new Map<string, StructuralAnalysis["classes"][number]>();
+    const protocolNames = new Set<string>();
+
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const node = rootNode.child(i);
+      if (!node) continue;
+
+      switch (node.type) {
+        case "preproc_include":
+          this.extractInclude(node, imports);
+          break;
+        case "module_import":
+          this.extractModuleImport(node, imports);
+          break;
+        case "class_interface":
+          this.extractInterface(node, classByName, exports);
+          break;
+        case "class_implementation":
+          this.extractImplementation(node, classByName);
+          break;
+        case "protocol_declaration":
+          this.extractProtocol(node, classByName, protocolNames, exports);
+          break;
+        case "function_definition":
+          this.extractCFunction(node, functions, exports);
+          break;
+      }
+    }
+
+    classes.push(...classByName.values());
+    return { functions, classes, imports, exports };
+  }
+
+  extractCallGraph(rootNode: TreeSitterNode): CallGraphEntry[] {
+    const entries: CallGraphEntry[] = [];
+    const functionStack: string[] = [];
+
+    const walk = (node: TreeSitterNode) => {
+      let pushed = false;
+
+      // Track the enclosing function/method name so calls within its body
+      // attribute correctly. Both C-style `function_definition` and Obj-C
+      // `method_definition` introduce a new scope.
+      if (node.type === "function_definition") {
+        const name = this.cFunctionName(node);
+        if (name) {
+          functionStack.push(name);
+          pushed = true;
+        }
+      } else if (node.type === "method_definition") {
+        const name = findChild(node, "identifier")?.text;
+        if (name) {
+          functionStack.push(name);
+          pushed = true;
+        }
+      }
+
+      // C-style call: `printf(...)` — first child is an identifier.
+      if (node.type === "call_expression" && functionStack.length > 0) {
+        const callee = node.child(0);
+        if (callee && callee.type === "identifier") {
+          entries.push({
+            caller: functionStack[functionStack.length - 1],
+            callee: callee.text,
+            lineNumber: node.startPosition.row + 1,
+          });
+        }
+      }
+
+      // Obj-C message send: `[receiver selector:arg ...]`. Children are a
+      // flat list of identifiers: [receiver, selector, arg, selector, arg, ...].
+      // The first selector identifier (index 1 among named identifier children)
+      // is the method name we attribute. Chained sends `[[a b] c]` have an
+      // inner message_expression as the receiver — we still want `c`, which
+      // is the first identifier child after the inner message_expression.
+      if (node.type === "message_expression" && functionStack.length > 0) {
+        const callee = this.messageCalleeName(node);
+        if (callee) {
+          entries.push({
+            caller: functionStack[functionStack.length - 1],
+            callee,
+            lineNumber: node.startPosition.row + 1,
+          });
+        }
+      }
+
+      for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i);
+        if (child) walk(child);
+      }
+
+      if (pushed) functionStack.pop();
+    };
+
+    walk(rootNode);
+    return entries;
+  }
+
+  // ───── Private helpers ─────
+
+  private extractInclude(
+    node: TreeSitterNode,
+    imports: StructuralAnalysis["imports"],
+  ): void {
+    // `#import <Foo/Foo.h>` or `#import "Foo.h"` or `#include ...`
+    // Surface the raw header path as the import source so consumers can
+    // map between code and headers later.
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (!child) continue;
+      if (child.type === "system_lib_string") {
+        // <Foundation/Foundation.h>
+        imports.push({
+          source: child.text.replace(/^<|>$/g, ""),
+          specifiers: [],
+          lineNumber: node.startPosition.row + 1,
+        });
+        return;
+      }
+      if (child.type === "string_literal") {
+        const content = findChild(child, "string_content");
+        if (content) {
+          imports.push({
+            source: content.text,
+            specifiers: [],
+            lineNumber: node.startPosition.row + 1,
+          });
+          return;
+        }
+      }
+    }
+  }
+
+  private extractModuleImport(
+    node: TreeSitterNode,
+    imports: StructuralAnalysis["imports"],
+  ): void {
+    // `@import UIKit;` — the identifier IS the module name.
+    const id = findChild(node, "identifier");
+    if (id) {
+      imports.push({
+        source: id.text,
+        specifiers: [],
+        lineNumber: node.startPosition.row + 1,
+      });
+    }
+  }
+
+  private extractInterface(
+    node: TreeSitterNode,
+    classByName: Map<string, StructuralAnalysis["classes"][number]>,
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    // The class name is the first `identifier` child. For categories
+    // `@interface NSString (MyCategory)`, the first identifier is the
+    // base class (`NSString`); we still attach the category's methods to
+    // that base class entry so consumers see the full surface.
+    const idents = findChildren(node, "identifier");
+    if (idents.length === 0) return;
+    const className = idents[0].text;
+    const entry = this.ensureClass(classByName, className, node);
+
+    // Properties: @property declarations
+    for (const prop of findChildren(node, "property_declaration")) {
+      const struct = findChild(prop, "struct_declaration");
+      if (!struct) continue;
+      const declarator = findChild(struct, "struct_declarator");
+      if (!declarator) continue;
+      // The declarator wraps `*name` — the bare identifier text strips the *.
+      const name = declarator.text.replace(/^\*+/, "").trim();
+      if (name) entry.properties.push(name);
+    }
+
+    // Method declarations (signatures only)
+    for (const decl of findChildren(node, "method_declaration")) {
+      const name = findChild(decl, "identifier")?.text;
+      if (name) entry.methods.push(name);
+    }
+
+    exports.push({
+      name: className,
+      lineNumber: node.startPosition.row + 1,
+    });
+  }
+
+  private extractImplementation(
+    node: TreeSitterNode,
+    classByName: Map<string, StructuralAnalysis["classes"][number]>,
+  ): void {
+    const className = findChild(node, "identifier")?.text;
+    if (!className) return;
+    const entry = this.ensureClass(classByName, className, node);
+
+    for (const def of findChildren(node, "implementation_definition")) {
+      const method = findChild(def, "method_definition");
+      if (!method) continue;
+      const name = findChild(method, "identifier")?.text;
+      if (name && !entry.methods.includes(name)) {
+        entry.methods.push(name);
+      }
+    }
+  }
+
+  private extractProtocol(
+    node: TreeSitterNode,
+    classByName: Map<string, StructuralAnalysis["classes"][number]>,
+    protocolNames: Set<string>,
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    const name = findChild(node, "identifier")?.text;
+    if (!name) return;
+    protocolNames.add(name);
+
+    const entry = this.ensureClass(classByName, name, node);
+    for (const decl of findChildren(node, "method_declaration")) {
+      const m = findChild(decl, "identifier")?.text;
+      if (m) entry.methods.push(m);
+    }
+    exports.push({ name, lineNumber: node.startPosition.row + 1 });
+  }
+
+  private extractCFunction(
+    node: TreeSitterNode,
+    functions: StructuralAnalysis["functions"],
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    const name = this.cFunctionName(node);
+    if (!name) return;
+    const declarator = findChild(node, "function_declarator");
+    const params = declarator
+      ? this.extractParams(findChild(declarator, "parameter_list"))
+      : [];
+
+    functions.push({
+      name,
+      lineRange: [
+        node.startPosition.row + 1,
+        node.endPosition.row + 1,
+      ],
+      params,
+    });
+    // Treat all top-level C functions as exported. Obj-C / C have no
+    // visibility keyword; the convention is `static` for file-private,
+    // which would appear in `storage_class_specifier`. We skip that
+    // detection for the first iteration and conservatively export all.
+    exports.push({ name, lineNumber: node.startPosition.row + 1 });
+  }
+
+  private cFunctionName(node: TreeSitterNode): string | null {
+    // function_definition → function_declarator → identifier
+    const declarator = findChild(node, "function_declarator");
+    if (!declarator) return null;
+    return findChild(declarator, "identifier")?.text ?? null;
+  }
+
+  private extractParams(paramList: TreeSitterNode | null): string[] {
+    if (!paramList) return [];
+    const params: string[] = [];
+    for (let i = 0; i < paramList.childCount; i++) {
+      const child = paramList.child(i);
+      if (!child) continue;
+      if (child.type === "parameter_declaration") {
+        // Last identifier in the parameter_declaration is the name
+        let lastIdent: string | null = null;
+        for (let j = 0; j < child.childCount; j++) {
+          const inner = child.child(j);
+          if (inner && inner.type === "identifier") lastIdent = inner.text;
+        }
+        if (lastIdent) params.push(lastIdent);
+      }
+    }
+    return params;
+  }
+
+  private ensureClass(
+    classByName: Map<string, StructuralAnalysis["classes"][number]>,
+    name: string,
+    node: TreeSitterNode,
+  ): StructuralAnalysis["classes"][number] {
+    let entry = classByName.get(name);
+    if (!entry) {
+      entry = {
+        name,
+        lineRange: [
+          node.startPosition.row + 1,
+          node.endPosition.row + 1,
+        ],
+        methods: [],
+        properties: [],
+      };
+      classByName.set(name, entry);
+    } else {
+      // Widen the line range so it spans both header + implementation.
+      entry.lineRange = [
+        Math.min(entry.lineRange[0], node.startPosition.row + 1),
+        Math.max(entry.lineRange[1], node.endPosition.row + 1),
+      ];
+    }
+    return entry;
+  }
+
+  private messageCalleeName(messageExpr: TreeSitterNode): string | null {
+    // Walk children in order. The receiver is the first thing (either an
+    // identifier or another message_expression). The first identifier that
+    // comes AFTER any receiver expression is the method name.
+    let receiverPassed = false;
+    for (let i = 0; i < messageExpr.childCount; i++) {
+      const child = messageExpr.child(i);
+      if (!child) continue;
+      if (child.type === "[") continue;
+
+      if (!receiverPassed) {
+        // First non-bracket child is the receiver expression
+        receiverPassed = true;
+        continue;
+      }
+      if (child.type === "identifier") return child.text;
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Third and largest piece of #226 — the iOS / mixed-language Apple ecosystem. Building on Swift (#344) and Dart (#348), this adds Objective-C, the last major language the original issue calls out. Together the three cover the bulk of a typical iOS codebase, including legacy code that still uses .m / .mm.

## What's covered

| AST construct | How it maps into the graph |
|---|---|
| \`@interface\` declarations | classes with properties from \`@property\` and method names from \`method_declaration\` signatures |
| \`@implementation\` blocks | merge method names into the matching \`@interface\` class entry (so header + impl appear as ONE class, not two) |
| Categories (\`@interface NSString (Reversal)\`) | methods attached to the base class entry, not a synthetic \"NSString_Reversal\" class — reflects how Obj-C actually composes |
| \`@protocol\` declarations | class-like entries with method requirements |
| Top-level C \`function_definition\` | functions entries |
| \`#import <System/Header.h>\` / \`#import \"Local.h\"\` / \`#include \"…\"\` / \`@import ModuleName;\` | imports |
| Call graph | both C-style \`call_expression\` and Obj-C \`message_expression\`, including chained sends like \`[[self window] makeKeyAndOrderFront:self]\` |

## Scope decisions

- **\`.h\` not claimed by this extractor.** The language-registry schema rejects duplicate extension mappings across configs and \`.h\` is already mapped to C/C++. In practice most .h files coexist with a .m file whose extractor pulls the same symbols into the graph, so structural data isn't lost.
- **Exports**: all top-level \`@interface\`, \`@protocol\`, and C \`function_definition\` are treated as exported. Obj-C / C have no visibility keyword equivalent; the convention is \`static\` for file-private, which we don't yet detect. Easy follow-up.
- **Selector representation**: \`[array addObject:item forKey:k]\` attributes the call to \`addObject\` (first selector identifier). Tracking the full keyword selector \`addObject:forKey:\` would change the \`CallGraphEntry\` shape, which is out of scope.

## Tests

\`objectivec-extractor.test.ts\` — 17 tests against the real tree-sitter-objc grammar:

- imports (system / quoted / @import / #include)
- classes (header-only, impl-only, header+impl merge, categories)
- @protocols
- top-level C functions + parameter extraction
- exports (all three categories)
- call graph (C calls, Obj-C message sends, chained sends)
- comprehensive end-to-end fixture mirroring a realistic iOS file shape

Total: 698 core tests passing (was 681).

## Dependency

Adds \`tree-sitter-objc@3.0.2\` — ships a prebuilt \`.wasm\` (~3 MB), Unlicense (public domain), verified to load with this project's \`web-tree-sitter@^0.26.6\`.

## Verification

- \`pnpm lint\` ✅
- \`pnpm --filter @understand-anything/core test\` — 698/698 ✅
- \`pnpm --filter @understand-anything/core build\` ✅
- \`pnpm --filter @understand-anything/skill build\` ✅
- \`pnpm test\` — 196/196 ✅

## Versioning

N/A — additive feature. Maintainer can bump on merge.

Refs #226 — Swift (#344) + Dart (#348) + Obj-C (this PR) together cover the bulk of the original iOS-codebase report.