### PR TITLE
fix(compute-batches): emit knownCrossBatchNodeIds so doc-batches use correct prefixes (#303)

### DIFF
--- a/tests/skill/understand/fixtures/scan-result-known-cross-batch-ids.json
+++ b/tests/skill/understand/fixtures/scan-result-known-cross-batch-ids.json
@@ -1,0 +1,35 @@
+{
+  "name": "fixture-known-cross-batch-ids",
+  "description": "Multi-batch input exercising knownCrossBatchNodeIds: one code clique (3 mutually-importing TS files survives merge-small) + a Dockerfile cluster (infra → service:) + .github/workflows/* (infra → pipeline:) + a docs/ batch (docs → document:) so each batch's knownCrossBatchNodeIds covers the other batches' IDs with the correct per-category prefix. Mirrors the issue #303 scenario where a docs batch needs to emit edges to non-docs files with the right prefix.",
+  "languages": ["typescript", "dockerfile", "yaml", "markdown"],
+  "frameworks": [],
+  "files": [
+    {"path": "src/index.ts", "language": "typescript", "sizeLines": 10, "fileCategory": "code"},
+    {"path": "src/server.ts", "language": "typescript", "sizeLines": 15, "fileCategory": "code"},
+    {"path": "src/router.ts", "language": "typescript", "sizeLines": 12, "fileCategory": "code"},
+    {"path": "Dockerfile", "language": "dockerfile", "sizeLines": 20, "fileCategory": "infra"},
+    {"path": "docker-compose.yml", "language": "yaml", "sizeLines": 15, "fileCategory": "infra"},
+    {"path": ".github/workflows/ci.yml", "language": "yaml", "sizeLines": 30, "fileCategory": "infra"},
+    {"path": ".github/workflows/deploy.yml", "language": "yaml", "sizeLines": 25, "fileCategory": "infra"},
+    {"path": "README.md", "language": "markdown", "sizeLines": 100, "fileCategory": "docs"},
+    {"path": "CLAUDE.md", "language": "markdown", "sizeLines": 80, "fileCategory": "docs"},
+    {"path": "docs/getting-started.md", "language": "markdown", "sizeLines": 60, "fileCategory": "docs"},
+    {"path": "tsconfig.json", "language": "json", "sizeLines": 15, "fileCategory": "config"}
+  ],
+  "totalFiles": 11,
+  "filteredByIgnore": 0,
+  "estimatedComplexity": "small",
+  "importMap": {
+    "src/index.ts": ["src/server.ts", "src/router.ts"],
+    "src/server.ts": ["src/router.ts"],
+    "src/router.ts": [],
+    "Dockerfile": [],
+    "docker-compose.yml": [],
+    ".github/workflows/ci.yml": [],
+    ".github/workflows/deploy.yml": [],
+    "README.md": [],
+    "CLAUDE.md": [],
+    "docs/getting-started.md": [],
+    "tsconfig.json": []
+  }
+}

--- a/tests/skill/understand/test_compute_batches.test.mjs
+++ b/tests/skill/understand/test_compute_batches.test.mjs
@@ -570,6 +570,120 @@ describe('compute-batches.mjs — merge-small', () => {
   });
 });
 
