### PR TITLE
fix(python-extractor): capture type-annotated *args/**kwargs parameters

### DIFF
--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts
@@ -132,6 +132,51 @@ def f(a: int, *args: str, b: int = 0, **kwargs: bool):
       parser.delete();
     });
 
+    it("extracts a typed **kwargs without a preceding typed *args", () => {
+      // Locks the dictionary_splat_pattern arm of the typed_parameter
+      // branch independently of the list_splat arm.
+      const { tree, parser, root } = parse(`
+def g(x: int, **kwargs: bool):
+    pass
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions[0].params).toEqual(["x", "**kwargs"]);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a typed *args without a preceding typed **kwargs", () => {
+      // Locks the list_splat_pattern arm of the typed_parameter branch
+      // independently of the dict-splat arm.
+      const { tree, parser, root } = parse(`
+def h(*args: int):
+    pass
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions[0].params).toEqual(["*args"]);
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts typed variadics on async functions", () => {
+      const { tree, parser, root } = parse(`
+async def fetch(a: int, *args: str, **kwargs: bool):
+    pass
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions).toHaveLength(1);
+      expect(result.functions[0].name).toBe("fetch");
+      expect(result.functions[0].params).toEqual(["a", "*args", "**kwargs"]);
+
+      tree.delete();
+      parser.delete();
+    });
+
     it("extracts decorated functions", () => {
       const { tree, parser, root } = parse(`
 @decorator

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts
@@ -114,6 +114,24 @@ def flexible(*args, **kwargs):
       parser.delete();
     });
 
+    it("extracts type-annotated *args and **kwargs", () => {
+      const { tree, parser, root } = parse(`
+def f(a: int, *args: str, b: int = 0, **kwargs: bool):
+    pass
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions[0].params).toEqual([
+        "a",
+        "*args",
+        "b",
+        "**kwargs",
+      ]);
+
+      tree.delete();
+      parser.delete();
+    });
+
     it("extracts decorated functions", () => {
       const { tree, parser, root } = parse(`
 @decorator

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts
@@ -8,6 +8,17 @@ import { findChild, findChildren } from "./base-extractor.js";
  * Handles: identifier (plain), typed_parameter, default_parameter,
  * typed_default_parameter, list_splat_pattern (*args),
  * dictionary_splat_pattern (**kwargs).
+ *
+ * Typed variadics (`*args: T`, `**kwargs: T`) are resolved inside the
+ * typed_parameter case via the nested list_splat_pattern /
+ * dictionary_splat_pattern, so they emit `*args` / `**kwargs` just like
+ * the untyped standalone splat arms below.
+ *
+ * Intentionally NOT emitted as params (they are syntactic markers, not
+ * named parameters): the bare `*` / bare `/` separators that mark
+ * keyword-only / positional-only boundaries. PEP 695 type-parameter lists
+ * (`def f[T](x: T)`) live on `function_definition`, not on this
+ * `parameters` node, so they are out of scope here as well.
  */
 function extractParams(paramsNode: TreeSitterNode | null): string[] {
   if (!paramsNode) return [];
@@ -26,6 +37,13 @@ function extractParams(paramsNode: TreeSitterNode | null): string[] {
         break;
 
       case "typed_parameter": {
+        // Grammar assumption (tree-sitter-python ^0.25.0): for a typed
+        // variadic, the list_splat_pattern / dictionary_splat_pattern is a
+        // DIRECT child of typed_parameter, so the shallow findChild below
+        // finds it. If a future grammar revision wraps the splat in an
+        // intermediate node this returns null and the typed variadic would
+        // be silently dropped again — the "extracts type-annotated *args and
+        // **kwargs" test would catch that regression.
         const splat = findChild(child, "list_splat_pattern");
         if (splat) {
           const sid = findChild(splat, "identifier");

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts
@@ -26,6 +26,18 @@ function extractParams(paramsNode: TreeSitterNode | null): string[] {
         break;
 
       case "typed_parameter": {
+        const splat = findChild(child, "list_splat_pattern");
+        if (splat) {
+          const sid = findChild(splat, "identifier");
+          if (sid) params.push("*" + sid.text);
+          break;
+        }
+        const dsplat = findChild(child, "dictionary_splat_pattern");
+        if (dsplat) {
+          const did = findChild(dsplat, "identifier");
+          if (did) params.push("**" + did.text);
+          break;
+        }
         const ident = findChild(child, "identifier");
         if (ident && ident.text !== "self" && ident.text !== "cls") {
           params.push(ident.text);


### PR DESCRIPTION
## Problem

In `extractParams` (`python-extractor.ts`), the `typed_parameter` case assumed the parameter name was a direct `identifier` child: `const ident = findChild(child, "identifier")`. For type-annotated variadic parameters such as `def f(*args: int, **kwargs: str)`, the tree-sitter-python grammar wraps the splat in a `typed_parameter` whose first child is a `list_splat_pattern` (for `*args`) or `dictionary_splat_pattern` (for `**kwargs`) — the identifier is nested inside that pattern, not a direct child. Because `findChild` is shallow (only scans direct children), it returned `null` and the parameter was silently dropped.

Verified by running the extractor: `def f(a: int, *args: str, b: int = 0, **kwargs: bool)` returned params `["a", "b"]` instead of `["a", "*args", "b", "**kwargs"]`. The untyped forms (`def f(*args, **kwargs)`) already worked because they parse as bare `list_splat_pattern`/`dictionary_splat_pattern` children of `parameters`. The gap was specifically typed variadics — a very common pattern in typed Python (`*args: Any`, `**kwargs: object`).

## Fix

In the `typed_parameter` case, check for a nested `list_splat_pattern` / `dictionary_splat_pattern` first and prefix the captured name with `*` / `**` respectively, falling back to the existing plain-identifier lookup otherwise. The change is confined to `understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts`.

## Testing

- Added test `extracts type-annotated *args and **kwargs` to `python-extractor.test.ts`, asserting `def f(a: int, *args: str, b: int = 0, **kwargs: bool)` yields params `["a", "*args", "b", "**kwargs"]`.
- The new test **fails before** the fix (`expected [ 'a', 'b' ] to deeply equal [ 'a', '*args', 'b', '**kwargs' ]`) and **passes after**.
- Full core vitest suite is green (693 passing, +1 from this test) with no regressions.
- `tsc --noEmit` (core) exits 0 and `eslint` is clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)