### PR TITLE
fix: Go extractor drops variadic parameters

### DIFF
--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts
@@ -101,6 +101,29 @@ func divide(a, b float64) (float64, error) {
       parser.delete();
     });
 
+    it("extracts variadic parameters", () => {
+      const { tree, parser, root } = parse(`package main
+
+func Sprintf(format string, args ...interface{}) string {
+    return ""
+}
+
+func Sum(nums ...int) int {
+    return 0
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(2);
+      expect(result.functions[0].name).toBe("Sprintf");
+      expect(result.functions[0].params).toEqual(["format", "args"]);
+      expect(result.functions[1].name).toBe("Sum");
+      expect(result.functions[1].params).toEqual(["nums"]);
+
+      tree.delete();
+      parser.delete();
+    });
+
     it("reports correct line ranges for multi-line functions", () => {
       const { tree, parser, root } = parse(`package main
 

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts
@@ -13,7 +13,13 @@ function extractParams(paramsNode: TreeSitterNode | null): string[] {
   if (!paramsNode) return [];
   const params: string[] = [];
 
-  const declarations = findChildren(paramsNode, "parameter_declaration");
+  // `parameter_declaration` covers normal params (`a int`, `a, b int`);
+  // `variadic_parameter_declaration` covers variadic params (`args ...int`),
+  // which tree-sitter-go emits as a distinct node type.
+  const declarations = [
+    ...findChildren(paramsNode, "parameter_declaration"),
+    ...findChildren(paramsNode, "variadic_parameter_declaration"),
+  ];
   for (const decl of declarations) {
     // A parameter_declaration can have multiple name identifiers sharing
     // a type, e.g. `a, b int`.  Collect all identifiers.


### PR DESCRIPTION
## What

The Go extractor silently drops **variadic parameters** (`args ...int`) from extracted function signatures.

## Why

`extractParams` only collected identifiers from `parameter_declaration` nodes:

```ts
const declarations = findChildren(paramsNode, "parameter_declaration");
```

tree-sitter-go emits a variadic parameter as a distinct **`variadic_parameter_declaration`** node, not `parameter_declaration`. So the variadic name is never collected:

```go
func Sprintf(format string, args ...interface{}) string  // extracted: ["format"]   (missing "args")
func Sum(nums ...int) int                                 // extracted: []           (missing "nums")
```

Variadic params are extremely common in real Go (printf-style APIs, functional-options constructors, `append`-style helpers), so this corrupts the extracted signatures / structural graph for a lot of ordinary code. Java's extractor already handles its equivalent (`spread_parameter`) separately, confirming this is an oversight.

## Fix

Also search `variadic_parameter_declaration`. A variadic is always the last Go parameter, so appending it after the normal declarations preserves order.

## Test

Added `extracts variadic parameters` to `go-extractor.test.ts`:

```
$ vitest run src/plugins/extractors/__tests__/go-extractor.test.ts
✓ 26 passed   (the new test fails against the previous code)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
