### PR TITLE
feat(core): add Bash/shell structural analysis via tree-sitter

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       ignore:
         specifier: ^7.0.5
         version: 7.0.5
+      tree-sitter-bash:
+        specifier: 0.25.1
+        version: 0.25.1
       tree-sitter-c-sharp:
         specifier: ^0.23.1
         version: 0.23.5
@@ -2816,6 +2819,14 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
+
+  tree-sitter-bash@0.25.1:
+    resolution: {integrity: sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
 
   tree-sitter-c-sharp@0.23.5:
     resolution: {integrity: sha512-xJGOeXPMmld0nES5+080N/06yY6LQi+KWGWV4LfZaZe6srJPtUtfhIbRSN7EZN6IaauzW28v6W4QHFwmeUW6HQ==}
@@ -6237,6 +6248,11 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.4: {}
+
+  tree-sitter-bash@0.25.1:
+    dependencies:
+      node-addon-api: 8.6.0
+      node-gyp-build: 4.8.4
 
   tree-sitter-c-sharp@0.23.5:
     dependencies:

--- a/understand-anything-plugin/packages/core/package.json
+++ b/understand-anything-plugin/packages/core/package.json
@@ -40,6 +40,7 @@
     "@tree-sitter-grammars/tree-sitter-kotlin": "1.1.0",
     "fuse.js": "^7.1.0",
     "ignore": "^7.0.5",
+    "tree-sitter-bash": "0.25.1",
     "tree-sitter-c-sharp": "^0.23.1",
     "tree-sitter-cpp": "^0.23.4",
     "tree-sitter-go": "^0.25.0",

--- a/understand-anything-plugin/packages/core/src/languages/configs/shell.ts
+++ b/understand-anything-plugin/packages/core/src/languages/configs/shell.ts
@@ -4,11 +4,20 @@ export const shellConfig = {
   id: "shell",
   displayName: "Shell Script",
   extensions: [".sh", ".bash", ".zsh"],
+  // The Bash grammar is a strict superset of POSIX shell and parses
+  // zsh-flavored scripts well enough for structural extraction (function
+  // definitions, sourced files, command invocations). We use it for all
+  // three extensions rather than skipping zsh — partial structural data is
+  // far more useful than none.
+  treeSitter: {
+    wasmPackage: "tree-sitter-bash",
+    wasmFile: "tree-sitter-bash.wasm",
+  },
   concepts: ["variables", "functions", "conditionals", "loops", "pipes", "redirection", "subshells", "exit codes"],
   filePatterns: {
-    entryPoints: [],
+    entryPoints: ["main.sh", "deploy.sh", "build.sh", "bootstrap.sh"],
     barrels: [],
-    tests: [],
+    tests: ["*test.sh", "*tests.sh", "*spec.sh"],
     config: [".bashrc", ".zshrc", ".profile"],
   },
 } satisfies LanguageConfig;

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/bash-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/bash-extractor.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { createRequire } from "node:module";
+import { BashExtractor } from "../bash-extractor.js";
+
+const require = createRequire(import.meta.url);
+
+let Parser: any;
+let Language: any;
+let bashLang: any;
+
+beforeAll(async () => {
+  const wts = await import("web-tree-sitter");
+  Parser = wts.Parser;
+  Language = wts.Language;
+  await Parser.init();
+  const wasmPath = require.resolve("tree-sitter-bash/tree-sitter-bash.wasm");
+  bashLang = await Language.load(wasmPath);
+});
+
+function parse(source: string) {
+  const parser = new Parser();
+  parser.setLanguage(bashLang);
+  const tree = parser.parse(source);
+  return { root: tree.rootNode, tree, parser };
+}
+
+describe("BashExtractor", () => {
+  const extractor = new BashExtractor();
+
+  describe("languageIds", () => {
+    it("claims both 'shell' and 'bash' language ids", () => {
+      // The language registry registers shell scripts under id 'shell',
+      // but third-party plugins may pass 'bash' — we claim both for safety.
+      expect(extractor.languageIds).toContain("shell");
+      expect(extractor.languageIds).toContain("bash");
+    });
+  });
+
+  describe("extractStructure - functions", () => {
+    it("extracts the parentheses form: `name() { ... }`", () => {
+      const { root, tree, parser } = parse(`
+deploy() {
+  echo "go"
+}`);
+      const result = extractor.extractStructure(root);
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("deploy");
+      expect(result.functions[0].params).toEqual([]);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts the keyword form: `function name { ... }`", () => {
+      const { root, tree, parser } = parse(`
+function helper {
+  return 0
+}`);
+      const result = extractor.extractStructure(root);
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("helper");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts the combined form: `function name() { ... }`", () => {
+      const { root, tree, parser } = parse(`
+function build() {
+  make
+}`);
+      const result = extractor.extractStructure(root);
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("build");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("captures the function's line range", () => {
+      const { root, tree, parser } = parse(`
+# header comment
+
+my_func() {
+  echo a
+  echo b
+  echo c
+}`);
+      const result = extractor.extractStructure(root);
+      // 1-indexed; the function starts on line 4 and ends on line 8
+      expect(result.functions[0].lineRange[0]).toBe(4);
+      expect(result.functions[0].lineRange[1]).toBe(8);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("returns empty functions[] for a script with no function definitions", () => {
+      const { root, tree, parser } = parse(`
+#!/bin/bash
+echo hello
+ls -la`);
+      const result = extractor.extractStructure(root);
+      expect(result.functions).toEqual([]);
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - sourced imports", () => {
+    it("extracts `source ./path.sh`", () => {
+      const { root, tree, parser } = parse(`source ./lib.sh`);
+      const result = extractor.extractStructure(root);
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("./lib.sh");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts `. /path/to/file.sh` (POSIX dot)", () => {
+      const { root, tree, parser } = parse(`. /etc/profile`);
+      const result = extractor.extractStructure(root);
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toBe("/etc/profile");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("strips surrounding quotes from quoted source paths", () => {
+      const { root, tree, parser } = parse(`source "./common.sh"`);
+      const result = extractor.extractStructure(root);
+      expect(result.imports[0].source).toBe("./common.sh");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("preserves unresolved variable expansions in the source path", () => {
+      // We can't resolve $DIR at static-analysis time — we surface the raw
+      // path so downstream consumers can choose how to handle it.
+      const { root, tree, parser } = parse(`source "$DIR/util.sh"`);
+      const result = extractor.extractStructure(root);
+      expect(result.imports).toHaveLength(1);
+      expect(result.imports[0].source).toContain("util.sh");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("does NOT treat ordinary commands as imports", () => {
+      const { root, tree, parser } = parse(`echo hello\nls -la\ngit status`);
+      const result = extractor.extractStructure(root);
+      expect(result.imports).toEqual([]);
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - exports", () => {
+    it("treats every top-level function as exported", () => {
+      const { root, tree, parser } = parse(`
+foo() { echo foo; }
+bar() { echo bar; }`);
+      const result = extractor.extractStructure(root);
+      const exportNames = result.exports.map((e) => e.name).sort();
+      expect(exportNames).toEqual(["bar", "foo"]);
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractStructure - classes", () => {
+    it("returns an empty classes array — bash has no class concept", () => {
+      const { root, tree, parser } = parse(`
+deploy() { echo a; }`);
+      const result = extractor.extractStructure(root);
+      expect(result.classes).toEqual([]);
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("extractCallGraph", () => {
+    it("attributes calls inside a function to that function", () => {
+      const { root, tree, parser } = parse(`
+deploy() {
+  build_artifact
+  ./upload.sh prod
+}`);
+      const calls = extractor.extractCallGraph(root);
+      const fromDeploy = calls.filter((c) => c.caller === "deploy").map((c) => c.callee);
+      expect(fromDeploy).toContain("build_artifact");
+      expect(fromDeploy).toContain("./upload.sh");
+      tree.delete();
+      parser.delete();
+    });
+
+    it("filters out shell built-ins (echo, cd, [, export, etc.)", () => {
+      const { root, tree, parser } = parse(`
+go() {
+  echo "starting"
+  cd /tmp
+  export FOO=bar
+  do_real_work
+  return 0
+}`);
+      const calls = extractor.extractCallGraph(root);
+      const callees = calls.filter((c) => c.caller === "go").map((c) => c.callee);
+      // Only the user-defined call survives
+      expect(callees).toEqual(["do_real_work"]);
+      tree.delete();
+      parser.delete();
+    });
+
+    it("captures calls inside pipelines and conditionals", () => {
+      const { root, tree, parser } = parse(`
+main() {
+  if check_health; then
+    restart_service
+  fi
+  fetch_logs | parse_logs
+}`);
+      const calls = extractor.extractCallGraph(root);
+      const callees = calls.filter((c) => c.caller === "main").map((c) => c.callee).sort();
+      expect(callees).toContain("check_health");
+      expect(callees).toContain("restart_service");
+      expect(callees).toContain("fetch_logs");
+      expect(callees).toContain("parse_logs");
+      tree.delete();
+      parser.delete();
+    });
+  });
+
+  describe("comprehensive script", () => {
+    it("extracts a realistic mix of imports, functions, and calls", () => {
+      const { root, tree, parser } = parse(`#!/bin/bash
+# Deployment script
+
+source ./lib/common.sh
+. /etc/deployment.conf
+
+build() {
+  echo "building..."
+  make clean
+  make all
+}
+
+deploy() {
+  build
+  upload_artifact "$BUILD_DIR/app.tar.gz"
+  notify_team
+}
+
+if [ "$1" = "prod" ]; then
+  deploy
+fi
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports.map((i) => i.source).sort()).toEqual([
+        "./lib/common.sh",
+        "/etc/deployment.conf",
+      ]);
+
+      const funcNames = result.functions.map((f) => f.name).sort();
+      expect(funcNames).toEqual(["build", "deploy"]);
+
+      const exportNames = result.exports.map((e) => e.name).sort();
+      expect(exportNames).toEqual(["build", "deploy"]);
+
+      const calls = extractor.extractCallGraph(root);
+      const fromDeploy = calls.filter((c) => c.caller === "deploy").map((c) => c.callee);
+      expect(fromDeploy).toContain("build");
+      expect(fromDeploy).toContain("upload_artifact");
+      expect(fromDeploy).toContain("notify_team");
+
+      // `make clean` and `make all` are interesting calls — `make` is not a builtin
+      const fromBuild = calls.filter((c) => c.caller === "build").map((c) => c.callee);
+      expect(fromBuild).toContain("make");
+
+      tree.delete();
+      parser.delete();
+    });
+  });
+});

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/bash-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/bash-extractor.ts
@@ -1,0 +1,191 @@
+import type { StructuralAnalysis, CallGraphEntry } from "../../types.js";
+import type { LanguageExtractor, TreeSitterNode } from "./types.js";
+import { findChild } from "./base-extractor.js";
+
+/**
+ * Commands that source another file. POSIX defines `.` (dot); bash adds
+ * `source` as an alias. Either one followed by a file argument means
+ * "import the symbols defined in that script."
+ */
+const SOURCE_COMMAND_NAMES = new Set([".", "source"]);
+
+/**
+ * Built-in commands and shell-level primitives that aren't useful as
+ * call-graph edges. Recording every `echo`, `printf`, `cd`, `[`, `local`
+ * etc. would drown out the actually-interesting calls to project-defined
+ * functions and other scripts.
+ */
+const SHELL_BUILTIN_NAMES = new Set([
+  "echo", "printf", "read", "exit", "return", "true", "false",
+  "cd", "pwd", "pushd", "popd", "dirs",
+  "export", "unset", "declare", "local", "readonly", "typeset",
+  "test", "[", "[[",
+  "set", "shift", "trap", "shopt", "exec",
+  ":", "eval",
+]);
+
+export class BashExtractor implements LanguageExtractor {
+  readonly name = "bash-extractor";
+  readonly languageIds = ["shell", "bash"];
+
+  extractStructure(rootNode: TreeSitterNode): StructuralAnalysis {
+    const functions: StructuralAnalysis["functions"] = [];
+    const imports: StructuralAnalysis["imports"] = [];
+    const exports: StructuralAnalysis["exports"] = [];
+
+    for (let i = 0; i < rootNode.childCount; i++) {
+      const node = rootNode.child(i);
+      if (!node) continue;
+
+      switch (node.type) {
+        case "function_definition":
+          this.extractFunction(node, functions, exports);
+          break;
+        case "command":
+          this.extractSourceImport(node, imports);
+          break;
+      }
+    }
+
+    // Bash has no class concept. We still return an empty array to
+    // match the StructuralAnalysis shape that downstream consumers expect.
+    return { functions, classes: [], imports, exports };
+  }
+
+  extractCallGraph(rootNode: TreeSitterNode): CallGraphEntry[] {
+    const entries: CallGraphEntry[] = [];
+    const functionStack: string[] = [];
+
+    const walk = (node: TreeSitterNode) => {
+      let pushed = false;
+
+      if (node.type === "function_definition") {
+        const name = this.functionName(node);
+        if (name) {
+          functionStack.push(name);
+          pushed = true;
+        }
+      }
+
+      if (node.type === "command" && functionStack.length > 0) {
+        const callee = this.commandName(node);
+        if (callee && !this.isUninterestingCall(callee)) {
+          entries.push({
+            caller: functionStack[functionStack.length - 1],
+            callee,
+            lineNumber: node.startPosition.row + 1,
+          });
+        }
+      }
+
+      for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i);
+        if (child) walk(child);
+      }
+
+      if (pushed) functionStack.pop();
+    };
+
+    walk(rootNode);
+    return entries;
+  }
+
+  // ───── Helpers ─────
+
+  private extractFunction(
+    node: TreeSitterNode,
+    functions: StructuralAnalysis["functions"],
+    exports: StructuralAnalysis["exports"],
+  ): void {
+    const name = this.functionName(node);
+    if (!name) return;
+
+    functions.push({
+      name,
+      lineRange: [
+        node.startPosition.row + 1,
+        node.endPosition.row + 1,
+      ],
+      // Bash functions take positional args (`$1`, `$2`, ...), not named
+      // parameters — there's nothing to extract.
+      params: [],
+    });
+
+    // Shell has no formal export keyword for functions (`declare -fx` aside).
+    // Match Python's convention: every top-level definition is an export.
+    exports.push({
+      name,
+      lineNumber: node.startPosition.row + 1,
+    });
+  }
+
+  private extractSourceImport(
+    node: TreeSitterNode,
+    imports: StructuralAnalysis["imports"],
+  ): void {
+    const cmdName = this.commandName(node);
+    if (!cmdName || !SOURCE_COMMAND_NAMES.has(cmdName)) return;
+
+    // The first `word` or `string` after the command_name is the path.
+    // Walk children in order, skip the command_name, take the first
+    // path-shaped child.
+    let seenCmdName = false;
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (!child) continue;
+      if (!seenCmdName && child.type === "command_name") {
+        seenCmdName = true;
+        continue;
+      }
+      if (!seenCmdName) continue;
+
+      if (child.type === "word") {
+        imports.push({
+          source: child.text,
+          specifiers: [],
+          lineNumber: node.startPosition.row + 1,
+        });
+        return;
+      }
+      if (child.type === "string") {
+        // Strings may contain `simple_expansion` ($VAR) or `expansion`
+        // (${VAR}) interleaved with `string_content`. We surface the raw
+        // text (minus surrounding quotes) so consumers can see the
+        // unresolved path; resolving variables would require a runtime
+        // environment we don't have at static-analysis time.
+        const raw = child.text.replace(/^["']|["']$/g, "");
+        imports.push({
+          source: raw,
+          specifiers: [],
+          lineNumber: node.startPosition.row + 1,
+        });
+        return;
+      }
+    }
+  }
+
+  private functionName(funcNode: TreeSitterNode): string | null {
+    // `foo() { ... }` — first `word` child IS the name
+    // `function foo { ... }` — `function` keyword first, then `word`
+    // `function foo() { ... }` — both forms combined
+    // Either way, the first `word` is the name.
+    const word = findChild(funcNode, "word");
+    return word?.text ?? null;
+  }
+
+  private commandName(commandNode: TreeSitterNode): string | null {
+    const cmdName = findChild(commandNode, "command_name");
+    if (!cmdName) return null;
+    const word = findChild(cmdName, "word");
+    return word?.text ?? null;
+  }
+
+  private isUninterestingCall(name: string): boolean {
+    if (SHELL_BUILTIN_NAMES.has(name)) return true;
+    // Strip leading variable assignments like `FOO=bar cmd` — the command
+    // name parsing already handles these, but be defensive.
+    if (name.includes("=")) return true;
+    return false;
+  }
+}
+

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/index.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/index.ts
@@ -10,6 +10,7 @@ export { PhpExtractor } from "./php-extractor.js";
 export { CppExtractor } from "./cpp-extractor.js";
 export { CSharpExtractor } from "./csharp-extractor.js";
 export { KotlinExtractor } from "./kotlin-extractor.js";
+export { BashExtractor } from "./bash-extractor.js";
 
 import type { LanguageExtractor } from "./types.js";
 import { TypeScriptExtractor } from "./typescript-extractor.js";
@@ -22,6 +23,7 @@ import { PhpExtractor } from "./php-extractor.js";
 import { CppExtractor } from "./cpp-extractor.js";
 import { CSharpExtractor } from "./csharp-extractor.js";
 import { KotlinExtractor } from "./kotlin-extractor.js";
+import { BashExtractor } from "./bash-extractor.js";
 
 export const builtinExtractors: LanguageExtractor[] = [
   new TypeScriptExtractor(),
@@ -34,4 +36,5 @@ export const builtinExtractors: LanguageExtractor[] = [
   new CppExtractor(),
   new CSharpExtractor(),
   new KotlinExtractor(),
+  new BashExtractor(),
 ];


### PR DESCRIPTION
## Summary

Shell scripts are everywhere in the analysis target audience — CI pipelines, deployment scripts, dev-loop helpers — and \`shellConfig\` already claimed \`.sh\` / \`.bash\` / \`.zsh\` but had no tree-sitter grammar attached, so structural extraction returned nothing for those files. This PR wires up the grammar and adds an extractor that mirrors what other languages give us.

## What's covered

| AST construct | How it maps |
|---|---|
| \`function_definition\` (both \`name() { ... }\` and \`function name { ... }\` forms, plus the combined form) | functions array |
| \`source ./path.sh\` and POSIX \`. /path/to/file\` | imports array — including quoted paths and paths with unresolved variable expansions like \`source \"\$DIR/util.sh\"\` (we surface the raw text since static analysis can't resolve env vars) |
| Top-level \`function_definition\` | exported (Python convention — shell has no formal export keyword) |
| Bash has no classes | \`classes: []\` always |
| Call graph | every command invocation inside a function body, filtered against a curated set of shell built-ins so the graph isn't drowned out by primitive noise |

Built-ins filtered: \`echo\`, \`printf\`, \`cd\`, \`pwd\`, \`pushd\`, \`popd\`, \`export\`, \`unset\`, \`declare\`, \`local\`, \`readonly\`, \`test\`, \`[\`, \`[[\`, \`set\`, \`shift\`, \`trap\`, \`shopt\`, \`exec\`, \`return\`, \`exit\`, \`true\`, \`false\`, \`:\`, \`eval\`, \`read\`. Project-defined functions, sibling scripts (\`./deploy.sh\`), and real tools (\`make\`, \`git\`, \`docker\`) all survive.

## Why enrich \`shellConfig\` instead of adding a new bash config

The language-registry schema rejects duplicate extension mappings across configs. \`shellConfig\` already claimed all three extensions; a separate bash config would have failed schema validation at startup. Enriching the existing config with the tree-sitter grammar keeps the language id \`shell\` stable for any downstream consumer.

## Notes / scope decisions

- The Bash grammar is a strict superset of POSIX shell and parses zsh-flavored scripts well enough for structural extraction. We use it for all three extensions rather than skipping zsh — partial structural data is far more useful than none.
- Parameters are empty (\`params: []\`) because bash functions take positional args (\`\$1\`, \`\$2\`, …), not named parameters. Nothing to extract.

## Tests

\`bash-extractor.test.ts\` — 17 tests against the real tree-sitter-bash grammar:

- both function-definition syntaxes + the combined form
- line ranges
- sourced-file detection: both \`source\` and \`.\`, quoted and unquoted, with and without variable expansions
- exports
- call graph: inside pipelines and conditionals, built-in filtering, sibling-script invocations
- comprehensive end-to-end deployment-script fixture

Total: 687 core tests passing (was 670).

## Dependency

Adds \`tree-sitter-bash@0.25.1\` — ships a prebuilt \`.wasm\` (~150 KB), verified to load with this project's \`web-tree-sitter@^0.26.6\`.

## Verification

- \`pnpm lint\` ✅
- \`pnpm --filter @understand-anything/core test\` — 687/687 ✅
- \`pnpm --filter @understand-anything/core build\` ✅
- \`pnpm --filter @understand-anything/skill build\` ✅
- \`pnpm test\` — 196/196 ✅

## Versioning

N/A — additive feature.