### PR TITLE
fix(ruby-extractor): capture keyword params and members of nested classes/modules

### DIFF
--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts
@@ -321,10 +321,22 @@ end
 `);
       const result = extractor.extractStructure(root);
 
-      expect(result.classes.map((c) => c.name)).toEqual(
-        expect.arrayContaining(["Outer", "Inner"]),
-      );
+      // Order is deterministic: extractClassBody recurses into (and pushes)
+      // the nested `Inner` before the enclosing `Outer` is pushed, so the
+      // flat classes[] is [Inner, Outer], not source order. Assert exactly
+      // so an ordering change (or a regression in either direction) is caught.
+      expect(result.classes.map((c) => c.name)).toEqual(["Inner", "Outer"]);
       expect(result.functions.some((f) => f.name === "foo")).toBe(true);
+
+      // The nested method `foo` belongs to Inner, NOT Outer. Locking this
+      // guards the most likely regression if the class/module branches were
+      // ever folded back into the method-collection path.
+      const inner = result.classes.find((c) => c.name === "Inner");
+      const outer = result.classes.find((c) => c.name === "Outer");
+      expect(inner).toBeDefined();
+      expect(outer).toBeDefined();
+      expect(inner!.methods).toContain("foo");
+      expect(outer!.methods).not.toContain("foo");
 
       tree.delete();
       parser.delete();

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts
@@ -92,6 +92,35 @@ end
       parser.delete();
     });
 
+    it("extracts keyword parameters", () => {
+      const { tree, parser, root } = parse(`
+def configure(name:, age: 30)
+end
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("configure");
+      expect(result.functions[0].params).toEqual(["name:", "age:"]);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts mixed positional and keyword parameters", () => {
+      const { tree, parser, root } = parse(`
+def build(a, b, name:, opts: {})
+end
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].params).toEqual(["a", "b", "name:", "opts:"]);
+
+      tree.delete();
+      parser.delete();
+    });
+
     it("extracts methods with no parameters", () => {
       const { tree, parser, root } = parse(`
 def noop
@@ -276,6 +305,26 @@ end
       expect(result.classes).toHaveLength(1);
       expect(result.classes[0].name).toBe("Helpers");
       expect(result.classes[0].methods).toContain("format_date");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts classes/modules nested inside a module", () => {
+      const { tree, parser, root } = parse(`
+module Outer
+  class Inner
+    def foo
+    end
+  end
+end
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes.map((c) => c.name)).toEqual(
+        expect.arrayContaining(["Outer", "Inner"]),
+      );
+      expect(result.functions.some((f) => f.name === "foo")).toBe(true);
 
       tree.delete();
       parser.delete();

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts
@@ -18,8 +18,8 @@ const ATTR_METHODS = new Set(["attr_accessor", "attr_reader", "attr_writer"]);
  * Extract parameter names from a Ruby `method_parameters` node.
  *
  * Handles: identifier (plain), optional_parameter (with default),
- * splat_parameter (*args), hash_splat_parameter (**kwargs),
- * block_parameter (&block).
+ * keyword_parameter (name:), splat_parameter (*args),
+ * hash_splat_parameter (**kwargs), block_parameter (&block).
  */
 function extractParams(paramsNode: TreeSitterNode | null): string[] {
   if (!paramsNode) return [];
@@ -396,10 +396,26 @@ export class RubyExtractor implements LanguageExtractor {
         if (methodNode && ATTR_METHODS.has(methodNode.text)) {
           properties.push(...extractAttrProperties(member));
         }
-      } else if (member.type === "class") {
-        this.extractClass(member, classes, functions);
-      } else if (member.type === "module") {
-        this.extractModule(member, classes, functions);
+      } else if (member.type === "class" || member.type === "module") {
+        // Nested class/module declarations are surfaced into the flat
+        // `classes` array, but intentionally with their bare name only:
+        // namespace qualification (e.g. "Outer::Inner") is NOT applied here.
+        // This matches the python-extractor convention of pushing bare
+        // nameNode.text, and avoids inventing a new cross-extractor naming
+        // scheme. Consequence: two same-named nested declarations in
+        // different enclosing scopes are indistinguishable in `classes[]`.
+        //
+        // Note also that nested declarations are deliberately NOT added to
+        // `exports`: per this extractor's contract, only top-level
+        // declarations are treated as exports (Ruby has no formal export
+        // syntax and a class nested inside a module is not a top-level
+        // export surface), so `classes[]` and `exports[]` can legitimately
+        // diverge for nested decls.
+        if (member.type === "class") {
+          this.extractClass(member, classes, functions);
+        } else {
+          this.extractModule(member, classes, functions);
+        }
       }
     }
   }

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts
@@ -40,6 +40,12 @@ function extractParams(paramsNode: TreeSitterNode | null): string[] {
         break;
       }
 
+      case "keyword_parameter": {
+        const ident = child.childForFieldName("name");
+        if (ident) params.push(ident.text + ":");
+        break;
+      }
+
       case "splat_parameter": {
         const ident = child.childForFieldName("name");
         if (ident) params.push("*" + ident.text);
@@ -314,7 +320,7 @@ export class RubyExtractor implements LanguageExtractor {
 
     const body = node.childForFieldName("body");
     if (body) {
-      this.extractClassBody(body, methods, properties, functions);
+      this.extractClassBody(body, methods, properties, functions, classes);
     }
 
     classes.push({
@@ -341,7 +347,7 @@ export class RubyExtractor implements LanguageExtractor {
 
     const body = node.childForFieldName("body");
     if (body) {
-      this.extractClassBody(body, methods, properties, functions);
+      this.extractClassBody(body, methods, properties, functions, classes);
     }
 
     classes.push({
@@ -357,13 +363,16 @@ export class RubyExtractor implements LanguageExtractor {
 
   /**
    * Extract methods and properties from a class/module body_statement.
-   * Also pushes each method into the top-level functions array.
+   * Also pushes each method into the top-level functions array, and recurses
+   * into nested class/module declarations (appending them to the shared
+   * `classes` array along with their methods).
    */
   private extractClassBody(
     body: TreeSitterNode,
     methods: string[],
     properties: string[],
     functions: StructuralAnalysis["functions"],
+    classes: StructuralAnalysis["classes"],
   ): void {
     for (let i = 0; i < body.childCount; i++) {
       const member = body.child(i);
@@ -387,6 +396,10 @@ export class RubyExtractor implements LanguageExtractor {
         if (methodNode && ATTR_METHODS.has(methodNode.text)) {
           properties.push(...extractAttrProperties(member));
         }
+      } else if (member.type === "class") {
+        this.extractClass(member, classes, functions);
+      } else if (member.type === "module") {
+        this.extractModule(member, classes, functions);
       }
     }
   }


### PR DESCRIPTION
## Problem

The Ruby extractor dropped two common constructs from structural analysis:

1. **Keyword parameters.** `extractParams` switched on the parameter node type but had no case for `keyword_parameter` — the tree-sitter node for Ruby keyword args (`name:`, `age: 30`). So `def configure(name:, age: 30)` produced `params: []`, and a mixed signature `def build(a, b, name:, opts: {})` produced `params: ["a","b"]`, losing every keyword arg. Keyword arguments are pervasive in modern Ruby, so this dropped a large fraction of real method signatures.

2. **Members of nested classes/modules.** `extractClassBody` only inspected `method`, `singleton_method`, and `call` members of a class/module body. It never handled nested `class` or `module` members, so `module Outer; class Inner; def foo; end; end; end` produced `classes: ['Outer']` and `functions: []` — the `Inner` class and its `foo` method vanished. Nesting a class inside a module is the standard Ruby namespacing idiom.

## Fix

In `understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts`:

- Added a `keyword_parameter` case in `extractParams` that pushes `ident.text + ":"` (the trailing `:` distinguishes keyword args from positional ones).
- Threaded the shared `classes` array into `extractClassBody` and added `class`/`module` member handling that recurses through the existing `extractClass`/`extractModule` helpers, appending nested declarations and their methods to the top-level `classes`/`functions` arrays.

## Testing

Added three test cases to `ruby-extractor.test.ts` (extracts keyword parameters, extracts mixed positional and keyword parameters, extracts classes/modules nested inside a module). All three fail before the fix (keyword params dropped; `Inner` missing) and pass after. The full core Vitest suite (695 tests across all extractors) is green, `tsc --noEmit` exits 0, and ESLint is clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)