### PR TITLE
fix: sanitiseFilePaths leaks sibling dirs sharing the root's name prefix

### DIFF
--- a/understand-anything-plugin/packages/core/src/persistence/index.ts
+++ b/understand-anything-plugin/packages/core/src/persistence/index.ts
@@ -53,8 +53,10 @@ function sanitiseFilePaths(
       return node;
     }
 
-    if (fp.startsWith(normalRoot) || fp.startsWith(projectRoot)) {
-      // Inside the project root — make it relative.
+    if (fp === projectRoot || fp.startsWith(normalRoot)) {
+      // Inside the project root — make it relative. Use normalRoot (trailing
+      // slash) for the boundary so a sibling like `<root>-backup/...` is not
+      // mistaken for being inside `<root>` and rewritten to a `../` path.
       return { ...node, filePath: relative(projectRoot, fp) };
     }
 

--- a/understand-anything-plugin/packages/core/src/persistence/persistence.test.ts
+++ b/understand-anything-plugin/packages/core/src/persistence/persistence.test.ts
@@ -112,6 +112,22 @@ describe("persistence", () => {
       expect(loaded).not.toBeNull();
       expect(loaded?.version).toBe(123);
     });
+
+    it("does not leak a sibling directory that shares the root's name prefix", () => {
+      // A path beside the project root (e.g. a backup or git worktree) must be
+      // reduced to its basename, not rewritten to a `../<root>-backup/...`
+      // traversal that both leaks the directory layout and escapes the root
+      // (graph filePaths later seed the dashboard's path allowlist).
+      const sibling = `${tempDir}-backup/src/auth.ts`;
+      const graph: KnowledgeGraph = {
+        ...sampleGraph,
+        nodes: [{ ...sampleGraph.nodes[0], id: "sibling-node", filePath: sibling }],
+      };
+      saveGraph(tempDir, graph);
+
+      const loaded = loadGraph(tempDir);
+      expect(loaded?.nodes[0].filePath).toBe("auth.ts");
+    });
   });
 
   describe("saveMeta / loadMeta", () => {


### PR DESCRIPTION
## What

`sanitiseFilePaths` (run by `saveGraph` before persisting) leaks **sibling directories** that share the project root's name prefix, and writes a `..`-traversal path into `knowledge-graph.json`.

## Why

The helper is meant to reduce absolute paths *outside* the project root to just their basename (its docstring: "the developer's home directory, username, and company directory layout are never written"). The "inside root" check:

```ts
if (fp.startsWith(normalRoot) || fp.startsWith(projectRoot)) {
  return { ...node, filePath: relative(projectRoot, fp) };
}
```

`normalRoot` has a guaranteed trailing slash (boundary-safe), but the `|| fp.startsWith(projectRoot)` arm uses the raw root with **no boundary**. With `projectRoot = /Users/alice/app`, a node path in a sibling like `/Users/alice/app-backup/src/auth.ts` passes `startsWith("/Users/alice/app")` and is rewritten to:

```
relative("/Users/alice/app", "/Users/alice/app-backup/src/auth.ts")  ->  "../app-backup/src/auth.ts"
```

So instead of being reduced to `auth.ts`, it (1) leaks the sibling directory name and (2) writes a `../` escaping path into the graph — which later seeds the dashboard server's graph-derived path allowlist for serving file content. Common triggers: a backup/worktree/vendored copy beside the repo, or a monorepo sibling package.

## Fix

Match on the boundary-safe `normalRoot` (trailing slash) plus an exact-root equality. Siblings now correctly fall through to `basename`.

## Test

```
$ vitest run src/persistence/persistence.test.ts
✓ 15 passed   (the new "sibling directory" test fails against the previous code)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
