### PR TITLE
fix(csharp-extractor): capture aliased usings and qualified `new` expressions in the call graph

### DIFF
--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts
@@ -302,6 +302,20 @@ namespace App {
       tree.delete();
       parser.delete();
     });
+
+    it("extracts aliased using with a simple-identifier target", () => {
+      const { tree, parser, root } = parse(`using Alias = System;
+namespace App { public class C {} }
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toEqual([
+        { source: "System", specifiers: ["System"], lineNumber: 1 },
+      ]);
+
+      tree.delete();
+      parser.delete();
+    });
   });
 
   // ---- Exports ----
@@ -447,6 +461,20 @@ namespace App {
       expect(result).toHaveLength(1);
       expect(result[0].caller).toBe("Create");
       expect(result[0].callee).toBe("new Bar");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts object creation of a qualified type", () => {
+      const { tree, parser, root } = parse(`namespace App { public class C { public void M() { var x = new System.Text.StringBuilder(); } } }`);
+      const result = extractor.extractCallGraph(root);
+
+      expect(result).toContainEqual({
+        caller: "M",
+        callee: "new System.Text.StringBuilder",
+        lineNumber: 1,
+      });
 
       tree.delete();
       parser.delete();

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts
@@ -316,6 +316,58 @@ namespace App { public class C {} }
       tree.delete();
       parser.delete();
     });
+
+    it("extracts a global using directive", () => {
+      const { tree, parser, root } = parse(`global using System.Collections.Generic;
+namespace App { public class C {} }
+`);
+      const result = extractor.extractStructure(root);
+
+      // tree-sitter-c-sharp parses `global using` as a `using_directive`
+      // carrying a `global` modifier child, so the existing handler applies.
+      expect(result.imports).toEqual([
+        {
+          source: "System.Collections.Generic",
+          specifiers: ["Generic"],
+          lineNumber: 1,
+        },
+      ]);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a global using with a simple-identifier alias target", () => {
+      const { tree, parser, root } = parse(`global using Alias = System;
+namespace App { public class C {} }
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toEqual([
+        { source: "System", specifiers: ["System"], lineNumber: 1 },
+      ]);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a global using with a qualified alias target", () => {
+      const { tree, parser, root } = parse(`global using Alias = System.Collections.Generic;
+namespace App { public class C {} }
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toEqual([
+        {
+          source: "System.Collections.Generic",
+          specifiers: ["Generic"],
+          lineNumber: 1,
+        },
+      ]);
+
+      tree.delete();
+      parser.delete();
+    });
   });
 
   // ---- Exports ----
@@ -473,6 +525,38 @@ namespace App { public class C {} }
       expect(result).toContainEqual({
         caller: "M",
         callee: "new System.Text.StringBuilder",
+        lineNumber: 1,
+      });
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts object creation of a generic type", () => {
+      const { tree, parser, root } = parse(`namespace App { public class C { public void M() { var x = new List<int>(); } } }`);
+      const result = extractor.extractCallGraph(root);
+
+      // The type node is a `generic_name`; its text includes the type arguments.
+      expect(result).toContainEqual({
+        caller: "M",
+        callee: "new List<int>",
+        lineNumber: 1,
+      });
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts object creation of a qualified generic type", () => {
+      const { tree, parser, root } = parse(`namespace App { public class C { public void M() { var x = new System.Collections.Generic.List<int>(); } } }`);
+      const result = extractor.extractCallGraph(root);
+
+      // tree-sitter-c-sharp shapes this as a single `qualified_name` whose
+      // trailing segment is a `generic_name`, so the node text carries the
+      // full dotted path including the type arguments.
+      expect(result).toContainEqual({
+        caller: "M",
+        callee: "new System.Collections.Generic.List<int>",
         lineNumber: 1,
       });
 

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts
@@ -59,37 +59,47 @@ function hasModifier(node: TreeSitterNode, modifier: string): boolean {
  *
  * Handles both simple identifiers (`using System;`) and qualified names
  * (`using System.Collections.Generic;`). For aliased usings like
- * `using Alias = Some.Namespace;`, extracts the target namespace.
+ * `using Alias = Some.Namespace;`, extracts the target namespace (the part
+ * after the `=`, not the alias). `global using` forms parse as a
+ * `using_directive` with a leading `global` child, so they flow through the
+ * same single pass below.
  */
 function extractUsingSource(node: TreeSitterNode): string | null {
-  // Check for alias form: `using Alias = Some.Namespace;`
-  const hasEquals = findChild(node, "=") !== null;
+  // A single pass over the children covers every using shape:
+  //   `using System;`                          -> first identifier
+  //   `using System.Collections.Generic;`      -> qualified_name
+  //   `using Alias = System;`                  -> identifier AFTER the `=`
+  //   `using Alias = System.Collections.X;`    -> qualified_name AFTER the `=`
+  // The alias name (before `=`) is intentionally skipped; `source` is always
+  // the target namespace.
+  let target: string | null = null;
 
-  if (hasEquals) {
-    // The target namespace is the qualified_name after the `=`
-    const qualifiedName = findChild(node, "qualified_name");
-    if (qualifiedName) return qualifiedName.text;
-    // Simple-identifier target (`using Alias = System;`): the target is the
-    // identifier AFTER the `=`, not the first identifier (which is the alias).
-    let seenEquals = false;
-    for (let i = 0; i < node.childCount; i++) {
-      const child = node.child(i);
-      if (!child) continue;
-      if (child.type === "=") {
-        seenEquals = true;
-        continue;
-      }
-      if (seenEquals && child.type === "identifier") return child.text;
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (!child) continue;
+
+    if (child.type === "=") {
+      // Discard anything seen before the `=` (that was the alias name) and
+      // resume scanning for the real target after it.
+      target = null;
+      continue;
     }
-    return null;
+
+    if (child.type === "qualified_name") {
+      // qualified_name is unambiguous: take it immediately whether or not we
+      // are in an alias directive.
+      return child.text;
+    }
+
+    if (child.type === "identifier" && target === null) {
+      // First identifier (the post-`=` one in the alias case). For a simple
+      // target this is the answer; we keep scanning in case a qualified_name
+      // follows (it would win above).
+      target = child.text;
+    }
   }
 
-  // Simple or qualified using
-  const qualifiedName = findChild(node, "qualified_name");
-  if (qualifiedName) return qualifiedName.text;
-
-  const identifier = findChild(node, "identifier");
-  return identifier ? identifier.text : null;
+  return target;
 }
 
 /**
@@ -236,6 +246,10 @@ export class CSharpExtractor implements LanguageExtractor {
 
       switch (child.type) {
         case "using_directive":
+          // Covers `using X;`, `using X.Y;`, `using A = X;`, and the C# 10
+          // `global using ...` forms — tree-sitter-c-sharp parses the latter
+          // as a `using_directive` with a leading `global` modifier child
+          // rather than a distinct node type.
           this.extractUsing(child, imports);
           break;
 

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts
@@ -68,7 +68,20 @@ function extractUsingSource(node: TreeSitterNode): string | null {
   if (hasEquals) {
     // The target namespace is the qualified_name after the `=`
     const qualifiedName = findChild(node, "qualified_name");
-    return qualifiedName ? qualifiedName.text : null;
+    if (qualifiedName) return qualifiedName.text;
+    // Simple-identifier target (`using Alias = System;`): the target is the
+    // identifier AFTER the `=`, not the first identifier (which is the alias).
+    let seenEquals = false;
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i);
+      if (!child) continue;
+      if (child.type === "=") {
+        seenEquals = true;
+        continue;
+      }
+      if (seenEquals && child.type === "identifier") return child.text;
+    }
+    return null;
   }
 
   // Simple or qualified using
@@ -173,8 +186,12 @@ export class CSharpExtractor implements LanguageExtractor {
       // Extract object creation: e.g. new Foo()
       if (node.type === "object_creation_expression") {
         if (functionStack.length > 0) {
-          // The type is the child after `new` — can be identifier or generic_name
-          const typeNode = findChild(node, "identifier") ?? findChild(node, "generic_name");
+          // The type is the child after `new` — can be identifier, generic_name,
+          // or a qualified_name (e.g. `new System.Text.StringBuilder()`).
+          const typeNode =
+            findChild(node, "identifier") ??
+            findChild(node, "generic_name") ??
+            findChild(node, "qualified_name");
           if (typeNode) {
             entries.push({
               caller: functionStack[functionStack.length - 1],


### PR DESCRIPTION
## Problem

Two C# extractor edge cases silently dropped real declarations:

1. **Aliased using directives with a simple-identifier target.** `extractUsingSource` handled the alias form `using Alias = Some.Namespace;` by looking only for a `qualified_name` child after the `=`. When the alias target is a single, undotted name (e.g. `using Alias = System;`), tree-sitter emits the target as a plain `identifier`, not a `qualified_name`. The alias branch returned `null`, so the whole using directive was dropped from imports. Falling back to the existing `findChild(node, "identifier")` would also be wrong, because the first identifier child is the alias name `Alias`, not the target `System`.

2. **`new` of a qualified type.** The `object_creation_expression` handler only looked for a direct `identifier` or `generic_name` child to name the constructed type. For a qualified type like `new System.Text.StringBuilder()`, tree-sitter places the type as a `qualified_name` child, so the object creation was dropped from the call graph entirely. (`new Bar()` and `new List<int>()` were captured correctly.)

## Fix

1. In the alias branch of `extractUsingSource`, when no `qualified_name` is found, fall back to the identifier that appears **after** the `=` token (tracking a `seenEquals` flag), so the target — not the alias name — is read.

2. Add `qualified_name` to the type-node fallback chain in the `object_creation_expression` handler:
   ```ts
   const typeNode =
     findChild(node, "identifier") ??
     findChild(node, "generic_name") ??
     findChild(node, "qualified_name");
   ```

## Testing

- Added two tests to `csharp-extractor.test.ts`:
  - `using Alias = System;` now yields `imports == [{ source: "System", specifiers: ["System"], lineNumber: 1 }]`.
  - `new System.Text.StringBuilder()` inside method `M` now produces call-graph entry `{ caller: "M", callee: "new System.Text.StringBuilder", lineNumber: 1 }`.
- Both tests **fail before** the fix (imports `[]`; call graph `[]`) and **pass after**.
- The full core package vitest suite is green (694 tests, csharp-extractor up to 29). Lint (`eslint`) and typecheck (`tsc --noEmit`) on the changed files both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)