### PR TITLE
fix: concept detection matched short keywords inside unrelated words

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts
@@ -153,5 +153,37 @@ describe("language-lesson", () => {
       const concepts = detectLanguageConcepts(plainNode, "typescript");
       expect(concepts).toEqual([]);
     });
+
+    it("does not match short keywords inside unrelated words", () => {
+      // Regression: keywords "is" (type guards) and "di" (dependency injection)
+      // were matched with naive .includes(), so "this"/"list"/"registered" and
+      // "audits" falsely attached those concepts to ordinary nodes.
+      const node: GraphNode = {
+        id: "function:users:register",
+        type: "function",
+        name: "registerUser",
+        filePath: "src/users/register.ts",
+        summary: "This handler audits and returns a list of registered users",
+        tags: ["users"],
+        complexity: "moderate",
+      };
+      const concepts = detectLanguageConcepts(node, "typescript");
+      expect(concepts).not.toContain("type guards");
+      expect(concepts).not.toContain("dependency injection");
+    });
+
+    it("still detects a concept when a short keyword appears as a whole word", () => {
+      const node: GraphNode = {
+        id: "function:guards:isString",
+        type: "function",
+        name: "isString",
+        filePath: "src/guards.ts",
+        summary: "Returns true when the value is a string",
+        tags: ["guard"],
+        complexity: "simple",
+      };
+      const concepts = detectLanguageConcepts(node, "typescript");
+      expect(concepts).toContain("type guards");
+    });
   });
 });

--- a/understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts
+++ b/understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts
@@ -79,10 +79,11 @@ export function detectLanguageConcepts(
 
   const patterns = buildConceptPatterns(langConfig);
   const detected: string[] = [];
+  const lowerText = text.toLowerCase();
 
   for (const [concept, keywords] of Object.entries(patterns)) {
     const found = keywords.some((keyword) =>
-      text.toLowerCase().includes(keyword.toLowerCase()),
+      matchesKeyword(lowerText, keyword.toLowerCase()),
     );
     if (found) {
       detected.push(concept);
@@ -90,6 +91,19 @@ export function detectLanguageConcepts(
   }
 
   return detected;
+}
+
+/**
+ * Match a keyword against text, requiring a word boundary on any alphanumeric
+ * edge of the keyword. This stops short tokens like `is` (type guards) or `di`
+ * (dependency injection) from matching inside unrelated words ("this", "list",
+ * "discriminated"), while leaving symbol keywords like `@` matching anywhere.
+ */
+function matchesKeyword(text: string, keyword: string): boolean {
+  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const left = /^[a-z0-9]/.test(keyword) ? "(?:^|[^a-z0-9])" : "";
+  const right = /[a-z0-9]$/.test(keyword) ? "(?:$|[^a-z0-9])" : "";
+  return new RegExp(`${left}${escaped}${right}`).test(text);
 }
 
 /**


### PR DESCRIPTION
## What

`detectLanguageConcepts` falsely attaches concepts like **type guards** and **dependency injection** to ordinary nodes, because short keywords match inside unrelated words.

## Why

```ts
const found = keywords.some((keyword) =>
  text.toLowerCase().includes(keyword.toLowerCase()),
);
```

The concept keyword lists include very short tokens — `"is"` (for `type guards`) and `"di"` (for `dependency injection`):

```ts
"dependency injection": ["inject", "provider", "container", "di"],
"type guards": ["type guard", "is", "narrowing", "discriminated union"],
```

With a naive substring match, `"is"` matches inside `th**is**`, `l**is**t`, `reg**is**tered`, and `"di"` matches inside `au**di**ts`, `mo**di**fy`, etc. So a node summarised as *"This handler audits and returns a list of registered users"* is tagged with both `type guards` and `dependency injection`. Those false concepts are rendered in the dashboard **and** injected into the language-lesson LLM prompt as "detected concepts to explain".

## Fix

Match with a word boundary on any **alphanumeric edge** of the keyword. This stops `"is"`/`"di"` from matching inside words, while leaving symbol keywords like `"@"` (decorators) matching anywhere and keeping genuine whole-word matches (e.g. *"value is a string"* → `type guards`).

## Test

```
$ vitest run src/__tests__/language-lesson.test.ts
✓ 12 passed
  - "does not match short keywords inside unrelated words"   (fails against the previous code)
  - "still detects a concept when a short keyword appears as a whole word"
$ vitest run        # full core suite
✓ 672 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