+describe('compute-batches.mjs — knownCrossBatchNodeIds (issue #303)', () => {
+  let projectRoot;
+  let batches;
+
+  beforeEach(() => {
+    projectRoot = setupProject('scan-result-known-cross-batch-ids.json');
+    const result = runScript(projectRoot);
+    expect(result.status).toBe(0);
+    batches = readBatches(projectRoot);
+  });
+
+  afterEach(() => {
+    if (projectRoot) rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('every batch carries a knownCrossBatchNodeIds string array', () => {
+    expect(batches.batches.length).toBeGreaterThan(1);
+    for (const b of batches.batches) {
+      expect(Array.isArray(b.knownCrossBatchNodeIds)).toBe(true);
+      for (const id of b.knownCrossBatchNodeIds) {
+        expect(typeof id).toBe('string');
+        // Canonical `<prefix>:<path>` form.
+        expect(id).toMatch(/^[a-z]+:.+/);
+      }
+    }
+  });
+
+  it('knownCrossBatchNodeIds excludes IDs from the batch\'s own files', () => {
+    for (const b of batches.batches) {
+      const ownPaths = new Set(b.files.map(f => f.path));
+      for (const id of b.knownCrossBatchNodeIds) {
+        // Extract `<path>` from `<prefix>:<path>` (path itself may contain
+        // slashes but not the first colon).
+        const path = id.slice(id.indexOf(':') + 1);
+        expect(ownPaths.has(path)).toBe(false);
+      }
+    }
+  });
+
+  it('knownCrossBatchNodeIds use the correct prefix per fileCategory', () => {
+    // Find the code batch (the TS clique survives merge-small as a 3-file
+    // mergeable=true batch, so it stays standalone).
+    const codeBatch = batches.batches.find(b =>
+      b.files.some(f => f.path === 'src/index.ts'));
+    expect(codeBatch).toBeDefined();
+
+    // From the code batch's perspective, the cross-batch IDs must include
+    // the other files with their CATEGORY-CORRECT prefixes — never `file:`
+    // for a doc/config/infra path. This is the exact bug described in #303.
+    const ids = codeBatch.knownCrossBatchNodeIds;
+    expect(ids).toContain('document:README.md');
+    expect(ids).toContain('document:CLAUDE.md');
+    expect(ids).toContain('document:docs/getting-started.md');
+    expect(ids).toContain('config:tsconfig.json');
+    expect(ids).toContain('service:Dockerfile');
+    expect(ids).toContain('service:docker-compose.yml');
+    expect(ids).toContain('pipeline:.github/workflows/ci.yml');
+    expect(ids).toContain('pipeline:.github/workflows/deploy.yml');
+
+    // The bug: under the old code, a doc/config batch referencing CLAUDE.md
+    // would fall back to `file:CLAUDE.md`. Assert that prefix never appears
+    // for a known doc path.
+    expect(ids).not.toContain('file:README.md');
+    expect(ids).not.toContain('file:CLAUDE.md');
+    expect(ids).not.toContain('file:docs/getting-started.md');
+    expect(ids).not.toContain('file:Dockerfile');
+    expect(ids).not.toContain('file:tsconfig.json');
+    expect(ids).not.toContain('file:.github/workflows/ci.yml');
+  });
+
+  it('docs batch sees code files with file: prefix and infra/config files with their own', () => {
+    // Find a batch owning a docs file (could be standalone or merged with
+    // other non-code files via Group E / merge-small).
+    const docsBatch = batches.batches.find(b =>
+      b.files.some(f => f.path === 'README.md'));
+    expect(docsBatch).toBeDefined();
+
+    const ids = docsBatch.knownCrossBatchNodeIds;
+    // The TS code clique lives in another batch — it must be referenced
+    // with the file: prefix.
+    expect(ids).toContain('file:src/index.ts');
+    expect(ids).toContain('file:src/server.ts');
+    expect(ids).toContain('file:src/router.ts');
+  });
+
+  it('knownCrossBatchNodeIds is sorted deterministically', () => {
+    for (const b of batches.batches) {
+      const sorted = [...b.knownCrossBatchNodeIds].sort();
+      expect(b.knownCrossBatchNodeIds).toEqual(sorted);
+    }
+  });
+
+  it('union of own-file IDs + knownCrossBatchNodeIds covers every file in the project', () => {
+    // For any batch, every other file in the project must be reachable via
+    // its knownCrossBatchNodeIds (modulo this batch's own files). This is
+    // the invariant the file-analyzer relies on when deciding whether to
+    // drop an edge ("not in the list → not in the graph").
+    const allPaths = new Set();
+    for (const b of batches.batches) {
+      for (const f of b.files) allPaths.add(f.path);
+    }
+    for (const b of batches.batches) {
+      const ownPaths = new Set(b.files.map(f => f.path));
+      const crossPaths = new Set(
+        b.knownCrossBatchNodeIds.map(id => id.slice(id.indexOf(':') + 1)),
+      );
+      for (const p of allPaths) {
+        const reachable = ownPaths.has(p) || crossPaths.has(p);
+        expect(reachable, `batch ${b.batchIndex} cannot reach ${p}`).toBe(true);
+      }
+    }
+  });
+});
+
 describe('compute-batches.mjs — --changed-files', () => {
   let root;
 

--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -63,6 +63,18 @@ Use neighborMap as a confidence boost for cross-batch edges (`calls`, `related`,
 
 The merge script's dangling-edge dropper is the safety net for genuinely unresolvable targets.
 
+### Cross-batch node IDs (knownCrossBatchNodeIds) — STRICT prefix authority
+
+Your dispatch prompt also includes a `knownCrossBatchNodeIds` array — a flat list of canonical `<prefix>:<path>` node IDs allocated by **every other batch** in the project (e.g. `file:src/server.ts`, `document:CLAUDE.md`, `config:tsconfig.json`, `pipeline:.github/workflows/ci.yml`). This list is the **authoritative source of truth** for the file-level node ID of any cross-batch target.
+
+Rules — apply to ALL edge types (`documents`, `configures`, `deploys`, `related`, `imports`, `calls`, etc.) whose `target` (or `source` for inverted relationships) lives in another batch:
+
+1. **Use these IDs verbatim.** When you need to reference a file owned by another batch, find its entry in `knownCrossBatchNodeIds` and copy the ID exactly. Do NOT guess the prefix — `CLAUDE.md` is `document:CLAUDE.md`, not `file:CLAUDE.md`; `Dockerfile` is `service:Dockerfile`, not `file:Dockerfile`.
+2. **Do NOT invent node IDs.** If you need to reference a cross-batch file by a sub-node (e.g. a function), the file-level ID's prefix in `knownCrossBatchNodeIds` still wins — never construct `file:<path>` for a file that appears in the list under a different prefix.
+3. **Drop the edge if the target is not in the list.** A target path absent from both your own batch AND `knownCrossBatchNodeIds` is not part of the project graph (most commonly because `.understandignore` excluded it). Do NOT emit the edge — the merge script will drop it anyway, and forcing a guess wastes the assemble-reviewer's repair budget. The recoveredFromImportMap pass in merge-batch-graphs.py covers `imports` edges deterministically when the source/target both have `file:` nodes; for non-`imports` cross-batch edges, your discipline here is the only signal.
+
+Note: sub-node IDs (`function:<path>:<symbol>`, `class:<path>:<symbol>`, `table:<path>:<table>`, `endpoint:<path>:<METHOD-path>`) are NOT enumerated in `knownCrossBatchNodeIds` — only the file-level node ID for each cross-batch file is listed. Use `neighborMap[file].symbols` (as above) to construct sub-node IDs with confidence.
+
 ### Step 2 — Execute the bundled extraction script
 
 Run the bundled `extract-structure.mjs` script. The `<SKILL_DIR>` path is provided in your dispatch prompt.

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -331,6 +331,11 @@ Dispatch prompt template (fill in batch-specific values from `batches.json[i]`):
 > <neighborMap JSON from batches.json[i].neighborMap>
 > ```
 >
+> Canonical node IDs owned by OTHER batches (use these verbatim for any cross-batch edge target — DO NOT invent IDs; drop the edge if the target is not in this list):
+> ```json
+> <knownCrossBatchNodeIds JSON from batches.json[i].knownCrossBatchNodeIds>
+> ```
+>
 > Files to analyze in this batch (every entry MUST be passed through to `batchFiles` with all four fields — `path`, `language`, `sizeLines`, `fileCategory`):
 > 1. `<path>` (<sizeLines> lines, language: `<language>`, fileCategory: `<fileCategory>`)
 > 2. `<path>` (<sizeLines> lines, language: `<language>`, fileCategory: `<fileCategory>`)

--- a/understand-anything-plugin/skills/understand/compute-batches.mjs
+++ b/understand-anything-plugin/skills/understand/compute-batches.mjs
@@ -193,6 +193,131 @@ function buildBatchOfMap(allBatches) {
   return m;
 }
 
+// ---------------------------------------------------------------------------
+// File → canonical node-ID prefix. Mirrors:
+//   1. file-analyzer.md "Node type mapping by fileCategory" (which is the
+//      contract the file-analyzer subagent emits node IDs under).
+//   2. merge-batch-graphs.py TYPE_TO_PREFIX (the merge step that normalizes
+//      whatever the agent produced).
+//
+// The file-level node ID for a file is `<prefix>:<path>` (e.g.
+// `file:src/index.ts`, `document:README.md`). We pre-compute the full ID
+// for every file at dispatch time so doc/config batches that reference
+// sibling files in OTHER batches can use the correct prefix instead of
+// guessing `file:<path>` and emitting a dangling edge (see issue #303).
+//
+// `code` / `script` / `markup` collapse to `file:` — file-analyzer.md's
+// table specifies `script` and `markup` as `file` type. `infra` and `data`
+// fan out by path heuristics that mirror buildNonCodeBatches' Group A-D
+// classification and the file-analyzer's "Choosing between infra/data
+// sub-types" guidance.
+// ---------------------------------------------------------------------------
+
+const _baseOf = p => p.includes('/') ? p.slice(p.lastIndexOf('/') + 1) : p;
+
+/**
+ * Return the canonical node-ID prefix for a file based on its category and
+ * path. The returned prefix matches what `file-analyzer.md` instructs the
+ * subagent to emit for the file-level node:
+ *
+ *   - code|script|markup → "file"
+ *   - config             → "config"
+ *   - docs               → "document"
+ *   - infra              → "service" | "pipeline" | "resource"
+ *   - data               → "table"   | "schema"   | "endpoint"
+ *
+ * For infra/data, the subtype is picked from the path (Dockerfile,
+ * .github/workflows/, *.tf, etc.) to match the file-analyzer's per-file
+ * subtype rules. When no specific subtype matches, falls back to the
+ * "most common" prefix for that category (`service` for infra, `table`
+ * for data) so dispatch never emits a path with no prefix.
+ *
+ * Defensive: an unknown fileCategory falls through to `file`, mirroring
+ * the merge script's "unknown type defaults to file" behavior — it's
+ * better to emit a slightly-wrong prefix the merge step will surface as
+ * a dangling edge than to omit the file from knownCrossBatchNodeIds
+ * entirely (which would also produce a dangling edge but with no recovery
+ * signal).
+ */
+function nodePrefixForFile(file) {
+  const cat = file.fileCategory;
+  if (cat === 'code' || cat === 'script' || cat === 'markup') return 'file';
+  if (cat === 'config') return 'config';
+  if (cat === 'docs') return 'document';
+
+  const path = file.path;
+  const base = _baseOf(path);
+
+  if (cat === 'infra') {
+    // Pipeline (CI/CD): .github/workflows/*, .gitlab-ci.yml, .circleci/*,
+    // Jenkinsfile, *.yml under k8s/kubernetes paths stay `service` below.
+    if (path.startsWith('.github/workflows/')) return 'pipeline';
+    if (path === '.gitlab-ci.yml') return 'pipeline';
+    if (path.startsWith('.circleci/')) return 'pipeline';
+    if (base === 'Jenkinsfile') return 'pipeline';
+    // Resource (IaC): Terraform, Vagrant.
+    if (path.endsWith('.tf') || path.endsWith('.tfvars')) return 'resource';
+    if (base === 'Vagrantfile') return 'resource';
+    // Service (containers / K8s): Dockerfile, docker-compose, .dockerignore,
+    // anything under k8s/kubernetes/, *.k8s.yml. This is the default for
+    // unmatched infra files (e.g. Makefile, Procfile) — those rarely
+    // become cross-batch edge targets so the small mis-classification
+    // risk is bounded.
+    return 'service';
+  }
+
+  if (cat === 'data') {
+    // Endpoint: OpenAPI/Swagger spec files.
+    if (/(^|\/)(openapi|swagger)\.(ya?ml|json)$/i.test(path)) return 'endpoint';
+    // Schema: GraphQL, Protobuf, Prisma.
+    if (path.endsWith('.graphql') || path.endsWith('.gql')) return 'schema';
+    if (path.endsWith('.proto')) return 'schema';
+    if (path.endsWith('.prisma')) return 'schema';
+    // Table: SQL is the file-analyzer default for the data category.
+    return 'table';
+  }
+
+  // Unknown / unexpected category — fall through to file. The
+  // merge-batch-graphs.py TYPE_TO_PREFIX has the same fallback.
+  return 'file';
+}
+
+/**
+ * Compute, for each batch, the flat array of canonical node IDs
+ * (`<prefix>:<path>`) that belong to ALL OTHER batches. Injected into the
+ * file-analyzer dispatch so doc/test/config batches referencing sibling
+ * files outside their own batch can emit edges with the correct prefix
+ * instead of falling back to `file:<guess-path>`. See issue #303.
+ *
+ * Returns Map<batchIndex, string[]> where the array is sorted for
+ * deterministic output.
+ */
+function buildKnownCrossBatchNodeIds(allBatches) {
+  // Pre-compute every file's full node ID once.
+  const idOf = new Map();
+  for (const b of allBatches) {
+    for (const f of b.files) {
+      idOf.set(f.path, `${nodePrefixForFile(f)}:${f.path}`);
+    }
+  }
+
+  const result = new Map();
+  for (const b of allBatches) {
+    const own = new Set(b.files.map(f => f.path));
+    const others = [];
+    for (const other of allBatches) {
+      if (other.batchIndex === b.batchIndex) continue;
+      for (const f of other.files) {
+        if (own.has(f.path)) continue;  // defensive — paths should be unique
+        others.push(idOf.get(f.path));
+      }
+    }
+    others.sort();
+    result.set(b.batchIndex, others);
+  }
+  return result;
+}
+
 /**
  * Returns Map<path, communityId> via Louvain. May throw — caller must catch
  * and fall back if it does. Honors UA_COMPUTE_BATCHES_FORCE_LOUVAIN_THROW=1
@@ -447,6 +572,12 @@ async function main() {
 
   const MAX_NEIGHBORS = 50;
 
+  // Pre-compute per-batch knownCrossBatchNodeIds — the canonical
+  // `<prefix>:<path>` IDs for every file owned by OTHER batches. Injected
+  // into file-analyzer dispatch so cross-batch edges land on the right
+  // prefix (`document:CLAUDE.md`, not `file:CLAUDE.md`). See issue #303.
+  const knownCrossBatchByIndex = buildKnownCrossBatchNodeIds(mergedBareBatches);
+
   // Second-pass: enrich each batch with batchImportData + neighborMap
   const batches = mergedBareBatches.map(b => {
     const batchPaths = new Set(b.files.map(f => f.path));
@@ -490,7 +621,13 @@ async function main() {
 
       if (kept.length) neighborMap[f.path] = kept;
     }
-    return { batchIndex: b.batchIndex, files: b.files, batchImportData, neighborMap };
+    return {
+      batchIndex: b.batchIndex,
+      files: b.files,
+      batchImportData,
+      neighborMap,
+      knownCrossBatchNodeIds: knownCrossBatchByIndex.get(b.batchIndex) || [],
+    };
   });
 
   let finalBatches = batches;


### PR DESCRIPTION
## Summary

Closes #303 — doc-batch file-analyzer subagents were emitting cross-batch edges with the wrong type prefix (e.g. `file:CLAUDE.md` instead of `document:CLAUDE.md`) because the dispatch prompt gave them `batchImportData[]` + `neighborMap{}` but no map of canonical node IDs allocated by other batches. ~17/19 of those bad edges were getting recovered post-hoc by the assemble-reviewer at extra LLM cost; 2 stayed dangling.

This change pre-computes the authoritative `<prefix>:<path>` for every file in `compute-batches.mjs` (Phase 1.5) and ships a per-batch `knownCrossBatchNodeIds: string[]` field in `batches.json`. The file-analyzer dispatch prompt now passes this list through with strict instructions: use the IDs verbatim, do not invent IDs, drop the edge if the target is not in the list.

- `compute-batches.mjs`: adds `nodePrefixForFile()` (mirrors `file-analyzer.md` "Node type mapping by fileCategory" + `merge-batch-graphs.py` `TYPE_TO_PREFIX`) and `buildKnownCrossBatchNodeIds()` (sorted per-batch list of all-other-batches' canonical IDs). New field is wired into the second-pass batch enrichment alongside `batchImportData` and `neighborMap`.
- `agents/file-analyzer.md`: adds a "Cross-batch node IDs (knownCrossBatchNodeIds) — STRICT prefix authority" section with rules for all edge types whose target lives in another batch.
- `skills/understand/SKILL.md` Phase 2: passes `knownCrossBatchNodeIds` through the dispatch template.
- `tests/skill/understand/test_compute_batches.test.mjs`: adds a new `knownCrossBatchNodeIds (issue #303)` suite (6 cases) backed by a new `scan-result-known-cross-batch-ids.json` fixture that exercises the exact #303 scenario (docs/config/infra batches with cross-references). Asserts the field exists on every batch, excludes own files, uses the correct prefix per `fileCategory` (the `document:CLAUDE.md` vs `file:CLAUDE.md` invariant), is sorted, and that the union `own ∪ knownCrossBatchNodeIds` reaches every project file (the invariant the agent uses for "drop the edge if not in the list").

### `fileCategory` → prefix mapping (mirrors file-analyzer.md and merge-batch-graphs.py)

| fileCategory | Prefix | Notes |
|---|---|---|
| `code` / `script` / `markup` | `file:` | per file-analyzer.md "Node type mapping by fileCategory" |
| `config` | `config:` | |
| `docs` | `document:` | |
| `infra` | `pipeline:` | `.github/workflows/*`, `.gitlab-ci.yml`, `.circleci/*`, `Jenkinsfile` |
| `infra` | `resource:` | `*.tf`, `*.tfvars`, `Vagrantfile` |
| `infra` | `service:` | default (Dockerfile, docker-compose, K8s, …) |
| `data` | `endpoint:` | `openapi.yaml`/`swagger.json` |
| `data` | `schema:` | `*.graphql`/`*.gql`/`*.proto`/`*.prisma` |
| `data` | `table:` | default (SQL) |
| unknown | `file:` | defensive fallback (matches merge-batch-graphs default) |

### Caveats

- The `infra` and `data` sub-classifications are path-heuristic, mirroring `buildNonCodeBatches()` Group A–D and the file-analyzer's "Choosing between infra/data sub-types" guidance. Edge cases like a `Makefile` (currently → `service:`) might mis-classify, but a small mis-prefix is bounded — the merge step's dangling-edge dropper still catches it and the existing assemble-reviewer pass still has the recovery signal. Worst case it falls back to today's behavior.
- I scoped this to JUST emitting `knownCrossBatchNodeIds` from `compute-batches.mjs` + the dispatch instructions, per the issue's "feel free to scope down" note. Verifying the full end-to-end gain (the 17/19 → 19/19 dangling-edge recovery rate) requires running `/understand` against a real multi-batch project, which is out of scope for this PR. The unit tests confirm the data shape and invariants.

## Test plan

- [x] `pnpm test tests/skill/understand/test_compute_batches.test.mjs` — 25 passed (19 existing + 6 new)
- [x] `pnpm test` (full suite) — 224 passed across 17 test files (no regressions in `extract-import-map`, `scan-project`, `merge-recover-imports`, `worktree-redirect`, dashboard utils, etc.)
- [ ] End-to-end: run `/understand --full` against a project that has multi-batch doc-cross-references (e.g. a repo with `CLAUDE.md` + multi-package src/) and confirm the merge-batch-graphs.py "Dropped dangling edges" count drops vs. baseline. (Recommended but not blocking.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)