### PR TITLE
fix(php-extractor): capture file-scope calls + map include/require as imports (#367)

### DIFF
--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts
@@ -322,6 +322,85 @@ use App\\Models\\Post;
       tree.delete();
       parser.delete();
     });
+
+    // ---- include / require imports (#367) ----
+
+    it("captures include/require with a plain string literal as imports (#367)", () => {
+      const { tree, parser, root } = parse(`<?php
+include 'config.php';
+include_once "lib/util.php";
+require 'data.php';
+require_once 'autoload.php';
+`);
+      const result = extractor.extractStructure(root);
+
+      const sources = result.imports.map((i) => i.source);
+      expect(sources).toContain("config.php");
+      expect(sources).toContain("lib/util.php");
+      expect(sources).toContain("data.php");
+      expect(sources).toContain("autoload.php");
+      expect(result.imports).toHaveLength(4);
+
+      // All include/require imports have empty specifiers (no named bindings).
+      for (const imp of result.imports) {
+        expect(imp.specifiers).toEqual([]);
+      }
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("resolves __DIR__ . '/path' concatenation in require_once (#367)", () => {
+      const { tree, parser, root } = parse(`<?php
+require_once __DIR__ . '/helpers.php';
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toHaveLength(1);
+      // We preserve __DIR__ verbatim and concatenate the literal suffix so
+      // downstream consumers can resolve relative to the current file.
+      expect(result.imports[0].source).toBe("__DIR__/helpers.php");
+      expect(result.imports[0].specifiers).toEqual([]);
+      expect(result.imports[0].lineNumber).toBe(2);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("captures include/require alongside use statements (#367)", () => {
+      const { tree, parser, root } = parse(`<?php
+use App\\Models\\User;
+require_once __DIR__ . '/helpers.php';
+include 'config.php';
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toHaveLength(3);
+      const sources = result.imports.map((i) => i.source);
+      expect(sources).toContain("App\\Models\\User");
+      expect(sources).toContain("__DIR__/helpers.php");
+      expect(sources).toContain("config.php");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("records non-resolvable include path as raw text (#367)", () => {
+      // Variable path — not statically determinable. We still emit the edge so
+      // the dependency isn't silently lost; downstream code can flag it.
+      const { tree, parser, root } = parse(`<?php
+$path = 'dynamic.php';
+include $path;
+`);
+      const result = extractor.extractStructure(root);
+
+      // We expect at least one import entry pointing at the variable text.
+      const sources = result.imports.map((i) => i.source);
+      expect(sources).toContain("$path");
+
+      tree.delete();
+      parser.delete();
+    });
   });
 
   // ---- Exports ----
@@ -454,15 +533,48 @@ class Service {
       parser.delete();
     });
 
-    it("ignores top-level calls (no caller)", () => {
+    it("attributes top-level calls to the synthetic <file> caller (#367)", () => {
+      // Procedural PHP — calls happen at file scope, outside any function/method.
+      // These used to be silently dropped, killing call-graph coverage on
+      // page-style PHP. We now record them under a synthetic <file> caller.
       const { tree, parser, root } = parse(`<?php
-echo "hello";
 main();
+$obj->run();
+Helper::go();
 `);
       const result = extractor.extractCallGraph(root);
 
-      // Top-level calls have no enclosing function, so they are skipped
-      expect(result).toHaveLength(0);
+      expect(result).toHaveLength(3);
+      expect(result.every((e) => e.caller === "<file>")).toBe(true);
+      const callees = result.map((e) => e.callee);
+      expect(callees).toContain("main");
+      expect(callees).toContain("$obj->run");
+      expect(callees).toContain("Helper::go");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("mixes file-scope and in-function calls in a single file (#367)", () => {
+      // A page that calls a helper at top level and also defines/calls
+      // a function. Both kinds of calls must be captured.
+      const { tree, parser, root } = parse(`<?php
+bootstrap();
+
+function handleRequest(): void {
+    process_input();
+}
+
+handleRequest();
+`);
+      const result = extractor.extractCallGraph(root);
+
+      const byCaller = (caller: string) =>
+        result.filter((e) => e.caller === caller).map((e) => e.callee);
+
+      expect(byCaller("<file>")).toContain("bootstrap");
+      expect(byCaller("<file>")).toContain("handleRequest");
+      expect(byCaller("handleRequest")).toContain("process_input");
 
       tree.delete();
       parser.delete();

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts
@@ -64,6 +64,17 @@ function extractReturnType(node: TreeSitterNode): string | undefined {
 }
 
 /**
+ * Synthetic caller name used for call-graph entries whose call site is
+ * not inside any function or method (procedural / page-style PHP).
+ *
+ * Procedural PHP frequently calls helpers at file scope (top-level), and
+ * dropping those would yield ~0% call-graph coverage on such codebases.
+ * We attribute them to this stable identifier so downstream consumers can
+ * still link the file-as-caller to its callees.
+ */
+const FILE_SCOPE_CALLER = "<file>";
+
+/**
  * Reconstruct a fully-qualified name from a `namespace_use_clause`.
  *
  * For a simple clause like `use App\Models\User;`, the clause contains
@@ -97,6 +108,85 @@ function lastSegment(fqn: string): string {
 }
 
 /**
+ * PHP include/require expression node types (statically dispatchable in tree-sitter-php).
+ */
+const INCLUDE_NODE_TYPES = new Set([
+  "include_expression",
+  "include_once_expression",
+  "require_expression",
+  "require_once_expression",
+]);
+
+/**
+ * Extract the string contents of a `string` or `encapsed_string` node.
+ *
+ * tree-sitter-php represents PHP strings as a `string` (single-quoted) or
+ * `encapsed_string` (double-quoted) node wrapping a `string_content` /
+ * `string_value` child. Returns null if the node is not a string-typed node.
+ */
+function extractStringLiteral(node: TreeSitterNode): string | null {
+  if (node.type !== "string" && node.type !== "encapsed_string") return null;
+  // Walk children to gather contiguous string_content / string_value pieces.
+  let value = "";
+  let sawContent = false;
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (!child) continue;
+    if (child.type === "string_content" || child.type === "string_value") {
+      value += child.text;
+      sawContent = true;
+    }
+  }
+  if (sawContent) return value;
+  // Fallback: strip surrounding quotes from the raw text.
+  return node.text.replace(/^['"]|['"]$/g, "");
+}
+
+/**
+ * Attempt to statically resolve the path argument of an include/require expression.
+ *
+ * Handles:
+ * - Plain string literal:    `include 'config.php';`
+ * - `__DIR__` / `__FILE__` concatenation: `require_once __DIR__ . '/helpers.php';`
+ *   (the magic constant is preserved as `__DIR__` in the resolved string so the
+ *    consumer can resolve it relative to the current file)
+ *
+ * Returns the resolved path string when statically determinable, otherwise the
+ * raw text of the argument expression (so the edge is still emitted, but with
+ * a non-resolvable source). Returns null if the expression has no usable form.
+ */
+function resolveIncludePath(argNode: TreeSitterNode): string | null {
+  // Direct string literal: `include 'config.php';`
+  const direct = extractStringLiteral(argNode);
+  if (direct !== null) return direct;
+
+  // Binary concatenation: `__DIR__ . '/helpers.php'` (possibly nested for
+  // multi-piece concatenations: `__DIR__ . '/sub' . '/helpers.php'`).
+  if (argNode.type === "binary_expression") {
+    const left = argNode.childForFieldName("left");
+    const right = argNode.childForFieldName("right");
+    const op = argNode.childForFieldName("operator");
+    if (left && right && op && op.text === ".") {
+      const leftStr = resolveIncludePath(left);
+      const rightStr = resolveIncludePath(right);
+      if (leftStr !== null && rightStr !== null) {
+        return leftStr + rightStr;
+      }
+    }
+  }
+
+  // Magic constants like __DIR__ / __FILE__ surface as bare `name` nodes.
+  // Preserve them verbatim so callers can resolve relative to the current file.
+  if (argNode.type === "name") {
+    return argNode.text;
+  }
+
+  // Unresolvable (variable, function call, etc.) — return raw text so the
+  // edge is still recorded but flagged as non-resolvable downstream.
+  return argNode.text;
+}
+
+/**
  * PHP extractor for tree-sitter structural analysis and call graph extraction.
  *
  * Handles functions, classes, interfaces, use imports, and call graphs
@@ -107,10 +197,15 @@ function lastSegment(fqn: string): string {
  * - `class_declaration` and `interface_declaration` map to the `classes` array.
  * - `property_declaration` nodes within classes map to class properties.
  * - `namespace_use_declaration` nodes (PHP `use` statements) map to imports.
+ * - `include` / `include_once` / `require` / `require_once` expressions also
+ *   map to imports, with the path string captured as the source (procedural
+ *   PHP relies on these for file→file dependencies).
  * - PHP has no formal export syntax, so public classes, interfaces, and
  *   top-level functions are treated as exports.
  * - Call graph covers `function_call_expression`, `member_call_expression`,
- *   and `scoped_call_expression`.
+ *   and `scoped_call_expression`. Calls at file scope (outside any function
+ *   or method) are attributed to a synthetic `<file>` caller so procedural
+ *   PHP pages still produce call-graph coverage.
  */
 export class PhpExtractor implements LanguageExtractor {
   readonly languageIds = ["php"];
@@ -174,6 +269,17 @@ export class PhpExtractor implements LanguageExtractor {
           this.extractUseDeclaration(node, imports);
           break;
 
+        case "expression_statement": {
+          // `include 'foo.php';` and friends parse as an expression_statement
+          // wrapping an include_expression / include_once_expression /
+          // require_expression / require_once_expression node.
+          const inner = node.child(0);
+          if (inner && INCLUDE_NODE_TYPES.has(inner.type)) {
+            this.extractIncludeRequire(inner, imports);
+          }
+          break;
+        }
+
         case "namespace_definition": {
           // Block-scoped namespaces (`namespace Foo { ... }`) nest declarations
           // inside a compound_statement body. Declarative namespaces (`namespace Foo;`)
@@ -204,50 +310,53 @@ export class PhpExtractor implements LanguageExtractor {
         }
       }
 
-      // Extract call expressions
-      if (functionStack.length > 0) {
-        const caller = functionStack[functionStack.length - 1];
+      // Extract call expressions. Calls inside functions/methods are attributed
+      // to the enclosing function; calls at file scope (procedural PHP pages)
+      // are attributed to the synthetic <file> caller so they aren't dropped.
+      const caller =
+        functionStack.length > 0
+          ? functionStack[functionStack.length - 1]
+          : FILE_SCOPE_CALLER;
 
-        if (node.type === "function_call_expression") {
-          // Standalone function call: baz($x), strtoupper($x), error_log($msg)
-          const nameNode = findChild(node, "name");
-          if (nameNode) {
-            entries.push({
-              caller,
-              callee: nameNode.text,
-              lineNumber: node.startPosition.row + 1,
-            });
-          }
-        } else if (node.type === "member_call_expression") {
-          // Instance method call: $this->fetchFromDb($id)
-          const nameNode = findChild(node, "name");
-          if (nameNode) {
-            // Determine the receiver for more descriptive callee
-            const firstChild = node.child(0);
-            const receiver = firstChild ? firstChild.text : "";
-            const callee = receiver
-              ? receiver + "->" + nameNode.text
-              : nameNode.text;
-            entries.push({
-              caller,
-              callee,
-              lineNumber: node.startPosition.row + 1,
-            });
-          }
-        } else if (node.type === "scoped_call_expression") {
-          // Static method call: Bar::staticMethod()
-          // Children: [name("Bar"), ::, name("staticMethod"), arguments]
-          // Both scope and method are `name` nodes, so we pick child[0] for scope
-          // and child[2] (after `::`) for the method name.
-          const scopeNode = node.child(0);
-          const methodNode = node.child(2);
-          if (scopeNode && methodNode && methodNode.type === "name") {
-            entries.push({
-              caller,
-              callee: scopeNode.text + "::" + methodNode.text,
-              lineNumber: node.startPosition.row + 1,
-            });
-          }
+      if (node.type === "function_call_expression") {
+        // Standalone function call: baz($x), strtoupper($x), error_log($msg)
+        const nameNode = findChild(node, "name");
+        if (nameNode) {
+          entries.push({
+            caller,
+            callee: nameNode.text,
+            lineNumber: node.startPosition.row + 1,
+          });
+        }
+      } else if (node.type === "member_call_expression") {
+        // Instance method call: $this->fetchFromDb($id)
+        const nameNode = findChild(node, "name");
+        if (nameNode) {
+          // Determine the receiver for more descriptive callee
+          const firstChild = node.child(0);
+          const receiver = firstChild ? firstChild.text : "";
+          const callee = receiver
+            ? receiver + "->" + nameNode.text
+            : nameNode.text;
+          entries.push({
+            caller,
+            callee,
+            lineNumber: node.startPosition.row + 1,
+          });
+        }
+      } else if (node.type === "scoped_call_expression") {
+        // Static method call: Bar::staticMethod()
+        // Children: [name("Bar"), ::, name("staticMethod"), arguments]
+        // Both scope and method are `name` nodes, so we pick child[0] for scope
+        // and child[2] (after `::`) for the method name.
+        const scopeNode = node.child(0);
+        const methodNode = node.child(2);
+        if (scopeNode && methodNode && methodNode.type === "name") {
+          entries.push({
+            caller,
+            callee: scopeNode.text + "::" + methodNode.text,
+            lineNumber: node.startPosition.row + 1,
+          });
         }
       }
 
@@ -457,5 +566,41 @@ export class PhpExtractor implements LanguageExtractor {
         lineNumber: node.startPosition.row + 1,
       });
     }
+  }
+
+  /**
+   * Extract an import entry from an include/require expression.
+   *
+   * Tree-sitter-php exposes these as `include_expression`, `include_once_expression`,
+   * `require_expression`, and `require_once_expression`. Each has a single child
+   * holding the path argument (string literal, magic-constant concatenation, etc.).
+   *
+   * When the path is statically resolvable (string literal or `__DIR__` / `__FILE__`
+   * concatenation) we capture the resolved string. Otherwise we capture the raw
+   * argument text so the dependency edge is still emitted, just non-resolvable.
+   */
+  private extractIncludeRequire(
+    node: TreeSitterNode,
+    imports: StructuralAnalysis["imports"],
+  ): void {
+    // The argument is the first named child of the include/require expression.
+    let arg: TreeSitterNode | null = null;
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (child && child.isNamed) {
+        arg = child;
+        break;
+      }
+    }
+    if (!arg) return;
+
+    const source = resolveIncludePath(arg);
+    if (source === null) return;
+
+    imports.push({
+      source,
+      specifiers: [],
+      lineNumber: node.startPosition.row + 1,
+    });
   }
 }


### PR DESCRIPTION
## Summary

Fixes two extractor bugs that caused ~0% call-graph + import coverage on procedural (page-style) PHP — the dominant style outside Composer/PSR-4 projects (#367).

**Bug A — top-level calls dropped.** `extractCallGraph()` only recorded a call when `functionStack.length > 0`, so any `function_call_expression` / `member_call_expression` / `scoped_call_expression` at file scope produced no entry. On procedural PHP, that meant the call graph was empty.

Fix: when `functionStack` is empty, attribute the call to a synthetic `<file>` caller (a stable, language-neutral identifier) so file→callee edges are still emitted.

**Bug B — `include` / `require` not mapped.** `extractStructure()` only looked at `namespace_use_declaration` for imports. `include`, `include_once`, `require`, and `require_once` — the file→file dependency mechanism for non-namespaced / legacy PHP — were ignored.

Fix: recognise `expression_statement` children whose inner node is `include_expression` / `include_once_expression` / `require_expression` / `require_once_expression`. Walk the path argument:
- String literal (`'config.php'`, `"lib/util.php"`) → captured as-is.
- Magic-constant concatenation (`__DIR__ . '/helpers.php'`) → reconstructed by recursing into `binary_expression` and preserving `__DIR__` / `__FILE__` verbatim so the consumer can resolve relative to the current file.
- Non-resolvable expressions (variables, function calls) → emitted with the raw argument text so the dependency edge isn't silently lost.

## Test plan

All 35 tests in `php-extractor.test.ts` pass (29 pre-existing + 6 new).

New tests cover:
- [x] `attributes top-level calls to the synthetic <file> caller (#367)` — `main()`, `$obj->run()`, `Helper::go()` at file scope all captured under `<file>`.
- [x] `mixes file-scope and in-function calls in a single file (#367)` — `<file>`-scope `bootstrap()` + `handleRequest()` and in-function `process_input()` both appear with correct callers.
- [x] `captures include/require with a plain string literal as imports (#367)` — all four variants (`include`, `include_once`, `require`, `require_once`) produce import entries.
- [x] `resolves __DIR__ . '/path' concatenation in require_once (#367)` — produces source `"__DIR__/helpers.php"`.
- [x] `captures include/require alongside use statements (#367)` — coexists with `namespace_use_declaration` extraction.
- [x] `records non-resolvable include path as raw text (#367)` — `include $path;` still emits an entry.

Existing behaviour (in-function calls, instance/static method calls, `use` imports, grouped/aliased `use`, block-scoped namespaces, return types, exports) is preserved — the original test that asserted top-level calls were silently dropped was updated to reflect the new (correct) behaviour.

Verification commands run:
- `pnpm test --root understand-anything-plugin/packages/core php-extractor` → 35/35 pass, 0 type errors (`--typecheck`).
- `pnpm lint` → clean.

Closes #367.