### PR TITLE
Fix TypeScript runtime .js import resolution

### DIFF
--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -91,6 +91,31 @@ describe('extract-import-map.mjs — TypeScript / JavaScript resolver', () => {
     expect(result.output.stats.totalEdges).toBe(2);
   });
 
+  it('resolves TypeScript ESM .js specifiers to .ts source files', () => {
+    projectRoot = setupTree({
+      'src/index.ts':
+        `import { run } from './commands/source.js';\n` +
+        `import { render } from './view/render.js';\n`,
+      'src/commands/source.ts': `export function run() { return true; }\n`,
+      'src/view/render.ts': `export function render() { return true; }\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'src/index.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/commands/source.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/view/render.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['src/index.ts']).toEqual([
+      'src/commands/source.ts',
+      'src/view/render.ts',
+    ]);
+  });
+
   it('resolves tsconfig paths aliases', () => {
     projectRoot = setupTree({
       'tsconfig.json': JSON.stringify({

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -365,9 +365,33 @@ function buildResolutionContext(projectRoot, files) {
 // Extensions probed when the import has no extension. The order mirrors the
 // historical project-scanner prose so behavior matches existing fixtures.
 const TS_EXT_PROBES = [
-  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
-  '/index.ts', '/index.tsx', '/index.js', '/index.jsx',
+  '.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs',
+  '/index.ts', '/index.tsx', '/index.mts', '/index.cts',
+  '/index.js', '/index.jsx', '/index.mjs', '/index.cjs',
 ];
+
+const RUNTIME_JS_SPECIFIER_PROBES = new Map([
+  ['.js', ['.ts', '.tsx', '.js', '.jsx']],
+  ['.jsx', ['.tsx', '.jsx']],
+  ['.mjs', ['.mts', '.ts', '.mjs']],
+  ['.cjs', ['.cts', '.ts', '.cjs']],
+]);
+
+function getRuntimeJsSpecifierExt(basePath) {
+  for (const runtimeExt of RUNTIME_JS_SPECIFIER_PROBES.keys()) {
+    if (basePath.endsWith(runtimeExt)) return runtimeExt;
+  }
+  return null;
+}
+
+function probeRuntimeJsSpecifier(basePath, runtimeExt, fileSet) {
+  const sourceStem = basePath.slice(0, -runtimeExt.length);
+  for (const sourceExt of RUNTIME_JS_SPECIFIER_PROBES.get(runtimeExt)) {
+    const candidate = sourceStem + sourceExt;
+    if (fileSet.has(candidate)) return candidate;
+  }
+  return null;
+}
 
 /**
  * Try ext probes against the file set for the given base path. Returns the
@@ -378,6 +402,8 @@ function probeWithExtensions(basePath, fileSet) {
   if (!basePath) return null;
   // Exact match (import already had an extension)
   if (fileSet.has(basePath)) return basePath;
+  const runtimeExt = getRuntimeJsSpecifierExt(basePath);
+  if (runtimeExt) return probeRuntimeJsSpecifier(basePath, runtimeExt, fileSet);
   for (const ext of TS_EXT_PROBES) {
     const candidate = basePath + ext;
     if (fileSet.has(candidate)) return candidate;


### PR DESCRIPTION
## Summary

- Resolve TypeScript NodeNext / ESM runtime `.js`, `.jsx`, `.mjs`, and `.cjs` import specifiers to source files when the exact runtime file does not exist.
- Preserve exact runtime file matches first, so real `.js` files still win.
- Add `.mts` / `.cts` source probes and a regression test for `./foo.js` resolving to `foo.ts`.

## Root Cause

The resolver previously appended source probes to the full import specifier. For example, `./commands/source.js` would probe paths like `commands/source.js.ts`, miss the existing `commands/source.ts`, and drop the deterministic import edge.

## Validation

- `pnpm --filter @understand-anything/core build`
- `pnpm --filter @understand-anything/skill build`
- `pnpm test` — 16 test files, 201 tests passing
- Verified a local TypeScript ESM fixture now produces deterministic internal import edges where it previously produced none.
