### PR TITLE
fix(merge-batch-graphs): re-prefix cross-category edge endpoints before dangling sweep (#341)

### DIFF
--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -1183,5 +1183,137 @@ class TestUnrecognizedBatchFilename(unittest.TestCase):
         self.assertNotIn("file:src/y.ts", node_ids)
 
 
+class CrossPrefixEdgeReconciliationTests(unittest.TestCase):
+    """Regression tests for #341 — `merge-batch-graphs.py` was silently
+    dropping valid edges whose endpoint pointed at a non-code node under
+    a `file:` prefix instead of the node's actual canonical prefix
+    (`config:`, `table:`, etc.). The fix re-prefixes such endpoints to
+    match the existing node IDs before the dangling-edge sweep runs.
+    """
+
+    def test_imports_edge_to_json_data_file_is_reconciled(self) -> None:
+        # Reproduces the original report:
+        #   file:src/syllable-data.js -> file:data/syllables/general.json
+        # where the JSON node landed under config:data/syllables/general.json.
+        batch = {
+            "nodes": [
+                _file_node("src/syllable-data.js"),
+                {
+                    "id": "config:data/syllables/general.json",
+                    "type": "config",
+                    "name": "general.json",
+                    "filePath": "data/syllables/general.json",
+                    "complexity": "simple",
+                },
+            ],
+            "edges": [
+                {
+                    "source": "file:src/syllable-data.js",
+                    "target": "file:data/syllables/general.json",
+                    "type": "imports",
+                },
+            ],
+        }
+        assembled, _report = mbg.merge_and_normalize([batch])
+        edges = assembled["edges"]
+        self.assertEqual(len(edges), 1, "edge must survive after reconciliation")
+        self.assertEqual(edges[0]["source"], "file:src/syllable-data.js")
+        # Target now points at the canonical config: node
+        self.assertEqual(edges[0]["target"], "config:data/syllables/general.json")
+
+    def test_migrates_edge_to_sql_migration_file_is_reconciled(self) -> None:
+        # Second case from the report: `migrates` edge from a JS seed script
+        # to a SQL migration file. SQL files normalize under `table:`.
+        batch = {
+            "nodes": [
+                _file_node("worker/seed/load-syllables.js"),
+                {
+                    "id": "table:worker/migrations/0002_seed_syllables.sql",
+                    "type": "table",
+                    "name": "0002_seed_syllables.sql",
+                    "filePath": "worker/migrations/0002_seed_syllables.sql",
+                    "complexity": "simple",
+                },
+            ],
+            "edges": [
+                {
+                    "source": "file:worker/seed/load-syllables.js",
+                    "target": "file:worker/migrations/0002_seed_syllables.sql",
+                    "type": "migrates",
+                },
+            ],
+        }
+        assembled, _report = mbg.merge_and_normalize([batch])
+        edges = assembled["edges"]
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0]["target"], "table:worker/migrations/0002_seed_syllables.sql")
+
+    def test_configures_edge_with_already_canonical_prefix_is_unchanged(self) -> None:
+        # Edge already points at canonical IDs - reconciliation is a no-op.
+        batch = {
+            "nodes": [
+                {"id": "config:package.json", "type": "config", "name": "package.json", "filePath": "package.json", "complexity": "simple"},
+                {"id": "config:vitest.config.js", "type": "config", "name": "vitest.config.js", "filePath": "vitest.config.js", "complexity": "simple"},
+            ],
+            "edges": [
+                {"source": "config:package.json", "target": "config:vitest.config.js", "type": "configures"},
+            ],
+        }
+        assembled, _report = mbg.merge_and_normalize([batch])
+        self.assertEqual(len(assembled["edges"]), 1)
+        self.assertEqual(assembled["edges"][0]["source"], "config:package.json")
+        self.assertEqual(assembled["edges"][0]["target"], "config:vitest.config.js")
+
+    def test_endpoint_without_canonical_target_still_drops(self) -> None:
+        # An edge to a path nothing in the graph knows about should still be
+        # dropped - reconciliation can't invent a node.
+        batch = {
+            "nodes": [_file_node("src/a.js")],
+            "edges": [
+                {"source": "file:src/a.js", "target": "file:nonexistent.json", "type": "imports"},
+            ],
+        }
+        assembled, _report = mbg.merge_and_normalize([batch])
+        self.assertEqual(len(assembled["edges"]), 0, "edge with no matching node anywhere must still drop")
+
+    def test_function_class_three_part_ids_are_skipped_safely(self) -> None:
+        # Reconciliation must skip 3-part IDs (`function:path:name`) so it
+        # doesn't accidentally pick up the wrong function when two share a path.
+        batch = {
+            "nodes": [
+                {"id": "function:src/utils.ts:helperA", "type": "function", "name": "helperA", "filePath": "src/utils.ts", "complexity": "simple"},
+                {"id": "function:src/utils.ts:helperB", "type": "function", "name": "helperB", "filePath": "src/utils.ts", "complexity": "simple"},
+                _file_node("src/main.ts"),
+            ],
+            "edges": [
+                {"source": "function:src/utils.ts:helperA", "target": "function:src/utils.ts:helperB", "type": "calls"},
+            ],
+        }
+        assembled, _report = mbg.merge_and_normalize([batch])
+        node_ids = {n["id"] for n in assembled["nodes"]}
+        self.assertIn("function:src/utils.ts:helperA", node_ids)
+        self.assertIn("function:src/utils.ts:helperB", node_ids)
+        # Edge survives unchanged
+        self.assertEqual(len(assembled["edges"]), 1)
+        self.assertEqual(assembled["edges"][0]["target"], "function:src/utils.ts:helperB")
+
+    def test_report_surfaces_reconciliation_count(self) -> None:
+        # When at least one edge is reconciled, the human-readable report
+        # should mention it so the maintainer sees the fix happening rather
+        # than silently rewriting state.
+        batch = {
+            "nodes": [
+                _file_node("src/a.js"),
+                {"id": "config:data/x.json", "type": "config", "name": "x.json", "filePath": "data/x.json", "complexity": "simple"},
+            ],
+            "edges": [
+                {"source": "file:src/a.js", "target": "file:data/x.json", "type": "imports"},
+            ],
+        }
+        _assembled, report = mbg.merge_and_normalize([batch])
+        report_text = "\n".join(report)
+        self.assertIn("re-prefixed", report_text)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -808,6 +808,60 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
         nodes_by_id, all_edges
     )
 
