### PR TITLE
fix(install): resolve Codex agents path on Windows (#340)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -26,12 +26,18 @@ $RepoUrl    = if ($env:UA_REPO_URL) { $env:UA_REPO_URL } else { 'https://github.
 $RepoDir    = if ($env:UA_DIR)      { $env:UA_DIR }      else { Join-Path $HOME '.understand-anything\repo' }
 $PluginLink = Join-Path $HOME '.understand-anything-plugin'
 
-# Platform table — Target = skills directory; Style = "per-skill" | "folder"
+# Platform table — Target = skills directory; Style = "per-skill" | "folder";
+# ExtraPluginLink = optional second plugin-root junction. The skills' SKILL.md
+# resolves the plugin root via a fallback chain that includes vendor-specific
+# locations (e.g. $HOME/.codex/understand-anything/understand-anything-plugin)
+# in addition to the universal $HOME/.understand-anything-plugin. Hosts that do
+# not auto-traverse the universal junction on Windows (issue #340) still find
+# the plugin via this vendor-specific path.
 $Platforms = [ordered]@{
     gemini      = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
-    codex       = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
-    opencode    = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
-    pi          = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
+    codex       = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill'; ExtraPluginLink = (Join-Path $HOME '.codex\understand-anything\understand-anything-plugin') }
+    opencode    = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill'; ExtraPluginLink = (Join-Path $HOME '.opencode\understand-anything\understand-anything-plugin') }
+    pi          = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill'; ExtraPluginLink = (Join-Path $HOME '.pi\understand-anything\understand-anything-plugin') }
     openclaw    = @{ Target = (Join-Path $HOME '.openclaw\skills');           Style = 'folder' }
     antigravity = @{ Target = (Join-Path $HOME '.gemini\antigravity\skills'); Style = 'folder' }
     vscode      = @{ Target = (Join-Path $HOME '.copilot\skills');            Style = 'per-skill' }
@@ -198,6 +204,25 @@ function ConvertTo-FileUri([string]$Path) {
     return 'file:///' + ($Path -replace '\\', '/')
 }
 
+function Link-Extra-Plugin-Root([string]$LinkPath) {
+    # Mirror the universal plugin junction at a vendor-specific path that the
+    # SKILL.md fallback chain already probes (e.g.
+    # $HOME/.codex/understand-anything/understand-anything-plugin). This makes
+    # the plugin discoverable to hosts whose Windows runtime does not auto-
+    # traverse the universal $HOME/.understand-anything-plugin junction (see
+    # issue #340).
+    if (-not $LinkPath) { return }
+    if (Test-Path $LinkPath) {
+        Write-Host "  • $LinkPath already exists, leaving as-is"
+        return
+    }
+    $parent = Split-Path -Parent $LinkPath
+    if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Path $parent | Out-Null }
+    $src = Join-Path $RepoDir 'understand-anything-plugin'
+    New-Item -ItemType Junction -Path $LinkPath -Target $src | Out-Null
+    Write-Host "  ✓ $LinkPath → $src"
+}
+
 function Cmd-Install([string]$Id) {
     $cfg = Resolve-Platform $Id
     Clone-Or-Update
@@ -205,6 +230,10 @@ function Cmd-Install([string]$Id) {
     Link-Skills $cfg.Target $cfg.Style
     Write-Host '→ Linking universal plugin root'
     Link-Plugin-Root
+    if ($cfg.Contains('ExtraPluginLink') -and $cfg.ExtraPluginLink) {
+        Write-Host "→ Linking vendor-specific plugin root for $Id"
+        Link-Extra-Plugin-Root $cfg.ExtraPluginLink
+    }
 
     if ($Id -eq 'kiro') {
         Write-Host '→ Creating Kiro agent configuration'
@@ -256,6 +285,11 @@ function Cmd-Uninstall([string]$Id) {
     }
     if (Remove-Reparse $PluginLink) {
         Write-Host "  ✓ removed $PluginLink"
+    }
+    if ($cfg.Contains('ExtraPluginLink') -and $cfg.ExtraPluginLink) {
+        if (Remove-Reparse $cfg.ExtraPluginLink) {
+            Write-Host "  ✓ removed $($cfg.ExtraPluginLink)"
+        }
     }
     if (Test-Path $RepoDir) {
         Write-Host "`nThe checkout at $RepoDir was kept (other platforms may still use it)."

--- a/understand-anything-plugin/hooks/auto-update-prompt.md
+++ b/understand-anything-plugin/hooks/auto-update-prompt.md
@@ -157,7 +157,7 @@ Only re-analyze files with structural changes. This is the **only** phase that c
 
 2. Batch the files from `filesToReanalyze` (from Phase 1). Use a single batch if ≤10 files, otherwise batch into groups of 5-10.
 
-3. For each batch, dispatch a subagent using the `file-analyzer` agent definition (at `agents/file-analyzer.md`). Append:
+3. For each batch, dispatch a subagent using the `file-analyzer` agent definition (at `$PLUGIN_ROOT/agents/file-analyzer.md`, using the `$PLUGIN_ROOT` resolved in Phase 0 step 9). Append:
 
    > **Additional context from main session:**
    >
@@ -200,7 +200,7 @@ Only re-analyze files with structural changes. This is the **only** phase that c
 
 If the change analysis flagged `ARCHITECTURE_UPDATE`:
 
-1. Dispatch a subagent using the `architecture-analyzer` agent definition (at `agents/architecture-analyzer.md`), passing the full merged node set and import edges. Include previous layer definitions for naming consistency:
+1. Dispatch a subagent using the `architecture-analyzer` agent definition (at `$PLUGIN_ROOT/agents/architecture-analyzer.md`, using the `$PLUGIN_ROOT` resolved in Phase 0 step 9), passing the full merged node set and import edges. Include previous layer definitions for naming consistency:
 
    > Previous layer definitions (for naming consistency):
    > ```json

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -120,6 +120,8 @@ Determine whether to run a full analysis or incremental update.
 
    If `pnpm` is missing, report to the user: "Install Node.js ≥ 22 and pnpm ≥ 10, then re-run `/understand`."
 
+   **Use `$PLUGIN_ROOT` for every agent-definition reference in subsequent phases.** All `agents/<name>.md` paths below are shorthand for `$PLUGIN_ROOT/agents/<name>.md`. On hosts that don't auto-resolve relative paths to the plugin tree (e.g. Codex CLI on Windows, where the `~/.understand-anything-plugin` junction is not implicitly traversed — see issue #340), always prefix agent reads with the resolved `$PLUGIN_ROOT` from above so the dispatcher receives an absolute path. Bare `agents/<name>.md` is not portable across all platforms.
+
 2. Get the current git commit hash:
    ```bash
    git rev-parse HEAD
@@ -218,7 +220,7 @@ Set up and verify the `.understandignore` file before scanning.
 
 Report to the user: `[Phase 1/7] Scanning project files...`
 
-Dispatch a subagent using the `project-scanner` agent definition (at `agents/project-scanner.md`). Append the following additional context:
+Dispatch a subagent using the `project-scanner` agent definition (at `$PLUGIN_ROOT/agents/project-scanner.md`). Append the following additional context:
 
 > **Additional context from main session:**
 >
@@ -284,7 +286,7 @@ Load `.understand-anything/intermediate/batches.json` (produced by Phase 1.5). I
 
 Report: `[Phase 2/7] Analyzing files — <totalFiles> files in <totalBatches> batches (up to 5 concurrent)...`
 
-For each batch, dispatch a subagent using the `file-analyzer` agent definition (at `agents/file-analyzer.md`). Run up to **5 subagents concurrently**. Append the following additional context:
+For each batch, dispatch a subagent using the `file-analyzer` agent definition (at `$PLUGIN_ROOT/agents/file-analyzer.md`). Run up to **5 subagents concurrently**. Append the following additional context:
 
 > **Additional context from main session:**
 >
@@ -374,7 +376,7 @@ After batches complete:
 
 Report to the user: `[Phase 3/7] Reviewing assembled graph...`
 
-Dispatch a subagent using the `assemble-reviewer` agent definition (at `agents/assemble-reviewer.md`).
+Dispatch a subagent using the `assemble-reviewer` agent definition (at `$PLUGIN_ROOT/agents/assemble-reviewer.md`).
 
 Pass these parameters in the dispatch prompt:
 
@@ -402,7 +404,7 @@ After the subagent completes, read `$PROJECT_ROOT/.understand-anything/intermedi
 Report to the user: `[Phase 4/7] Identifying architectural layers...`
 
 **Build the combined prompt template:**
- 1. Use the `architecture-analyzer` agent definition (at `agents/architecture-analyzer.md`).
+ 1. Use the `architecture-analyzer` agent definition (at `$PLUGIN_ROOT/agents/architecture-analyzer.md`).
  2. **Language context injection:** For each language detected in Phase 1 (e.g., `python`, `markdown`, `dockerfile`, `yaml`, `sql`, `terraform`, `graphql`, `protobuf`, `shell`, `html`, `css`), read the file at `./languages/<language-id>.md` (e.g., `./languages/python.md`, `./languages/dockerfile.md`) and append its content after the base template under a `## Language Context` header. If the file does not exist for a detected language, skip it silently and continue. These files are in the `languages/` subdirectory next to this SKILL.md file. **Include non-code language snippets** — they provide edge patterns and summary styles for non-code files.
  3. **Framework addendum injection:** For each framework detected in Phase 1 (e.g., `Django`), read the file at `./frameworks/<framework-id-lowercase>.md` (e.g., `./frameworks/django.md`) and append its full content after the language context. If the file does not exist for a detected framework, skip it silently and continue. These files are in the `frameworks/` subdirectory next to this SKILL.md file.
  4. **Output locale injection:** If `$OUTPUT_LANGUAGE` is NOT `en` (English), read the locale guidance file at `./locales/<language-code>.md` (e.g., `./locales/zh.md`, `./locales/ja.md`, `./locales/ko.md`) and append its content after the framework addendums under a `## Output Language Guidelines` header. This provides language-specific guidance for tag naming conventions, summary style, and layer name translations. If the locale file does not exist for the specified language, skip silently — the `$LANGUAGE_DIRECTIVE` still applies. These files are in the `locales/` subdirectory next to this SKILL.md file.
@@ -484,7 +486,7 @@ All four fields (`id`, `name`, `description`, `nodeIds`) are required.
 
 Report to the user: `[Phase 5/7] Building guided tour...`
 
-Dispatch a subagent using the `tour-builder` agent definition (at `agents/tour-builder.md`). Append the following additional context:
+Dispatch a subagent using the `tour-builder` agent definition (at `$PLUGIN_ROOT/agents/tour-builder.md`). Append the following additional context:
 
 > **Additional context from main session:**
 >
@@ -677,7 +679,7 @@ If the script exits non-zero, read stderr, fix the script, and retry once.
 
 If `--review` IS in `$ARGUMENTS`, dispatch the LLM graph-reviewer subagent as follows:
 
-Dispatch a subagent using the `graph-reviewer` agent definition (at `agents/graph-reviewer.md`). Append the following additional context:
+Dispatch a subagent using the `graph-reviewer` agent definition (at `$PLUGIN_ROOT/agents/graph-reviewer.md`). Append the following additional context:
 
 > **Additional context from main session:**
 >


### PR DESCRIPTION
## Summary

Closes #340.

On Windows + Codex CLI, `/understand` fails to dispatch its subagents because the relative `agents/<name>.md` paths emitted by the skill aren't auto-resolved to `~/.understand-anything-plugin/agents/<name>.md`. The reporter confirmed the agents load when the full path is typed manually, so the underlying junction is fine — it's the implicit path resolution that breaks.

This PR ships a two-pronged, defensive fix:

1. **`understand-anything-plugin/skills/understand/SKILL.md` + `hooks/auto-update-prompt.md`:** every `agents/<name>.md` reference now reads `$PLUGIN_ROOT/agents/<name>.md`, using the plugin-root variable that the SKILL.md already resolves in Phase 0 step 1.5. This mirrors the pattern already used in `understand-domain/SKILL.md` ("Read the domain-analyzer agent prompt from `$PLUGIN_ROOT/agents/domain-analyzer.md`") and gives every host — Claude Code, Codex, opencode, gemini, pi, anything else — an unambiguous absolute path, so it no longer matters whether the host auto-traverses the universal junction.

2. **`install.ps1` only:** for the `codex`, `opencode`, and `pi` platforms, also create a vendor-specific plugin-root junction (e.g. `~/.codex/understand-anything/understand-anything-plugin`). These paths are already in the SKILL.md fallback chain, so even on the worst-case Windows host that won't traverse `~/.understand-anything-plugin`, the plugin is still discoverable through the vendor-specific junction. POSIX symlinks already resolve the universal junction correctly, so `install.sh` is intentionally untouched — the SKILL.md change is the symmetric fix that helps every platform equally.

## Diagnosis

`/understand`'s SKILL.md resolves a `$PLUGIN_ROOT` via a bash chain that probes `$CLAUDE_PLUGIN_ROOT`, `~/.understand-anything-plugin`, `~/.agents/skills/understand/../..` (after `realpath`), and several vendor-specific paths. Once resolved, subsequent phases used to say:

> Dispatch a subagent using the `project-scanner` agent definition (at `agents/project-scanner.md`).

That bare `agents/...` reference is what hosts have to guess at. On Claude Code the runtime knows the plugin layout and finds it. On Codex Linux/macOS the LLM appears to chase the `$PLUGIN_ROOT` variable and read `$PLUGIN_ROOT/agents/...` anyway. On Codex Windows the path stays unresolved relative to whatever the host's notion of cwd is, the read fails, and dispatch silently drops. Making the absolute path explicit removes the guess.

## Why install.ps1 also changed

I want a belt-and-suspenders mitigation for Windows users. Even with the SKILL.md fix, the plugin-root resolution chain itself depends on bash (`realpath`, `readlink -f`, `$()` substitution). If a Windows host doesn't run bash at all and only the universal `~/.understand-anything-plugin` junction is created, and the host happens to also refuse to traverse it, the fallback chain has nothing left to try. Mirroring the junction at `~/.codex/understand-anything/understand-anything-plugin` (which is already in the fallback chain) adds another lifeline.

## What I could verify (and what I couldn't)

I'm developing on macOS, so I cannot reproduce the Windows + Codex symptom directly. What I did verify:

- `install.ps1` parses as valid PowerShell (manual review — `pwsh` is not installed on this machine). The new `Link-Extra-Plugin-Root` helper uses standard `Test-Path` / `Split-Path` / `New-Item` calls and reuses the existing `Remove-Reparse` for uninstall. The `$cfg.Contains('ExtraPluginLink') -and $cfg.ExtraPluginLink` guard is short-circuited so the `.ExtraPluginLink` access never runs when the key is missing.
- All `agents/<name>.md` references in dispatch context were updated; only two intentional doc cross-references remain (`auto-update-prompt.md:40` describes "same semantics as Step 2.5 in agents/project-scanner.md" and `extract-import-map.mjs:11` is a comment about prior prose docs) — neither is a dispatch path.
- `pnpm lint` is clean.
- No version bump (per the PR template — internal/install-fix, no user-visible behavior change in the dashboard or skill output).

What I cannot verify from macOS:
- Whether the SKILL.md change alone is enough on Windows + Codex.
- Whether the new vendor-specific junction actually gets picked up by Codex on Windows.

**Asking the reporter (and any Windows Codex users):** please re-run the installer (`iwr -useb https://raw.githubusercontent.com/tirth8205/Understand-Anything/fix/windows-codex-agents-path/install.ps1 | iex`, then `./install.ps1 codex`), verify that the new junction at `~/.codex/understand-anything/understand-anything-plugin` exists, then run `$understand-anything:understand --language en --full` and confirm the agent definitions load without specifying the full path.

## Linked issue

- Closes #340

## How I tested this

- [x] `pnpm lint` (clean)
- [x] Diff review of all `agents/<name>.md` references — every dispatch now uses `$PLUGIN_ROOT/agents/<name>.md`
- [x] Manual PowerShell review of `install.ps1` (no `pwsh` available locally to parse)
- [ ] **Needs Windows verification** — reporter, please confirm

## Versioning

- [ ] Version bumped in all five manifests, OR
- [x] N/A — internal/docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)