### PR TITLE
fix(skill): bypass host packageManager pin in Phase 0 build (#315)

### DIFF
--- a/understand-anything-plugin/package.json
+++ b/understand-anything-plugin/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b",
   "scripts": {
     "build": "tsc",
     "test": "node -e \"console.log('skill tests live at <repo-root>/tests/skill — run via root \\`pnpm test\\`')\""

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -114,9 +114,13 @@ Determine whether to run a full analysis or incremental update.
    fi
 
    if [ ! -f "$PLUGIN_ROOT/packages/core/dist/index.js" ]; then
-     cd "$PLUGIN_ROOT" && (pnpm install --frozen-lockfile 2>/dev/null || pnpm install) && pnpm --filter @understand-anything/core build
+     (cd "$PLUGIN_ROOT" && COREPACK_ENABLE_PROJECT_SPEC=0 pnpm install --frozen-lockfile 2>/dev/null \
+       || (cd "$PLUGIN_ROOT" && COREPACK_ENABLE_PROJECT_SPEC=0 pnpm install)) \
+       && (cd "$PLUGIN_ROOT" && COREPACK_ENABLE_PROJECT_SPEC=0 pnpm --filter @understand-anything/core build)
    fi
    ```
+
+   **Why the subshell + `COREPACK_ENABLE_PROJECT_SPEC=0`?** When `/understand` runs from a host project whose `package.json` pins `"packageManager": "yarn@x"` or `"npm@x"`, corepack reads the **shell CWD's** `packageManager` field (not the `-C` / `--dir` target) and refuses to launch pnpm — failing the build with errors like `This project is configured to use yarn`. The fix is two-pronged: (1) `cd "$PLUGIN_ROOT"` inside a subshell so corepack's CWD-based lookup hits the plugin's own `packageManager` pin (`pnpm@…`); (2) `COREPACK_ENABLE_PROJECT_SPEC=0` to disable corepack's project-spec enforcement entirely as a belt-and-suspenders backstop in case the plugin's `packageManager` field is missing or stripped (e.g., during installation). Do **not** simplify this to `pnpm -C "$PLUGIN_ROOT" install` — `pnpm -C` does not change the CWD that corepack inspects, so the host pin still wins and the build still fails. See issue #315.
 
    If `pnpm` is missing, report to the user: "Install Node.js ≥ 22 and pnpm ≥ 10, then re-run `/understand`."
 


### PR DESCRIPTION
## Summary

Closes #315.

When `/understand` runs from a host project whose `package.json` pins `"packageManager": "yarn@x"` or `"npm@x"`, corepack reads the **shell CWD's** pin (not pnpm's `-C` / `--dir` target) and refuses to launch pnpm — failing the Phase 0 plugin build before any analysis can begin.

- **SKILL.md Phase 0** — wrap each pnpm invocation in `(cd "$PLUGIN_ROOT" && COREPACK_ENABLE_PROJECT_SPEC=0 pnpm …)`. The subshell `cd` makes corepack's CWD-based lookup hit the plugin's own `packageManager` pin; the env var disables corepack project-spec enforcement entirely as a backstop. Added a maintainer note inline so future cleanups don't strip the guards.
- **understand-anything-plugin/package.json** — add the same `"packageManager": "pnpm@10.6.2+sha512.…"` value used by the root `package.json`, so corepack inside the plugin dir always picks pnpm (e.g., when running from the marketplace cache copy where the root `package.json` isn't a parent).
- **pnpm-lock.yaml** — regenerate. The shipped lockfile was missing the `graphology` / `graphology-communities-louvain` importer entries (added in earlier PRs to the plugin's `package.json`) plus a stale `vite` pin in the dashboard workspace, so `pnpm install --frozen-lockfile` was already failing with `ERR_PNPM_OUTDATED_LOCKFILE` before the corepack issue could even surface — the issue's second papercut.

## Test plan

- [x] `pnpm install --frozen-lockfile` from `understand-anything-plugin/` succeeds (was failing before with `ERR_PNPM_OUTDATED_LOCKFILE`).
- [x] `pnpm --filter @understand-anything/core build` from `understand-anything-plugin/` succeeds.
- [ ] Manual repro: run `/understand` from a project whose `package.json` pins `"packageManager": "yarn@4.x"` and confirm Phase 0 build no longer fails with `This project is configured to use yarn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)