+    # ── Step 5c: Cross-prefix edge reconciliation ────────────────────
+    # The file-analyzer agent emits every imports/references edge with a
+    # hard-coded `file:` prefix on both endpoints. That's correct for
+    # code→code imports, but a code file can also reference a non-code file
+    # (JS importing a `.json` data file, a seed script referencing a `.sql`
+    # migration). After Step 2 the non-code node landed under its correct
+    # canonical prefix (`config:data/x.json`, `table:.../migration.sql`),
+    # so the edge `file:src/x.js → file:data/x.json` points at no node
+    # and gets dropped by Step 6's dangling-edge sweep — silently losing
+    # genuine cross-category edges on essentially every project.
+    #
+    # Reconcile by re-prefixing edge endpoints that don't match an existing
+    # node ID but DO match a node's path under a different prefix.
+    node_ids_pass1 = set(nodes_by_id.keys())
+    # Map path-string → canonical node ID, but only for nodes whose ID
+    # has the simple `<prefix>:<path>` shape. Function/class nodes use
+    # `<prefix>:<filePath>:<name>` (3-part) and would generate ambiguous
+    # lookups, so we skip them.
+    path_to_canonical_id: dict[str, str] = {}
+    for nid in node_ids_pass1:
+        # Split on the FIRST colon only — paths can contain colons (rare,
+        # but Windows drive letters can sneak in), and we want everything
+        # after the prefix verbatim.
+        if ":" not in nid:
+            continue
+        prefix, rest = nid.split(":", 1)
+        if prefix not in VALID_NODE_PREFIXES:
+            continue
+        # Skip 3-part IDs (`function:path:name`, `class:path:name`) since
+        # the same `path` may host many functions and a single path-keyed
+        # lookup would be ambiguous.
+        if rest.count(":") >= 1 and prefix in ("function", "func", "class"):
+            continue
+        # Last-write-wins is fine here; we only use this map as a tiebreaker
+        # for missing edge endpoints, and the canonical node's existence is
+        # what matters, not which one was registered first.
+        path_to_canonical_id[rest] = nid
+
+    edges_reconciled = 0
+    for edge in all_edges:
+        for endpoint_key in ("source", "target"):
+            ep = edge.get(endpoint_key, "")
+            if ep in node_ids_pass1:
+                continue
+            if ":" not in ep:
+                continue
+            prefix, rest = ep.split(":", 1)
+            if prefix not in VALID_NODE_PREFIXES:
+                continue
+            canonical = path_to_canonical_id.get(rest)
+            if canonical and canonical != ep:
+                edge[endpoint_key] = canonical
+                edges_reconciled += 1
+
     # ── Step 6: Deduplicate edges, drop dangling ─────────────────────
     node_ids = set(nodes_by_id.keys())
     # Direction is part of the dedup key so a `forward` edge does not silently
