### PR TITLE
docs(skill): recommend cost-tier model per phase (#314)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,21 @@ The `/understand` command orchestrates 5 specialized agents, and `/understand-do
 
 File analyzers run in parallel (up to 5 concurrent, 20-30 files per batch). Supports incremental updates — only re-analyzes files that changed since the last run.
 
+### Model cost tiers (per phase)
+
+Not every phase needs the strongest model. `file-analyzer` fans out across every batch (dozens to hundreds of dispatches on a real codebase) and does mostly templated work on top of tree-sitter facts the bundled scripts already extracted — defaulting it to the same model as the rare synthesis steps (`architecture-analyzer`, `tour-builder`) drains premium budgets disproportionately (issue [#314](https://github.com/Lum1104/Understand-Anything/issues/314)).
+
+| Agent | Suggested tier | Why |
+|---|---|---|
+| `project-scanner` | Cheap / mid (Haiku · Sonnet) | Mostly deterministic; LLM just writes a short narrative blurb from README + manifest |
+| `file-analyzer` (**high fan-out**) | Cheap / mid (Haiku · Sonnet) | Largest cost lever — one dispatch per batch, templated outputs grounded in pre-extracted structure |
+| `assemble-reviewer` | Mid (Sonnet) | One dispatch; reviews already-merged graph |
+| `architecture-analyzer` | Strong (Opus) | One dispatch; synthesis over the whole graph |
+| `tour-builder` | Strong (Opus) | One dispatch; pedagogy over the whole graph |
+| `graph-reviewer` (only with `--review`) | Mid / strong | Default path uses a deterministic Node script — most runs never invoke the LLM here |
+
+These recommendations live in [`understand/SKILL.md`](understand-anything-plugin/skills/understand/SKILL.md#model-cost-tier-recommendations-per-phase) (and as inline reminders at each phase's dispatch step) rather than in agent frontmatter, because `model:` in frontmatter is platform-specific — `model: inherit` was a Claude Code-only keyword that broke opencode and other orchestrators (issue [#167](https://github.com/Lum1104/Understand-Anything/issues/167), PR [#200](https://github.com/Lum1104/Understand-Anything/pull/200)). Orchestrators that support per-dispatch model selection are expected to apply the table above; platforms that cannot route per-agent fall back to the session model with no behaviour change.
+
 ---
 
 ## 🎥 Community

--- a/understand-anything-plugin/skills/understand-knowledge/SKILL.md
+++ b/understand-anything-plugin/skills/understand-knowledge/SKILL.md
@@ -51,6 +51,8 @@ No additional scanning is needed. Proceed to Phase 3.
 
 ### Phase 3: ANALYZE
 
+> **Cost tier:** Cheap (Haiku) or mid (Sonnet). This is a high-fan-out phase — one dispatch per batch of 10-15 articles, with up to 3 concurrent. Each dispatch performs structured extraction (entities/claims/implicit links) over preprocessed content, so the LLM workload per dispatch is modest. Reserve the strongest model for one-shot synthesis steps in other skills (e.g., `architecture-analyzer`, `tour-builder`). See `skills/understand/SKILL.md` "Model Cost-Tier Recommendations" for the rationale and the constraint that prevents us from encoding this in agent frontmatter (issues #167, #314).
+
 Dispatch `article-analyzer` subagents to extract implicit knowledge:
 
 1. Read the scan-manifest.json to get the article list

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -20,6 +20,44 @@ Analyze the current codebase and produce a `knowledge-graph.json` file in `.unde
 
 ---
 
+## Model Cost-Tier Recommendations (per-phase)
+
+This pipeline is a mix of high-fan-out, largely-deterministic phases (where every dispatch piles onto premium-model spend with little marginal quality benefit) and low-fan-out, synthesis-heavy phases (where the strongest model materially improves the output). When the orchestrator (Claude Code, opencode, codex, etc.) supports per-dispatch model selection, prefer the cost tier below.
+
+> **Why this lives in SKILL.md and not in agent frontmatter.** A `model:` field in an agent's frontmatter would be the cleanest place for this, but `model: inherit` was a Claude Code-only keyword that broke opencode and similar orchestrators with `ProviderModelNotFoundError` (issue #167, PR #200). To stay portable across every supported platform, agent frontmatter intentionally omits `model:` so each platform falls back to its configured default. These recommendations are therefore advisory — the orchestrator is expected to apply them when dispatching, and platforms that cannot route per-agent simply fall back to the session model with no behaviour change.
+>
+> See also issue #314 — high-fan-out `file-analyzer` dispatches were the original motivation for this guidance.
+
+| Phase | Agent | Suggested tier | Why |
+|---|---|---|---|
+| 1 | `project-scanner` | Cheap (Haiku) or mid (Sonnet) | Mostly deterministic — runs `scan-project.mjs` + `extract-import-map.mjs`; LLM only writes a short narrative `name`/`description`/`frameworks` blurb from README + manifest. |
+| 2 | `file-analyzer` (**high fan-out — dozens to hundreds per run**) | Cheap (Haiku) or mid (Sonnet) | Dispatched once per batch with up to 5 concurrent. Phase 1.5 + the bundled `extract-structure.mjs` already give it the import map and tree-sitter facts; the LLM emits templated summaries/tags/edges. This is the single biggest cost lever — defaulting it to Opus drains premium budgets disproportionately. |
+| 3 | `assemble-reviewer` | Mid (Sonnet) | Reviews already-merged graph for residual issues the merge script can't catch. One dispatch. |
+| 4 | `architecture-analyzer` | Strong (Opus) | One dispatch, synthesis-heavy: looks across the whole graph to decide layer boundaries. Quality here propagates everywhere. |
+| 5 | `tour-builder` | Strong (Opus) | One dispatch, pedagogy-heavy: needs to weave a narrative across the full graph. |
+| 6 | `graph-reviewer` (only with `--review`) | Mid (Sonnet) or Strong (Opus) | One dispatch. Default path uses a deterministic Node script and skips the LLM entirely. |
+
+**Inline reminders** appear next to each phase's dispatch step below — search for "Cost tier:".
+
+**Config-level opt-in (future / not yet wired):** A future iteration may honour a `models` map in `.understand-anything/config.json` of the form below; this PR is documentation-only and does not wire it into the runtime. Recording the shape now so downstream tooling can converge on it:
+
+```json
+{
+  "models": {
+    "project-scanner": "haiku",
+    "file-analyzer": "haiku",
+    "assemble-reviewer": "sonnet",
+    "architecture-analyzer": "opus",
+    "tour-builder": "opus",
+    "graph-reviewer": "sonnet"
+  }
+}
+```
+
+Until the runtime reads this field, treat the table above as guidance for the orchestrator's per-dispatch routing.
+
+---
+
 ## Progress Reporting
 
 Throughout execution, report progress to the user at each phase transition and during batch processing. This keeps users informed on large codebases where analysis can take a long time.
@@ -236,6 +274,8 @@ Set up and verify the `.understandignore` file before scanning.
 
 Report to the user: `[Phase 1/7] Scanning project files...`
 
+> **Cost tier:** Cheap (Haiku) or mid (Sonnet). Most of project-scanner's work is deterministic (bundled `scan-project.mjs` + `extract-import-map.mjs`); the LLM only writes a short narrative from README + manifest. See "Model Cost-Tier Recommendations" above.
+
 Dispatch a subagent using the `project-scanner` agent definition (at `agents/project-scanner.md`). Append the following additional context:
 
 > **Additional context from main session:**
@@ -301,6 +341,8 @@ If the script exits non-zero, the failure is hard — relay the full stderr to t
 Load `.understand-anything/intermediate/batches.json` (produced by Phase 1.5). Iterate the `batches[]` array.
 
 Report: `[Phase 2/7] Analyzing files — <totalFiles> files in <totalBatches> batches (up to 5 concurrent)...`
+
+> **Cost tier:** Cheap (Haiku) or mid (Sonnet). **This is the highest fan-out phase in the entire pipeline** — one dispatch per batch, with dozens-to-hundreds of dispatches on a real codebase. Phase 1.5 + bundled `extract-structure.mjs` already give the analyzer the import map and tree-sitter facts; the LLM emits templated summaries/tags/edges. Routing every analyzer to the strongest model drains premium budgets disproportionately (issue #314). Reserve the strongest model for Phase 4 (`architecture-analyzer`) and Phase 5 (`tour-builder`).
 
 For each batch, dispatch a subagent using the `file-analyzer` agent definition (at `agents/file-analyzer.md`). Run up to **5 subagents concurrently**. Append the following additional context:
 
@@ -392,6 +434,8 @@ After batches complete:
 
 Report to the user: `[Phase 3/7] Reviewing assembled graph...`
 
+> **Cost tier:** Mid (Sonnet). One dispatch — review of the already-merged graph for residual issues the merge script can't catch.
+
 Dispatch a subagent using the `assemble-reviewer` agent definition (at `agents/assemble-reviewer.md`).
 
 Pass these parameters in the dispatch prompt:
@@ -418,6 +462,8 @@ After the subagent completes, read `$PROJECT_ROOT/.understand-anything/intermedi
 ## Phase 4 — ARCHITECTURE
 
 Report to the user: `[Phase 4/7] Identifying architectural layers...`
+
+> **Cost tier:** Strong (Opus or equivalent). One dispatch — synthesis-heavy: looks across the whole graph to decide layer boundaries. Quality here propagates to the dashboard layout, tour structure, and every downstream consumer of the graph.
 
 **Build the combined prompt template:**
  1. Use the `architecture-analyzer` agent definition (at `agents/architecture-analyzer.md`).
@@ -501,6 +547,8 @@ All four fields (`id`, `name`, `description`, `nodeIds`) are required.
 ## Phase 5 — TOUR
 
 Report to the user: `[Phase 5/7] Building guided tour...`
+
+> **Cost tier:** Strong (Opus or equivalent). One dispatch — pedagogy-heavy: needs to weave a narrative across the full graph and pick the right 5-15 nodes for a newcomer's mental model.
 
 Dispatch a subagent using the `tour-builder` agent definition (at `agents/tour-builder.md`). Append the following additional context:
 
@@ -692,6 +740,8 @@ If the script exits non-zero, read stderr, fix the script, and retry once.
 ---
 
 #### `--review` path: full LLM reviewer
+
+> **Cost tier:** Mid (Sonnet) or strong (Opus). One dispatch and only when the user explicitly asks for `--review`. The default path uses a deterministic Node script and skips the LLM entirely, so most runs never pay this cost.
 
 If `--review` IS in `$ARGUMENTS`, dispatch the LLM graph-reviewer subagent as follows:
 


### PR DESCRIPTION
## Summary

Closes #314.

`/understand` Phase 2 fans out one `file-analyzer` subagent per batch — dozens-to-hundreds per run. When the session model is Opus, every analyzer inherits it and drains premium budgets even though the analyzer's work is largely deterministic (it runs the bundled `extract-structure.mjs` + emits templated summaries on top of tree-sitter facts). The strongest model only materially helps on the rare synthesis-heavy single-dispatch phases (`architecture-analyzer`, `tour-builder`).

### Why this is a docs change, not an agent-frontmatter change

The cleanest fix would be a per-agent `model:` frontmatter field, but that path is blocked by an existing portability constraint documented in CLAUDE.md:

> Agent `model` field is omitted from frontmatter so each platform falls back to its configured default — `inherit` was a Claude Code-only keyword that opencode (and similar tools) treated as a literal model id and rejected with `ProviderModelNotFoundError` (see #167).

So this PR is documentation-first. Orchestrators that support per-dispatch model selection are expected to apply the table; platforms that cannot route per-agent fall back to the session model with no behaviour change.

### Per-phase recommendations introduced

| Phase | Agent | Suggested tier |
|---|---|---|
| 1 | `project-scanner` | Cheap (Haiku) or mid (Sonnet) |
| 2 | `file-analyzer` (high fan-out) | Cheap (Haiku) or mid (Sonnet) |
| 3 | `assemble-reviewer` | Mid (Sonnet) |
| 4 | `architecture-analyzer` | Strong (Opus) |
| 5 | `tour-builder` | Strong (Opus) |
| 6 | `graph-reviewer` (only with `--review`) | Mid (Sonnet) or Strong (Opus) |

### Files changed

- `understand-anything-plugin/skills/understand/SKILL.md` — new "Model Cost-Tier Recommendations" section with rationale, table, and a future-shape sketch for a `config.json` `models` map (not wired into the runtime). Inline "Cost tier:" reminders at every phase dispatch step.
- `understand-anything-plugin/skills/understand-knowledge/SKILL.md` — Phase 3 (`article-analyzer`) gains the same hint; this is the other high-fan-out phase in the plugin.
- `README.md` — "Multi-Agent Pipeline" section gains a "Model cost tiers (per phase)" subsection with the table and cross-link to SKILL.md, plus the opencode-portability rationale.

### What this PR does **not** do

- No agent frontmatter is modified — `agents/*.md` files are untouched.
- No runtime model-selection plumbing is added. The `config.json` `models` map shape is documented as a future opt-in only.

## Test plan

- [x] Verified `grep -n "^model:" understand-anything-plugin/agents/*.md` returns no matches (the opencode portability constraint is preserved).
- [x] Diff scope confirmed: only `README.md`, `understand/SKILL.md`, `understand-knowledge/SKILL.md`.
- [ ] Maintainer sanity-check: does the recommended tier mapping match how you'd want orchestrators to route?