### PR TITLE
fix: framework detection false-positives on substring matches (preact -> React)

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { FrameworkRegistry } from "../languages/framework-registry.js";
 import { djangoConfig } from "../languages/frameworks/django.js";
 import { reactConfig } from "../languages/frameworks/react.js";
+import { vueConfig } from "../languages/frameworks/vue.js";
 
 describe("FrameworkRegistry", () => {
   it("registers and retrieves a framework config by id", () => {
@@ -44,6 +45,26 @@ describe("FrameworkRegistry", () => {
       });
       expect(detected).toHaveLength(1);
       expect(detected[0].id).toBe("react");
+    });
+
+    it("does not detect React for a Preact-only project", () => {
+      // Regression: the bare "react" keyword matched the substring inside
+      // "preact", so a Preact dependency was misdetected as React.
+      const registry = new FrameworkRegistry();
+      registry.register(reactConfig);
+      const detected = registry.detectFrameworks({
+        "package.json": '{"dependencies": {"preact": "^10.19.0"}}',
+      });
+      expect(detected).toEqual([]);
+    });
+
+    it("still detects Vue after the quoted-keyword change", () => {
+      const registry = new FrameworkRegistry();
+      registry.register(vueConfig);
+      const detected = registry.detectFrameworks({
+        "package.json": '{"dependencies": {"vue": "^3.4.0"}}',
+      });
+      expect(detected.map((f) => f.id)).toContain("vue");
     });
 
     it("detection is case-insensitive", () => {

--- a/understand-anything-plugin/packages/core/src/languages/frameworks/react.ts
+++ b/understand-anything-plugin/packages/core/src/languages/frameworks/react.ts
@@ -4,7 +4,7 @@ export const reactConfig = {
   id: "react",
   displayName: "React",
   languages: ["typescript", "javascript"],
-  detectionKeywords: ["react", "react-dom", "@types/react"],
+  detectionKeywords: ["\"react\":", "react-dom", "@types/react"],
   manifestFiles: ["package.json"],
   promptSnippetPath: "./frameworks/react.md",
   entryPoints: ["src/App.tsx", "src/App.jsx", "src/index.tsx", "src/main.tsx"],

--- a/understand-anything-plugin/packages/core/src/languages/frameworks/vue.ts
+++ b/understand-anything-plugin/packages/core/src/languages/frameworks/vue.ts
@@ -4,7 +4,7 @@ export const vueConfig = {
   id: "vue",
   displayName: "Vue",
   languages: ["typescript", "javascript"],
-  detectionKeywords: ["vue", "@vue/cli-service", "nuxt", "vite-plugin-vue"],
+  detectionKeywords: ["\"vue\":", "@vue/cli-service", "nuxt", "vite-plugin-vue"],
   manifestFiles: ["package.json"],
   promptSnippetPath: "./frameworks/vue.md",
   entryPoints: ["src/main.ts", "src/App.vue", "src/main.js"],


### PR DESCRIPTION
## What

Framework detection misidentifies a **Preact** project as **React** (and is similarly loose for Vue).

## Why

`detectFrameworks` does a case-insensitive substring match of each keyword against the manifest:

```ts
const found = config.detectionKeywords.some((keyword) =>
  contentLower.includes(keyword.toLowerCase()),
);
```

React's keyword list starts with the bare token `"react"`, which is a substring of `"preact"`. So a Preact-only `package.json`:

```json
{ "dependencies": { "preact": "^10.19.0" } }
```

is detected as React. Vue's bare `"vue"` keyword is loose the same way.

The maintainers already guard against this exact class for Next.js and Express by using **quoted-key** keywords (e.g. `"express":`), so React/Vue were just inconsistent.

## Fix

Quote the ambiguous bare keys (`"react":`, `"vue":`) so they match the actual dependency key in the manifest rather than an unrelated substring. Specific keys (`react-dom`, `@types/react`, `@vue/cli-service`, `nuxt`, …) are left as-is. Real React/Vue detection is unchanged.

## Test

```
$ vitest run src/__tests__/framework-registry.test.ts
✓ 16 passed
  - "does not detect React for a Preact-only project"  (fails against the previous code)
  - "still detects Vue after the quoted-keyword change"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
