### PR TITLE
fix(php): capture file-scope calls and include/require imports (#367)

### DIFF
--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts
@@ -322,6 +322,28 @@ use App\\Models\\Post;
       tree.delete();
       parser.delete();
     });
+
+    it("extracts require_once / include dependencies as imports (#367)", () => {
+      const { tree, parser, root } = parse(`<?php
+require_once __DIR__ . '/helpers.php';
+include 'config.php';
+require 'bootstrap.php';
+include_once 'extra.php';
+`);
+      const result = extractor.extractStructure(root);
+
+      // Procedural PHP wires files together via include/require, not `use`.
+      // Dropping these leaves cross-file dependencies invisible (~0% coverage).
+      const sources = result.imports.map((i) => i.source);
+      expect(sources.some((s) => s.includes("helpers.php"))).toBe(true);
+      expect(sources.some((s) => s.includes("config.php"))).toBe(true);
+      expect(sources.some((s) => s.includes("bootstrap.php"))).toBe(true);
+      expect(sources.some((s) => s.includes("extra.php"))).toBe(true);
+      expect(result.imports).toHaveLength(4);
+
+      tree.delete();
+      parser.delete();
+    });
   });
 
   // ---- Exports ----
@@ -454,15 +476,39 @@ class Service {
       parser.delete();
     });
 
