### PR TITLE
fix: protobuf map<> fields were silently dropped from message definitions

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts
@@ -373,6 +373,18 @@ describe("ProtobufParser", () => {
     expect(result.definitions![0].fields).toContain("emails");
   });
 
+  it("extracts map<> fields", () => {
+    const content = `message Config {
+  string name = 1;
+  map<string, int32> scores = 2;
+  map<string, Endpoint> endpoints = 3;
+}`;
+    const result = parser.analyzeFile("config.proto", content);
+    expect(result.definitions![0].fields).toContain("name");
+    expect(result.definitions![0].fields).toContain("scores");
+    expect(result.definitions![0].fields).toContain("endpoints");
+  });
+
   it("extracts enum definitions", () => {
     const content = "enum Status {\n  UNKNOWN = 0;\n  ACTIVE = 1;\n  INACTIVE = 2;\n}";
     const result = parser.analyzeFile("status.proto", content);

--- a/understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts
@@ -97,7 +97,11 @@ export class ProtobufParser implements AnalyzerPlugin {
     const closeBrace = this.findClosingBrace(afterMsg);
     const body = afterMsg.slice(openBrace + 1, closeBrace);
 
-    const fieldRegex = /^\s*(?:repeated\s+|optional\s+|required\s+|map<[^>]+>\s+)?\w+\s+(\w+)\s*=/gm;
+    // `map<K, V>` is itself the field type, not a qualifier before a type, so
+    // it belongs in the type position (alongside `\w+`) — not in the optional
+    // qualifier group, where it left a trailing `<type> <name> =` the rest of
+    // the pattern could not satisfy, silently dropping every map field.
+    const fieldRegex = /^\s*(?:repeated\s+|optional\s+|required\s+)?(?:map<[^>]+>|\w+)\s+(\w+)\s*=/gm;
     let match;
     while ((match = fieldRegex.exec(body)) !== null) {
       fields.push(match[1]);


### PR DESCRIPTION
## What

The protobuf parser silently drops every `map<K, V>` field from a message's extracted `fields[]`.

## Why

```ts
const fieldRegex = /^\s*(?:repeated\s+|optional\s+|required\s+|map<[^>]+>\s+)?\w+\s+(\w+)\s*=/gm;
```

`map<...>` was placed inside the **qualifier** alternation group, next to `repeated`/`optional`/`required`. But those qualifiers precede a *separate* type token, whereas `map<K, V>` **is** the type. After optionally consuming `map<string, int32> `, the rest of the pattern still demands `<type> <name> =` — but only `name =` remains, so the match fails and the field is omitted.

```proto
message Config {
  string name = 1;
  map<string, int32> scores = 2;     // dropped
  map<string, Endpoint> endpoints = 3;  // dropped
}
// extracted fields: ["name"]   (expected: ["name", "scores", "endpoints"])
```

Map fields are common in real `.proto` files, so message summaries are silently incomplete. (The file's doc comment lists what's unsupported — nested messages, oneof, proto2 extensions — and does *not* list maps; the regex visibly tries to handle them, it's just placed wrong.)

## Fix

Move `map<...>` into the type position, as an alternative to `\w+`:

```ts
/^\s*(?:repeated\s+|optional\s+|required\s+)?(?:map<[^>]+>|\w+)\s+(\w+)\s*=/gm
```

## Test

```
$ vitest run src/__tests__/parsers.test.ts
✓ 62 passed   (the new "extracts map<> fields" test fails against the previous code)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