@@ -849,6 +903,8 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
             fixed_lines.append(f"  {count:>4} × complexity {pattern}")
     if edges_rewritten:
         fixed_lines.append(f"  {edges_rewritten:>4} × edge references rewritten after ID normalization")
+    if edges_reconciled:
+        fixed_lines.append(f"  {edges_reconciled:>4} × edge endpoints re-prefixed to match canonical node IDs (cross-category)")
     if duplicate_count:
         fixed_lines.append(f"  {duplicate_count:>4} × duplicate node IDs removed (kept last)")
     if tested_by_swapped:
@@ -862,6 +918,7 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
             sum(id_fix_patterns.values())
             + sum(complexity_fix_patterns.values())
             + edges_rewritten
+            + edges_reconciled
             + duplicate_count
             + tested_by_swapped
             + tested_by_dropped


### PR DESCRIPTION
## Summary

Closes #341 — \`merge-batch-graphs.py\` was silently dropping every \`imports\` / \`migrates\` / \`configures\` edge whose endpoint crossed the code↔non-code boundary. Real losses observed on the reporter's production project (11 edges dropped on a ~111-file repo, all of them genuine code→data references that the optional \`assemble-reviewer\` had to recover).

## Root cause (from the issue's analysis)

1. The \`file-analyzer\` agent emits every imports-style edge with a hard-coded \`file:\` prefix on both endpoints (per its prompt).
2. \`normalize_node_id\` correctly assigns each **node** its canonical prefix from \`node.type\` — so a JSON node lands at \`config:data/x.json\`, a SQL file at \`table:.../mig.sql\`, etc.
3. There was no pass that re-prefixed **edge** endpoints to match. The edge \`file:src/x.js → file:data/x.json\` couldn't find a node \`file:data/x.json\` (the node is \`config:data/x.json\`) and got dropped by the dangling-edge sweep.

The bug was invisible on most runs — only the optional \`assemble-reviewer\` phase recovered these. The reporter noticed because review took their graph from 440 → 450 edges with 0 dangling, all 10 recovered edges being cross-category.

## Fix

New **Step 5c**: cross-prefix edge reconciliation. After node-ID normalization, build a \`path → canonical node ID\` map, then walk edges and re-prefix any endpoint that doesn't match an existing node ID but DOES match a node's path under a different prefix.

The map deliberately skips 3-part IDs (\`function:path:name\`, \`class:path:name\`) since multiple functions can share a path; a single path-keyed lookup would be ambiguous. Two-part IDs are unambiguous: each path has at most one canonical node.

Reconciliation count is surfaced in the human-readable report so the maintainer sees the fix rather than have it silently rewrite state.

### Before / after on the reporter's repro

| Phase | Before | After |
|---|---|---|
| Merge (Step 6) drops | 10 edges as \"missing target\" | 0 |
| Assemble-review recovers | 10 | 0 (already correct) |
| Final graph | same 450 edges | same 450 edges, but produced 1 phase earlier |

The optional review phase still has work to do for cases reconciliation can't handle (truly missing nodes, LLM mis-emissions), but cross-category edges are now correct on the default path.

## Tests

6 new regression tests in \`CrossPrefixEdgeReconciliationTests\`:

- The original \`file:js → file:json\` case from the bug report
- \`file:js → file:sql\` migration case
- No-op when edge already points at canonical IDs
- Edges to truly-missing paths still drop (reconciliation can't invent nodes)
- 3-part function IDs aren't ambiguously rewritten
- Report mentions reconciliation when at least one edge is rewritten

Total: 75 python tests passing (was 69).

## Verification

- \`python3 -m unittest tests.skill.understand.test_merge_batch_graphs\` — 75/75 ✅
- \`pnpm lint\` ✅
- \`pnpm test\` — 196/196 ✅

## Versioning

N/A — pure bug fix. Maintainer can bump on merge.

Closes #341