### PR TITLE
feat(graph): add `specifies` edge for normative spec → code links

### DIFF
--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -876,6 +876,43 @@ class MergeIntegrationTests(unittest.TestCase):
         prod_node = next(n for n in assembled["nodes"] if n["id"] == "file:src/foo.ts")
         self.assertIn("tested", prod_node["tags"])
 
+    def test_spec_linker_runs_during_merge(self) -> None:
+        batch = {
+            "nodes": [
+                {
+                    "id": "document:specs/auth.md", "type": "document",
+                    "name": "auth.md", "filePath": "specs/auth.md",
+                    "summary": "", "tags": [], "complexity": "simple",
+                },
+                {
+                    "id": "file:src/auth.ts", "type": "file",
+                    "name": "auth.ts", "filePath": "src/auth.ts",
+                    "summary": "", "tags": [], "complexity": "simple",
+                },
+            ],
+            "edges": [
+                # LLM-emitted inverted specifies edge (code → spec).
+                {
+                    "source": "file:src/auth.ts",
+                    "target": "document:specs/auth.md",
+                    "type": "specifies",
+                    "direction": "forward",
+                    "weight": 0.6,
+                },
+            ],
+        }
+
+        assembled, _report = mbg.merge_and_normalize([batch])
+
+        spec_edges = [e for e in assembled["edges"] if e["type"] == "specifies"]
+        self.assertEqual(len(spec_edges), 1)
+        self.assertEqual(spec_edges[0]["source"], "document:specs/auth.md")
+        self.assertEqual(spec_edges[0]["target"], "file:src/auth.ts")
+        self.assertEqual(spec_edges[0]["direction"], "forward")
+
+        doc_node = next(n for n in assembled["nodes"] if n["id"] == "document:specs/auth.md")
+        self.assertIn("normative-spec", doc_node["tags"])
+
 
 class NormalizeDirectionTests(unittest.TestCase):
     """`direction` canonicalization mirrors the dashboard schema validator."""
@@ -1181,6 +1218,214 @@ class TestUnrecognizedBatchFilename(unittest.TestCase):
         node_ids = {n["id"] for n in assembled["nodes"]}
         self.assertNotIn("file:src/x.ts", node_ids)
         self.assertNotIn("file:src/y.ts", node_ids)