-    it("ignores top-level calls (no caller)", () => {
+    it("captures top-level (file-scope) calls under a synthetic caller (#367)", () => {
       const { tree, parser, root } = parse(`<?php
 echo "hello";
 main();
 `);
       const result = extractor.extractCallGraph(root);
 
-      // Top-level calls have no enclosing function, so they are skipped
-      expect(result).toHaveLength(0);
+      // Top-level calls have no enclosing function. Attribute them to a
+      // synthetic file-scope caller instead of dropping them — procedural PHP
+      // (scripts with no functions) would otherwise yield ~0% call coverage.
+      expect(result.some((e) => e.caller === "<file>" && e.callee === "main")).toBe(true);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("captures file-scope calls alongside in-function calls (#367)", () => {
+      const { tree, parser, root } = parse(`<?php
+require_once __DIR__ . '/helpers.php';
+function helper() { return 1; }
+helper();
+function caller() { helper(); }
+`);
+      const result = extractor.extractCallGraph(root);
+
+      // File-scope call: helper() at top level
+      expect(
+        result.some((e) => e.caller === "<file>" && e.callee === "helper"),
+      ).toBe(true);
+      // In-function call still works: caller() -> helper()
+      expect(
+        result.some((e) => e.caller === "caller" && e.callee === "helper"),
+      ).toBe(true);
 
       tree.delete();
       parser.delete();

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts
@@ -3,6 +3,20 @@ import type { LanguageExtractor, TreeSitterNode } from "./types.js";
 import { findChild, findChildren } from "./base-extractor.js";
 
 /**
+ * Synthetic caller name for calls made at file scope (outside any function or
+ * method). Used so procedural PHP scripts still produce call-graph edges.
+ */
+const FILE_SCOPE_CALLER = "<file>";
+
+/** PHP include/require expression node types (file-include dependencies). */
+const INCLUDE_EXPRESSION_TYPES = new Set([
+  "include_expression",
+  "include_once_expression",
+  "require_expression",
+  "require_once_expression",
+]);
+
+/**
  * Extract parameter names from a PHP `formal_parameters` node.
  *
  * Each child is a `simple_parameter` containing an optional type hint
@@ -174,6 +188,17 @@ export class PhpExtractor implements LanguageExtractor {
           this.extractUseDeclaration(node, imports);
           break;
 
+        case "expression_statement": {
+          // include/require expressions are wrapped in an expression_statement,
+          // e.g. `require_once __DIR__ . '/helpers.php';`. These wire files
+          // together in procedural PHP, so treat them as import edges (#367).
+          const includeExpr = this.findIncludeExpression(node);
+          if (includeExpr) {
+            this.extractIncludeDeclaration(includeExpr, imports);
+          }
+          break;
+        }
+
         case "namespace_definition": {
           // Block-scoped namespaces (`namespace Foo { ... }`) nest declarations
           // inside a compound_statement body. Declarative namespaces (`namespace Foo;`)
@@ -204,9 +229,15 @@ export class PhpExtractor implements LanguageExtractor {
         }
       }
 
-      // Extract call expressions
-      if (functionStack.length > 0) {
-        const caller = functionStack[functionStack.length - 1];
+      // Extract call expressions. Calls made outside any function/method are
+      // file-scope (top-level) calls — common in procedural PHP scripts. We
+      // attribute them to a synthetic `<file>` caller instead of dropping
+      // them, otherwise such scripts produce ~0% call-graph coverage (#367).
+      {
+        const caller =
+          functionStack.length > 0
+            ? functionStack[functionStack.length - 1]
+            : FILE_SCOPE_CALLER;
 
         if (node.type === "function_call_expression") {
           // Standalone function call: baz($x), strtoupper($x), error_log($msg)
@@ -405,6 +436,58 @@ export class PhpExtractor implements LanguageExtractor {
         }
       }
     }
+  }
+
+  /**
+   * Find an include/require expression directly inside an `expression_statement`.
+   * Returns null if the statement is not a file-include expression.
+   */
+  private findIncludeExpression(
+    statement: TreeSitterNode,
+  ): TreeSitterNode | null {
+    for (let i = 0; i < statement.childCount; i++) {
+      const child = statement.child(i);
+      if (child && INCLUDE_EXPRESSION_TYPES.has(child.type)) {
+        return child;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Extract an import edge from an include/require expression.
+   *
+   * The path argument follows the keyword and may be:
+   * - a string literal: `include 'config.php'`
+   * - an encapsed string: `require "bootstrap.php"`
+   * - a dynamic expression: `require_once __DIR__ . '/helpers.php'`
+   *
+   * For string literals we use the literal contents as the source; for dynamic
+   * expressions we fall back to the raw expression text so the dependency
+   * (e.g. `helpers.php`) remains visible.
+   */
+  private extractIncludeDeclaration(
+    includeExpr: TreeSitterNode,
+    imports: StructuralAnalysis["imports"],
+  ): void {
+    // The argument is the last child (the keyword token is first).
+    const argNode = includeExpr.child(includeExpr.childCount - 1);
+    if (!argNode) return;
+
+    let source: string;
+    if (argNode.type === "string" || argNode.type === "encapsed_string") {
+      const content = findChild(argNode, "string_content");
+      source = content ? content.text : argNode.text;
+    } else {
+      // Dynamic path (concatenation, variable, etc.) — keep the raw text.
+      source = argNode.text;
+    }
+
+    imports.push({
+      source,
+      specifiers: [],
+      lineNumber: includeExpr.startPosition.row + 1,
+    });
   }
 
   /**


### PR DESCRIPTION
## What

Fixes two gaps in the PHP extractor that left procedural PHP with ~0% call-graph and dependency coverage (#367).

1. **File-scope calls dropped.** `extractCallGraph` only recorded a call when it was lexically inside a function/method (`functionStack.length > 0`). Top-level calls — the norm in script/page-style PHP — were silently dropped. Now they are attributed to a synthetic `<file>` caller. In-function extraction is unchanged.
2. **include/require not mapped.** `extractStructure` recognized only `use` statements as imports. `include` / `include_once` / `require` / `require_once` — the actual dependency mechanism in non-namespaced/legacy PHP — produced no edges. Now they emit import edges: string-literal paths use the string contents; dynamic paths (e.g. `require_once __DIR__ . '/helpers.php'`) fall back to the raw expression text so the dependency stays visible.

## Why

On procedural PHP codebases, file→file and call edges were almost entirely absent even though the tree-sitter parse succeeds, and the LLM layer does not recover them. See #367 for measurements (page files: ~645–1218 real call sites, 0 captured).

## Tests

Added RED→GREEN tests in `php-extractor.test.ts` (real `tree-sitter-php` wasm grammar): file-scope calls under `<file>`, file-scope + in-function calls together, and include/require dependency extraction. Full core suite 672/672 pass; lint and `tsc --noEmit` clean.

## Note for maintainers

The other language extractors still gate call recording on an enclosing function and drop file-scope calls. This PR changes only PHP, where procedural code is dominant; happy to generalize the `<file>` convention to other extractors in a follow-up if you'd prefer it project-wide.

---
Submitted by @Brentbin; AI-assisted with Claude Code and reviewed before submission.