+
+
+def _doc_node(path: str, **extra: Any) -> dict[str, Any]:
+    """Build a minimal document node with the given relative path."""
+    node: dict[str, Any] = {
+        "id": f"document:{path}",
+        "type": "document",
+        "name": path.rsplit("/", 1)[-1],
+        "filePath": path,
+        "summary": "",
+        "tags": [],
+        "complexity": "simple",
+    }
+    node.update(extra)
+    return node
+
+
+class LinkSpecsTests(unittest.TestCase):
+    """Canonicalization behaviour of the specifies linker."""
+
+    def test_canonical_edge_kept_and_direction_forced_forward(self) -> None:
+        nodes_by_id = {
+            "document:specs/auth.md": _doc_node("specs/auth.md"),
+            "file:src/auth.ts": _file_node("src/auth.ts"),
+        }
+        edges: list[dict[str, Any]] = [
+            {
+                "source": "document:specs/auth.md",
+                "target": "file:src/auth.ts",
+                "type": "specifies",
+                "direction": "backward",
+                "weight": 0.6,
+            },
+        ]
+
+        dropped, swapped, tagged = mbg.link_specs(nodes_by_id, edges)
+
+        self.assertEqual(dropped, 0)
+        self.assertEqual(swapped, 0)
+        self.assertEqual(tagged, 1)
+        self.assertEqual(len(edges), 1)
+        edge = edges[0]
+        self.assertEqual(edge["source"], "document:specs/auth.md")
+        self.assertEqual(edge["target"], "file:src/auth.ts")
+        self.assertEqual(edge["direction"], "forward")
+        self.assertIn("normative-spec", nodes_by_id["document:specs/auth.md"]["tags"])
+        # The specified code node is NOT tagged (links are inferred, so absence
+        # of a spec edge is not a reliable "unspecified" signal).
+        self.assertNotIn("normative-spec", nodes_by_id["file:src/auth.ts"]["tags"])
+
+    def test_inverted_edge_is_flipped(self) -> None:
+        nodes_by_id = {
+            "document:specs/auth.md": _doc_node("specs/auth.md"),
+            "module:auth": {
+                "id": "module:auth", "type": "module", "name": "auth",
+                "summary": "", "tags": [], "complexity": "simple",
+            },
+        }
+        edges: list[dict[str, Any]] = [
+            {
+                "source": "module:auth",
+                "target": "document:specs/auth.md",
+                "type": "specifies",
+                "direction": "forward",
+                "weight": 0.6,
+                "description": "from LLM",
+            },
+        ]
+
+        dropped, swapped, tagged = mbg.link_specs(nodes_by_id, edges)
+
+        self.assertEqual(dropped, 0)
+        self.assertEqual(swapped, 1)
+        self.assertEqual(tagged, 1)
+        self.assertEqual(len(edges), 1)
+        edge = edges[0]
+        self.assertEqual(edge["source"], "document:specs/auth.md")
+        self.assertEqual(edge["target"], "module:auth")
+        self.assertEqual(edge["direction"], "forward")
+        self.assertIn("direction corrected", edge["description"].lower())
+
+    def test_specified_by_type_is_folded_and_flipped(self) -> None:
+        nodes_by_id = {
+            "document:specs/auth.md": _doc_node("specs/auth.md"),
+            "file:src/auth.ts": _file_node("src/auth.ts"),
+        }
+        edges: list[dict[str, Any]] = [
+            {
+                "source": "file:src/auth.ts",
+                "target": "document:specs/auth.md",
+                "type": "specified_by",
+                "direction": "forward",
+                "weight": 0.6,
+            },
+        ]
+
+        dropped, swapped, tagged = mbg.link_specs(nodes_by_id, edges)
+
+        self.assertEqual(dropped, 0)
+        self.assertEqual(swapped, 1)
+        self.assertEqual(len(edges), 1)
+        edge = edges[0]
+        self.assertEqual(edge["type"], "specifies")
+        self.assertEqual(edge["source"], "document:specs/auth.md")
+        self.assertEqual(edge["target"], "file:src/auth.ts")
+
+    def test_doc_to_doc_and_code_to_code_dropped(self) -> None:
+        nodes_by_id = {
+            "document:specs/auth.md": _doc_node("specs/auth.md"),
+            "document:README.md": _doc_node("README.md"),
+            "file:src/a.ts": _file_node("src/a.ts"),
+            "file:src/b.ts": _file_node("src/b.ts"),
+        }
+        edges: list[dict[str, Any]] = [
+            {  # spec ↔ spec
+                "source": "document:README.md",
+                "target": "document:specs/auth.md",
+                "type": "specifies", "direction": "forward", "weight": 0.5,
+            },
+            {  # code ↔ code
+                "source": "file:src/a.ts",
+                "target": "file:src/b.ts",
+                "type": "specifies", "direction": "forward", "weight": 0.5,
+            },
+        ]
+
+        dropped, swapped, tagged = mbg.link_specs(nodes_by_id, edges)
+
+        self.assertEqual(dropped, 2)
+        self.assertEqual(swapped, 0)
+        self.assertEqual(tagged, 0)
+        self.assertEqual(len(edges), 0)
+
+    def test_missing_endpoint_dropped(self) -> None:
+        nodes_by_id = {
+            "document:specs/auth.md": _doc_node("specs/auth.md"),
+        }
+        edges: list[dict[str, Any]] = [
+            {
+                "source": "document:specs/auth.md",
+                "target": "file:src/gone.ts",
+                "type": "specifies", "direction": "forward", "weight": 0.6,
+            },
+        ]
+
+        dropped, swapped, tagged = mbg.link_specs(nodes_by_id, edges)
+
+        self.assertEqual(dropped, 1)
+        self.assertEqual(len(edges), 0)
+
+    def test_duplicate_pair_keeps_heavier_weight(self) -> None:
+        nodes_by_id = {
+            "document:specs/auth.md": _doc_node("specs/auth.md"),
+            "file:src/auth.ts": _file_node("src/auth.ts"),
+        }
+        edges: list[dict[str, Any]] = [
+            {
+                "source": "document:specs/auth.md", "target": "file:src/auth.ts",
+                "type": "specifies", "direction": "forward", "weight": 0.4,
+            },
+            {
+                "source": "document:specs/auth.md", "target": "file:src/auth.ts",
+                "type": "specifies", "direction": "forward", "weight": 0.9,
+            },
+        ]
+
+        dropped, swapped, tagged = mbg.link_specs(nodes_by_id, edges)
+
+        self.assertEqual(dropped, 1)
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0]["weight"], 0.9)
+
+    def test_unrelated_edges_preserved(self) -> None:
+        nodes_by_id = {
+            "file:src/a.ts": _file_node("src/a.ts"),
+            "file:src/b.ts": _file_node("src/b.ts"),
+        }
+        edges: list[dict[str, Any]] = [
+            {
+                "source": "file:src/a.ts", "target": "file:src/b.ts",
+                "type": "imports", "direction": "forward", "weight": 1.0,
+            },
+        ]
+
+        dropped, swapped, tagged = mbg.link_specs(nodes_by_id, edges)
+
+        self.assertEqual((dropped, swapped, tagged), (0, 0, 0))
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0]["type"], "imports")
+
+    def test_idempotent(self) -> None:
+        nodes_by_id = {
+            "document:specs/auth.md": _doc_node("specs/auth.md"),
+            "file:src/auth.ts": _file_node("src/auth.ts"),
+        }
+        edges: list[dict[str, Any]] = [
+            {
+                "source": "document:specs/auth.md", "target": "file:src/auth.ts",
+                "type": "specifies", "direction": "forward", "weight": 0.6,
+            },
+        ]
+
+        mbg.link_specs(nodes_by_id, edges)
+        dropped2, swapped2, tagged2 = mbg.link_specs(nodes_by_id, edges)
+
+        self.assertEqual((dropped2, swapped2), (0, 0))
+        self.assertEqual(tagged2, 0)  # tag already present
+        self.assertEqual(len(edges), 1)
 
 
 if __name__ == "__main__":

--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -1324,6 +1324,33 @@ class LinkSpecsTests(unittest.TestCase):
         self.assertEqual(edge["source"], "document:specs/auth.md")
         self.assertEqual(edge["target"], "file:src/auth.ts")
 
+    def test_specification_of_type_is_folded_and_flipped(self) -> None:
+        nodes_by_id = {
+            "document:specs/auth.md": _doc_node("specs/auth.md"),
+            "file:src/auth.ts": _file_node("src/auth.ts"),
+        }
+        edges: list[dict[str, Any]] = [
+            {
+                "source": "file:src/auth.ts",
+                "target": "document:specs/auth.md",
+                "type": "specification_of",
+                "direction": "forward",
+                "weight": 0.6,
+            },
+        ]
+
+        dropped, swapped, tagged = mbg.link_specs(nodes_by_id, edges)
+
+        self.assertEqual(dropped, 0)
+        self.assertEqual(swapped, 1)
+        self.assertEqual(len(edges), 1)
+        edge = edges[0]
+        self.assertEqual(edge["type"], "specifies")
+        self.assertEqual(edge["source"], "document:specs/auth.md")
+        self.assertEqual(edge["target"], "file:src/auth.ts")
+        self.assertEqual(edge["direction"], "forward")
+        self.assertIn("normative-spec", nodes_by_id["document:specs/auth.md"]["tags"])
+
     def test_doc_to_doc_and_code_to_code_dropped(self) -> None:
         nodes_by_id = {
             "document:specs/auth.md": _doc_node("specs/auth.md"),

--- a/understand-anything-plugin/agents/architecture-analyzer.md
+++ b/understand-anything-plugin/agents/architecture-analyzer.md
@@ -81,10 +81,16 @@ Using `allEdges`, compute cross-category relationships:
   ```
   config -> file: 5 (configures)
   document -> file: 3 (documents)
+  document -> file: 2 (specifies)
   service -> file: 2 (deploys)
   pipeline -> file: 1 (triggers)
   schema -> file: 2 (defines_schema)
   ```
+
+  > `specifies` edges (a normative spec document → the code it governs) are
+  > informational context only. A spec frequently spans multiple layers, so do
+  > **not** let `specifies` edges pull files into a "spec" layer or otherwise
+  > reshape layer boundaries — assign files to layers by their own role.
 
 **E. Inter-Group Import Frequency**
 

--- a/understand-anything-plugin/agents/assemble-reviewer.md
+++ b/understand-anything-plugin/agents/assemble-reviewer.md
@@ -66,6 +66,20 @@ The merge script combines what each batch produced independently. Batches don't 
 - If an edge is missing between two file nodes that should be connected, add it with `type: "imports"`, `direction: "forward"`, `weight: 0.7`.
 - Do NOT add speculative edges — only add edges that are backed by `$IMPORT_MAP` data.
 
+### Step 3b — Canonicalize `specifies` edges
+
+A `specifies` edge links a normative spec `document` → the code node it governs.
+The merge script already canonicalizes direction and drops broken pairs, but if
+you spot uncanonicalized variants, fix them:
+
+- A `specified_by` edge (or a `specifies` edge pointing `code → document`) is
+  inverted — rewrite it as `document → code`, `type: "specifies"`,
+  `direction: "forward"`.
+- Drop `specifies` edges where both endpoints are documents or both are code —
+  they have no recoverable meaning.
+- Do NOT invent `specifies` edges. Only the file-analyzer (which read the doc)
+  can judge which code a spec governs.
+
 ### Step 4 — Write results
 
 1. Apply all fixes directly to `assembled-graph.json`.

--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -271,6 +271,7 @@ Using the script's structural data and file categories, create edges:
 |---|---|---|---|
 | `configures` | Config file affects a code file or module (e.g., `tsconfig.json` configures TypeScript compilation, `.env` configures runtime settings) | `0.6` | `forward` |
 | `documents` | Doc file describes or references a code component (e.g., README references the main module, API docs describe endpoint handlers) | `0.5` | `forward` |
+| `specifies` | Doc file is a **normative specification** for a code component — it defines required behavior, a contract, acceptance criteria, or implementation constraints (MUST/SHOULD language, formal specs, `specs/<feature>/spec.md`, API contracts, design docs that prescribe rather than describe). Direction is `document → code`; the merge script flips inverted edges. | `0.6` | `forward` |
 | `deploys` | Infrastructure file builds/deploys code (e.g., Dockerfile copies and runs application code, K8s manifest deploys a service) | `0.7` | `forward` |
 | `migrates` | SQL migration file modifies a table/schema (e.g., ALTER TABLE, CREATE TABLE) | `0.7` | `forward` |
 | `triggers` | CI/CD config triggers a pipeline or deployment (e.g., GitHub Actions workflow deploys on push to main) | `0.6` | `forward` |
@@ -296,6 +297,7 @@ The `batchImportData` values contain only resolved project-internal paths — ex
 **Non-code edge creation guidance:**
 - **Config files:** Look at the config file's purpose. `tsconfig.json` configures all `.ts` files; `package.json` configures the build. Create `configures` edges to the most relevant entry points or directories.
 - **Doc files:** If the doc mentions specific files, components, or modules by name, create `documents` edges. README.md typically documents the project entry point.
+- **Spec / requirement docs:** If a doc *prescribes* how code must behave (formal specifications, contracts, acceptance criteria, MUST/SHOULD requirements, files under `specs/`, `*.spec.md`, API contracts), create `specifies` edges to the code it governs — `document → code`. Use `specifies` only for normative docs; ordinary explanatory docs (READMEs, guides, changelogs) stay `documents`. A doc may emit both if it is partly normative and partly explanatory. Only the LLM can judge which code a spec governs (spec docs are organized by feature, not code path), so emit these edges when you recognize the relationship — there is no path-convention fallback for specs.
 - **Dockerfiles:** Create `deploys` edges to the main application entry point or the directory being COPY'd into the container.
 - **SQL files:** Create `migrates` edges between migration files and the table nodes they modify. Create `defines_schema` edges from schema files to API handlers that serve that data.
 - **CI configs:** Create `triggers` edges to the deployment targets or test suites they invoke.

--- a/understand-anything-plugin/agents/graph-reviewer.md
+++ b/understand-anything-plugin/agents/graph-reviewer.md
@@ -53,12 +53,12 @@ Verify every **edge** has ALL required fields with correct types:
 |---|---|---|
 | `source` | string | Non-empty, references an existing node ID |
 | `target` | string | Non-empty, references an existing node ID |
-| `type` | string | One of the 29 valid edge types (see below) |
+| `type` | string | One of the 30 valid edge types (see below) |
 | `direction` | string | One of: `forward`, `backward`, `bidirectional` |
 | `weight` | number | Between 0.0 and 1.0 inclusive |
 
-**Valid edge types (29 total: 26 structural + 3 domain):**
-`imports`, `exports`, `contains`, `inherits`, `implements`, `calls`, `subscribes`, `publishes`, `middleware`, `reads_from`, `writes_to`, `transforms`, `validates`, `depends_on`, `tested_by`, `configures`, `related`, `similar_to`, `deploys`, `serves`, `migrates`, `documents`, `provisions`, `routes`, `defines_schema`, `triggers`, `contains_flow`, `flow_step`, `cross_domain`
+**Valid edge types (30 total: 27 structural + 3 domain):**
+`imports`, `exports`, `contains`, `inherits`, `implements`, `calls`, `subscribes`, `publishes`, `middleware`, `reads_from`, `writes_to`, `transforms`, `validates`, `depends_on`, `tested_by`, `configures`, `specifies`, `related`, `similar_to`, `deploys`, `serves`, `migrates`, `documents`, `provisions`, `routes`, `defines_schema`, `triggers`, `contains_flow`, `flow_step`, `cross_domain`
 
 **Check 2 -- Referential Integrity (Critical)**
 
@@ -105,7 +105,7 @@ Verify every **edge** has ALL required fields with correct types:
 
 Only warn about missing edges for nodes that have a clear expected relationship. Skip this check for nodes where the expected edge would be too broad (e.g., `.prettierrc` doesn't meaningfully "configure" a specific file).
 
-- Document nodes (type: `document`) should have at least one `documents` edge — warn if missing
+- Document nodes (type: `document`) should have at least one `documents` or `specifies` edge — warn if missing
 - Service nodes (type: `service`) should have at least one `deploys` or `depends_on` edge — warn if missing
 - Pipeline nodes (type: `pipeline`) should have at least one `triggers` edge — warn if missing
 - Table nodes (type: `table`) should have at least one `migrates` or `defines_schema` edge — warn if missing

--- a/understand-anything-plugin/agents/knowledge-graph-guide.md
+++ b/understand-anything-plugin/agents/knowledge-graph-guide.md
@@ -53,14 +53,14 @@ Both graph types share the same top-level shape:
 | `flow` | `flow:<kebab-case-name>` | Business flow/process (domain graph only) |
 | `step` | `step:<flow-name>:<step-name>` | Business step (domain graph only) |
 
-### Edge Types (29 total in 7 categories)
+### Edge Types (30 total in 7 categories)
 
 | Category | Types |
 |---|---|
 | Structural | `imports`, `exports`, `contains`, `inherits`, `implements` |
 | Behavioral | `calls`, `subscribes`, `publishes`, `middleware` |
 | Data flow | `reads_from`, `writes_to`, `transforms`, `validates` |
-| Dependencies | `depends_on`, `tested_by`, `configures` |
+| Dependencies | `depends_on`, `tested_by`, `configures`, `specifies` |
 | Semantic | `related`, `similar_to` |
 | Infrastructure | `deploys`, `serves`, `provisions`, `triggers`, `migrates`, `documents`, `routes`, `defines_schema` |
 | Domain | `contains_flow`, `flow_step`, `cross_domain` |

--- a/understand-anything-plugin/packages/core/src/__tests__/schema.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/schema.test.ts
@@ -233,6 +233,24 @@ describe("schema validation", () => {
     expect(result.data!.edges[0].type).toBe("depends_on");
   });
 
+  it('accepts the "specifies" edge type', () => {
+    const graph = structuredClone(validGraph);
+    (graph.edges[0] as any).type = "specifies";
+
+    const result = validateGraph(graph);
+    expect(result.success).toBe(true);
+    expect(result.data!.edges[0].type).toBe("specifies");
+  });
+
+  it('normalizes "specified_by" edge type to "specifies"', () => {
+    const graph = structuredClone(validGraph);
+    (graph.edges[0] as any).type = "specified_by";
+
+    const result = validateGraph(graph);
+    expect(result.success).toBe(true);
+    expect(result.data!.edges[0].type).toBe("specifies");
+  });
+
   it('drops "tests" edge type — direction-inverting alias is unsafe', () => {
     const graph = structuredClone(validGraph);
     (graph.edges[0] as any).type = "tests";

--- a/understand-anything-plugin/packages/core/src/schema.ts
+++ b/understand-anything-plugin/packages/core/src/schema.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
 
-// Edge types (35 values across 8 categories)
+// Edge types (36 values across 8 categories)
 export const EdgeTypeSchema = z.enum([
   "imports", "exports", "contains", "inherits", "implements",  // Structural
   "calls", "subscribes", "publishes", "middleware",             // Behavioral
   "reads_from", "writes_to", "transforms", "validates",        // Data flow
-  "depends_on", "tested_by", "configures",                     // Dependencies
+  "depends_on", "tested_by", "configures", "specifies",        // Dependencies
   "related", "similar_to",                                      // Semantic
   "deploys", "serves", "provisions", "triggers",               // Infrastructure
   "migrates", "documents", "routes", "defines_schema",         // Schema/Data
@@ -92,6 +92,11 @@ export const EDGE_TYPE_ALIASES: Record<string, string> = {
   // Non-code aliases
   describes: "documents",
   documented_by: "documents",
+  // Note: `specified_by` inverts direction (code → spec); the merge-step spec
+  // linker rewrites it to canonical `specifies` (spec → code). Aliasing the
+  // type here keeps validator-side normalization consistent.
+  specified_by: "specifies",
+  specification_of: "specifies",
   creates: "provisions",
   exposes: "serves",
   listens: "serves",

--- a/understand-anything-plugin/packages/core/src/types.test.ts
+++ b/understand-anything-plugin/packages/core/src/types.test.ts
@@ -129,17 +129,17 @@ describe("Extended types", () => {
     expect(check).toBe("file");
   });
 
-  it("accepts all 26 edge types", () => {
+  it("accepts all 27 edge types", () => {
     const edgeTypes: EdgeType[] = [
       "imports", "exports", "contains", "inherits", "implements",
       "calls", "subscribes", "publishes", "middleware",
       "reads_from", "writes_to", "transforms", "validates",
-      "depends_on", "tested_by", "configures",
+      "depends_on", "tested_by", "configures", "specifies",
       "related", "similar_to",
       "deploys", "serves", "migrates", "documents",
       "provisions", "routes", "defines_schema", "triggers",
     ];
-    expect(edgeTypes).toHaveLength(26);
+    expect(edgeTypes).toHaveLength(27);
   });
 
   it("StructuralAnalysis has optional non-code fields", () => {

--- a/understand-anything-plugin/packages/core/src/types.ts
+++ b/understand-anything-plugin/packages/core/src/types.ts
@@ -6,12 +6,12 @@ export type NodeType =
   | "domain" | "flow" | "step"
   | "article" | "entity" | "topic" | "claim" | "source";
 
-// Edge types (35 total in 8 categories: Structural, Behavioral, Data flow, Dependencies, Semantic, Infrastructure/Schema, Domain, Knowledge)
+// Edge types (36 total in 8 categories: Structural, Behavioral, Data flow, Dependencies, Semantic, Infrastructure/Schema, Domain, Knowledge)
 export type EdgeType =
   | "imports" | "exports" | "contains" | "inherits" | "implements"  // Structural
   | "calls" | "subscribes" | "publishes" | "middleware"              // Behavioral
   | "reads_from" | "writes_to" | "transforms" | "validates"         // Data flow
-  | "depends_on" | "tested_by" | "configures"                       // Dependencies
+  | "depends_on" | "tested_by" | "configures" | "specifies"          // Dependencies
   | "related" | "similar_to"                                         // Semantic
   | "deploys" | "serves" | "provisions" | "triggers"                // Infrastructure
   | "migrates" | "documents" | "routes" | "defines_schema"          // Schema/Data

--- a/understand-anything-plugin/packages/dashboard/src/locales/en.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/en.ts
@@ -244,6 +244,7 @@ export const en = {
     depends_on: { forward: "depends on", backward: "depended on by" },
     tested_by: { forward: "tested by", backward: "tests" },
     configures: { forward: "configures", backward: "configured by" },
+    specifies: { forward: "specifies", backward: "specified by" },
     related: { forward: "related to", backward: "related to" },
     similar_to: { forward: "similar to", backward: "similar to" },
     deploys: { forward: "deploys", backward: "deployed by" },

--- a/understand-anything-plugin/packages/dashboard/src/locales/ja.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/ja.ts
@@ -244,6 +244,7 @@ export const ja = {
     depends_on: { forward: "依存", backward: "依存される" },
     tested_by: { forward: "テストされる", backward: "テスト" },
     configures: { forward: "設定", backward: "設定される" },
+    specifies: { forward: "仕様を定義", backward: "仕様で定義される" },
     related: { forward: "関連", backward: "関連" },
     similar_to: { forward: "類似", backward: "類似" },
     deploys: { forward: "デプロイ", backward: "デプロイされる" },

--- a/understand-anything-plugin/packages/dashboard/src/locales/ko.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/ko.ts
@@ -244,6 +244,7 @@ edgeLabels: {
     depends_on: { forward: "종속", backward: "종속됨" },
     tested_by: { forward: "테스트됨", backward: "테스트" },
     configures: { forward: "설정", backward: "설정됨" },
+    specifies: { forward: "명세함", backward: "명세됨" },
     related: { forward: "관련", backward: "관련" },
     similar_to: { forward: "유사", backward: "유사" },
     deploys: { forward: "배포", backward: "배포됨" },

--- a/understand-anything-plugin/packages/dashboard/src/locales/ru.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/ru.ts
@@ -244,6 +244,7 @@ export const ru = {
     depends_on: { forward: "зависит от", backward: "является зависимостью" },
     tested_by: { forward: "тестируется", backward: "тестирует" },
     configures: { forward: "конфигурирует", backward: "конфигурируется" },
+    specifies: { forward: "специфицирует", backward: "специфицируется" },
     related: { forward: "связан с", backward: "связан с" },
     similar_to: { forward: "похож на", backward: "похож на" },
     deploys: { forward: "разворачивает", backward: "разворачивается" },

--- a/understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts
@@ -244,6 +244,7 @@ export const zhTW = {
     depends_on: { forward: "依賴", backward: "被依賴" },
     tested_by: { forward: "被測試", backward: "測試" },
     configures: { forward: "配置", backward: "被配置" },
+    specifies: { forward: "規範", backward: "被規範" },
     related: { forward: "相關", backward: "相關" },
     similar_to: { forward: "相似", backward: "相似" },
     deploys: { forward: "部署", backward: "被部署" },

--- a/understand-anything-plugin/packages/dashboard/src/locales/zh.ts
+++ b/understand-anything-plugin/packages/dashboard/src/locales/zh.ts
@@ -244,6 +244,7 @@ export const zh = {
     depends_on: { forward: "依赖", backward: "被依赖" },
     tested_by: { forward: "被测试", backward: "测试" },
     configures: { forward: "配置", backward: "被配置" },
+    specifies: { forward: "规范", backward: "被规范" },
     related: { forward: "相关", backward: "相关" },
     similar_to: { forward: "相似", backward: "相似" },
     deploys: { forward: "部署", backward: "被部署" },

--- a/understand-anything-plugin/packages/dashboard/src/store.ts
+++ b/understand-anything-plugin/packages/dashboard/src/store.ts
@@ -32,7 +32,7 @@ export const EDGE_CATEGORY_MAP: Record<EdgeCategory, string[]> = {
   structural: ["imports", "exports", "contains", "inherits", "implements"],
   behavioral: ["calls", "subscribes", "publishes", "middleware"],
   "data-flow": ["reads_from", "writes_to", "transforms", "validates"],
-  dependencies: ["depends_on", "tested_by", "configures"],
+  dependencies: ["depends_on", "tested_by", "configures", "specifies"],
   semantic: ["related", "similar_to"],
   infrastructure: ["deploys", "serves", "provisions", "triggers", "migrates", "documents", "routes", "defines_schema"],
   domain: ["contains_flow", "flow_step", "cross_domain"],

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -828,16 +828,22 @@ Report to the user: `[Phase 7/7] Saving knowledge graph...`
 | `schema` | Schema definition (GraphQL, Protobuf, Prisma) | `schema:<relative-path>` |
 | `resource` | Infrastructure resource (Terraform, CloudFormation) | `resource:<relative-path>` |
 
-### Edge Types (26 total)
+### Edge Types (27 total)
 | Category | Types |
 |---|---|
 | Structural | `imports`, `exports`, `contains`, `inherits`, `implements` |
 | Behavioral | `calls`, `subscribes`, `publishes`, `middleware` |
 | Data flow | `reads_from`, `writes_to`, `transforms`, `validates` |
-| Dependencies | `depends_on`, `tested_by`, `configures` |
+| Dependencies | `depends_on`, `tested_by`, `configures`, `specifies` |
 | Semantic | `related`, `similar_to` |
 | Infrastructure | `deploys`, `serves`, `provisions`, `triggers` |
 | Schema/Data | `migrates`, `documents`, `routes`, `defines_schema` |
+
+`specifies` is the normative counterpart of `documents`: a spec `document` →
+the code node it governs (requirements, contract, acceptance criteria). Emit it
+only for prescriptive docs; ordinary explanatory docs use `documents`. The
+merge step canonicalizes direction (spec → code) and tags source documents
+`normative-spec`. See `agents/file-analyzer.md` for emission guidance.
 
 ### Edge Weight Conventions
 | Edge Type | Weight |
@@ -846,6 +852,6 @@ Report to the user: `[Phase 7/7] Saving knowledge graph...`
 | `inherits`, `implements` | 0.9 |
 | `calls`, `exports`, `defines_schema` | 0.8 |
 | `imports`, `deploys`, `migrates` | 0.7 |
-| `depends_on`, `configures`, `triggers` | 0.6 |
+| `depends_on`, `configures`, `triggers`, `specifies` | 0.6 |
 | `tested_by`, `documents`, `provisions`, `serves`, `routes` | 0.5 |
 | All others | 0.5 (default) |

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -719,6 +719,169 @@ def link_tests(
     return added, dropped, tagged, swapped
 
 
+# ── Deterministic specifies linker ─────────────────────────────────────────
+# Unlike `tested_by`, spec → code links are LLM-inferred ONLY: spec documents
+# (especially feature-oriented ones like `specs/<feature>/spec.md`) are
+# organized by feature, not by code path, so there is no reliable path
+# convention to auto-pair them. This linker therefore CANONICALIZES the LLM's
+# `specifies` edges (it does NOT supplement new ones):
+#   1. Keep canonical `document → code` edges, forcing `direction: forward`.
+#   2. Flip inverted `code → document` edges (with an audit note).
+#   3. Drop edges that don't classify cleanly (doc↔doc, code↔code, or a
+#      missing / non-targetable endpoint) — they have no recoverable meaning.
+# A `document` that survives as the source of any `specifies` edge is tagged
+# `normative-spec`, which distinguishes a normative specification from ordinary
+# reference documentation (which uses `documents`).
+
+# Node types a `specifies` edge may legitimately target. The source is always a
+# `document`; the target is a concrete code / artifact node. Domain and
+# knowledge node types are intentionally excluded — specs describe code.
+SPEC_TARGET_TYPES: frozenset[str] = frozenset({
+    "file", "function", "class", "module",
+    "endpoint", "schema", "table", "config",
+    "service", "resource", "pipeline",
+})
+
+# Edge type names that mean "specifies". `specified_by` inverts direction; the
+# linker recovers the correct orientation by node-type classification, so it is
+# safe to fold it in here (the Python merge step does not apply the TS-side
+# edge-type aliases).
+SPEC_EDGE_TYPES: frozenset[str] = frozenset({"specifies", "specified_by"})
+
+
+def _swap_specifies_in_place(
+    edge: dict[str, Any], original_src: str, original_tgt: str
+) -> None:
+    """Flip an inverted `specifies` edge so source becomes the spec document
+    and target becomes the specified code node. Mutates `edge` in place and
+    appends a `[direction corrected]` audit marker to `description`.
+    """
+    edge["source"] = original_tgt
+    edge["target"] = original_src
+    edge["direction"] = "forward"
+    prev = edge.get("description")
+    edge["description"] = (
+        "Direction corrected (was code → spec)"
+        if not prev
+        else f"{prev} [direction corrected]"
+    )
+
+
+def _ensure_normative_spec_tag(node: dict[str, Any]) -> bool:
+    """Append "normative-spec" to `node["tags"]`, coercing malformed `tags` to
+    a fresh list. Returns True if the tag was newly added.
+    """
+    tags = node.get("tags")
+    if not isinstance(tags, list):
+        tags = []
+        node["tags"] = tags
+    if "normative-spec" in tags:
+        return False
+    tags.append("normative-spec")
+    return True
+
+
+def link_specs(
+    nodes_by_id: dict[str, dict[str, Any]],
+    edges: list[dict[str, Any]],
+) -> tuple[int, int, int]:
+    """Canonicalize `specifies` edges (spec document → specified code node).
+
+    Single pass (no path-convention supplement — see the module-level
+    "Deterministic specifies linker" comment for the rationale):
+
+      * Keep canonical `document → code` edges, normalizing `direction` to
+        `forward`.
+      * Flip inverted `code → document` edges so the LLM's pairing survives
+        with the right orientation.
+      * Drop edges where the endpoints don't classify cleanly as one
+        `document` and one targetable code node.
+
+    `specified_by`-typed edges are treated as inverted `specifies` edges.
+
+    Mutates `nodes_by_id` (adds the "normative-spec" tag) and `edges`
+    (rewrites in place: drops broken edges, flips inverted ones).
+
+    Returns (dropped, swapped, tagged_docs):
+      dropped: `specifies`/`specified_by` edges removed (unsalvageable)
+      swapped: edges flipped (code → document became document → code)
+      tagged_docs: document nodes newly tagged "normative-spec"
+    """
+    def _type(nid: str) -> str | None:
+        node = nodes_by_id.get(nid)
+        return node.get("type") if node else None
+
+    # `covered` tracks (doc_id, target_id) pairs kept after the pass — used to
+    # deduplicate. `pair_to_idx` lets a heavier-weight duplicate replace an
+    # earlier slot in place (mirrors `link_tests` / Step 6 weight-wins rule).
+    covered: set[tuple[str, str]] = set()
+    pair_to_idx: dict[tuple[str, str], int] = {}
+    swapped_pairs: set[tuple[str, str]] = set()
+    dropped = 0
+    write_idx = 0
+    for edge in edges:
+        if edge.get("type") not in SPEC_EDGE_TYPES:
+            edges[write_idx] = edge
+            write_idx += 1
+            continue
+
+        # Fold `specified_by` into the canonical type name; orientation is
+        # recovered below by node-type classification.
+        edge["type"] = "specifies"
+        src = edge.get("source", "")
+        tgt = edge.get("target", "")
+        src_type = _type(src)
+        tgt_type = _type(tgt)
+
+        # Exactly one endpoint must be a document, the other a targetable node.
+        if src_type == "document" and tgt_type in SPEC_TARGET_TYPES:
+            pair = (src, tgt)
+            needs_swap = False
+        elif tgt_type == "document" and src_type in SPEC_TARGET_TYPES:
+            pair = (tgt, src)
+            needs_swap = True
+        else:
+            dropped += 1
+            continue
+
+        if pair in covered:
+            existing_idx = pair_to_idx[pair]
+            existing = edges[existing_idx]
+            if _num(edge.get("weight", 0)) > _num(existing.get("weight", 0)):
+                if needs_swap:
+                    _swap_specifies_in_place(edge, src, tgt)
+                    swapped_pairs.add(pair)
+                else:
+                    edge["direction"] = "forward"
+                    swapped_pairs.discard(pair)
+                edges[existing_idx] = edge
+            dropped += 1
+            continue
+
+        if needs_swap:
+            _swap_specifies_in_place(edge, src, tgt)
+            swapped_pairs.add(pair)
+        else:
+            edge["direction"] = "forward"
+        covered.add(pair)
+        pair_to_idx[pair] = write_idx
+        edges[write_idx] = edge
+        write_idx += 1
+    del edges[write_idx:]
+    swapped = len(swapped_pairs)
+
+    # ── Tag every document that survived as the source of a specifies edge.
+    tagged = 0
+    for doc_id, _target_id in covered:
+        doc_node = nodes_by_id.get(doc_id)
+        if doc_node is None:
+            continue
+        if _ensure_normative_spec_tag(doc_node):
+            tagged += 1
+
+    return dropped, swapped, tagged
+
+
 # ── Main merge + normalize ────────────────────────────────────────────────
 
 def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], list[str]]:
@@ -808,6 +971,10 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
         nodes_by_id, all_edges
     )
 
+    # ── Step 5c: Deterministic specifies linker ──────────────────────
+    # See module-level "Deterministic specifies linker" section above.
+    spec_dropped, spec_swapped, spec_tagged = link_specs(nodes_by_id, all_edges)
+
     # ── Step 6: Deduplicate edges, drop dangling ─────────────────────
     node_ids = set(nodes_by_id.keys())
     # Direction is part of the dedup key so a `forward` edge does not silently
@@ -855,6 +1022,10 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
         fixed_lines.append(f"  {tested_by_swapped:>4} × tested_by edges flipped (test → production became production → test)")
     if tested_by_dropped:
         fixed_lines.append(f"  {tested_by_dropped:>4} × tested_by edges dropped (orphan endpoint or test↔test / prod↔prod pair)")
+    if spec_swapped:
+        fixed_lines.append(f"  {spec_swapped:>4} × specifies edges flipped (code → spec became spec → code)")
+    if spec_dropped:
+        fixed_lines.append(f"  {spec_dropped:>4} × specifies edges dropped (orphan endpoint or spec↔spec / code↔code pair)")
 
     if fixed_lines:
         report.append("")
@@ -865,6 +1036,8 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
             + duplicate_count
             + tested_by_swapped
             + tested_by_dropped
+            + spec_swapped
+            + spec_dropped
         )
         report.append(f"Fixed ({total_fixes} corrections):")
         report.extend(fixed_lines)
@@ -876,6 +1049,12 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
         report.append("Tested-by linker:")
         report.append(f"  {tested_by_added:>4} × tested_by edges produced (path-convention supplement, production → test)")
         report.append(f"  {tested_by_tagged:>4} × production nodes tagged \"tested\"")
+
+    # Specifies linker section — net-new tagging (no supplemental edges).
+    if spec_tagged:
+        report.append("")
+        report.append("Specifies linker:")
+        report.append(f"  {spec_tagged:>4} × document nodes tagged \"normative-spec\"")
 
     # Could not fix section — unknown patterns (grouped) + individual details
     unfixable_total = (

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -1028,7 +1028,7 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
     if spec_swapped:
         fixed_lines.append(f"  {spec_swapped:>4} × specifies edges flipped (code → spec became spec → code)")
     if spec_dropped:
-        fixed_lines.append(f"  {spec_dropped:>4} × specifies edges dropped (orphan endpoint or spec↔spec / code↔code pair)")
+        fixed_lines.append(f"  {spec_dropped:>4} × specifies edges dropped (orphan/non-targetable endpoint or spec↔spec / code↔code pair)")
 
     if fixed_lines:
         report.append("")

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -742,11 +742,14 @@ SPEC_TARGET_TYPES: frozenset[str] = frozenset({
     "service", "resource", "pipeline",
 })
 
-# Edge type names that mean "specifies". `specified_by` inverts direction; the
-# linker recovers the correct orientation by node-type classification, so it is
-# safe to fold it in here (the Python merge step does not apply the TS-side
-# edge-type aliases).
-SPEC_EDGE_TYPES: frozenset[str] = frozenset({"specifies", "specified_by"})
+# Edge type names that mean "specifies". `specified_by` / `specification_of`
+# invert direction (code → spec); the linker recovers the correct orientation by
+# node-type classification, so it is safe to fold them in here (the Python merge
+# step does not apply the TS-side edge-type aliases — see EDGE_TYPE_ALIASES in
+# packages/core/src/schema.ts, which folds all three spellings into `specifies`).
+SPEC_EDGE_TYPES: frozenset[str] = frozenset(
+    {"specifies", "specified_by", "specification_of"}
+)
 
 
 def _swap_specifies_in_place(


### PR DESCRIPTION
## What & why

Adds a **`specifies`** edge type: a spec `document` node points at the code node it normatively governs (requirements / contract / acceptance criteria). It is the **normative counterpart of `documents`** and the **spec-side mirror of the existing `tested_by` edge (#122/#113)** — giving specifications a first-class, queryable place in the knowledge graph instead of being indistinguishable from ordinary reference docs.

This lets a graph consumer answer: *"which code does this spec govern, and is that code also `tested_by` something?"* — i.e. spec/test coverage of a unit, **without introducing a new node primitive.**

## Design

- **One new edge, no new node type.** Reuses the existing `document` node. `document --specifies--> code`.
- **LLM-inferred only.** Spec docs are organized by *feature*, not by code path, so (unlike `tested_by`) there's no reliable path convention to auto-pair them. There is therefore **no deterministic path linker** — `file-analyzer` emits the links and the merge step only *canonicalizes* them.
- **`link_specs` merge pass (canonicalization-only), runs as "Step 5c" alongside the existing `link_tests` "Step 5b":**
  - keep canonical `document → code` (force `direction: forward`),
  - flip inverted `code → document` (with an audit note),
  - fold `specified_by` / `specification_of`-typed edges into canonical `specifies`,
  - drop edges that don't classify cleanly (spec↔spec, code↔code, or a missing / non-targetable endpoint),
  - tag each source document **`normative-spec`** to distinguish a specification from `documents` reference material.
- **Does not reshape layers.** `architecture-analyzer` is made aware of `specifies` but explicitly told it must not pull files into a "spec" layer.

## Changes

- **core:** add `specifies` to `EdgeTypeSchema` + `EdgeType`; alias `specified_by` / `specification_of` → `specifies`; update counts + tests.
- **merge:** `link_specs` (Step 5c) in `merge-batch-graphs.py` + report section.
- **prompts:** `file-analyzer` emission guidance; `assemble-reviewer` canonicalization rule; `architecture-analyzer` awareness; `graph-reviewer` + `knowledge-graph-guide` valid-edge lists; `SKILL.md` edge/weight tables.
- **dashboard:** `specifies` in the dependencies edge category + labels for all six locales.

## Tests

- `packages/core`: 672 pass · root vitest: 200 pass · python merge suite: 78 pass (9 new, incl. an end-to-end merge integration test) · dashboard `tsc -b` clean · eslint + ruff clean.

The Python merge tests (including the 9 added here) run via `python -m unittest tests.skill.understand.test_merge_batch_graphs`, matching the existing `test_merge_batch_graphs.py` convention. (These — like the existing Python suite — aren't currently gated by CI; happy to add a `setup-python` job if you'd like.)

## Relationship to #341 / #357

`link_specs` shares the edge-endpoint normalization assumptions of `link_tests` (it runs in the same pass region against the canonicalized `nodes_by_id`). The in-flight #357 ("re-prefix cross-category edge endpoints before dangling sweep") touches the same area and would also benefit `specifies` edges that target non-code nodes (`config`/`table`/`schema`). These changes are additive in separate functions; happy to rebase on #357 if it lands first.

## spec-kit note

`file-analyzer` guidance recognizes spec-kit-style `specs/<feature>/spec.md` as candidate normative docs, so those link naturally — but there's no hard dependency on any spec tool.