### PR TITLE
fix(tests): make scan-project fixtures hermetic against host global gitignore (#427)

### DIFF
--- a/tests/skill/understand/test_scan_project.test.mjs
+++ b/tests/skill/understand/test_scan_project.test.mjs
@@ -20,6 +20,26 @@ const SCRIPT = resolve(
 );
 
 /**
+ * scan-project.mjs enumerates files via `git ls-files -co --exclude-standard`,
+ * which honors the host's global gitignore (core.excludesFile). Many
+ * contributors keep `.env`/`.env.local` in their global gitignore, which would
+ * then hide the fixture dotfiles from the scanner and break tests that assert
+ * on them (e.g. the `.env` dotfile-config test) — see #427. Nulling
+ * GIT_CONFIG_GLOBAL/SYSTEM is NOT enough: core.excludesFile defaults to
+ * $XDG_CONFIG_HOME/git/ignore (or ~/.config/git/ignore) even with no config
+ * file, so the knob itself must be overridden. Passing this env to every git
+ * invocation makes the fixtures hermetic against any host config.
+ */
+const HERMETIC_GIT_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+  GIT_CONFIG_COUNT: '1',
+  GIT_CONFIG_KEY_0: 'core.excludesFile',
+  GIT_CONFIG_VALUE_0: '/dev/null',
+};
+
+/**
  * Build a project tree from a `{ relPath: contents }` object. Creates parent
  * directories as needed. Initializes a real git repo so the script's preferred
  * `git ls-files` enumeration path is exercised — tests that need the walker
@@ -36,7 +56,11 @@ function setupTree(files, { gitInit = true } = {}) {
     // `git ls-files -co --exclude-standard` returns BOTH cached and others
     // (modulo gitignore), so an `add` is unnecessary for our tests — the
     // bare repo init is enough for ls-files to enumerate.
-    const init = spawnSync('git', ['init', '-q'], { cwd: root, encoding: 'utf-8' });
+    const init = spawnSync('git', ['init', '-q'], {
+      cwd: root,
+      encoding: 'utf-8',
+      env: HERMETIC_GIT_ENV,
+    });
     if (init.status !== 0) {
       // CI without git: continue without it; the walker fallback will fire.
     }
@@ -66,6 +90,7 @@ function runScript(projectRoot) {
   const outputPath = join(outputDir, 'scan-output.json');
   const result = spawnSync('node', [SCRIPT, projectRoot, outputPath], {
     encoding: 'utf-8',
+    env: HERMETIC_GIT_ENV,
   });
   let output = null;
   try {
@@ -398,10 +423,15 @@ describe('scan-project.mjs — category assignment (project-scanner.md Step 4)',
     const r = runScript(projectRoot);
     expect(r.status).toBe(0);
     for (const p of ['.env', '.env.local', '.env.production']) {
-      expect(byPath(r.output, p).fileCategory).toBe('config');
+      const entry = byPath(r.output, p);
+      // Guard for a clearer failure than "Cannot read properties of
+      // undefined" if a host global gitignore ever hides these dotfiles
+      // (see HERMETIC_GIT_ENV above / #427).
+      expect(entry).toBeDefined();
+      expect(entry.fileCategory).toBe('config');
       // LANGUAGE_BY_EXT['.env'] -> 'config' (the language id itself; not
       // a typo — the language for env files is the 'config' bucket).
-      expect(byPath(r.output, p).language).toBe('config');
+      expect(entry.language).toBe('config');
     }
   });
 });

--- a/tests/skill/understand/test_scan_project.test.mjs
+++ b/tests/skill/understand/test_scan_project.test.mjs
@@ -416,6 +416,13 @@ describe('scan-project.mjs — category assignment (project-scanner.md Step 4)',
   // review on PR #204.
   it('dotfile configs (.env, .env.local, .env.production) map to config + env language', () => {
     projectRoot = setupTree({
+      // A non-dotfile sibling keeps `git ls-files` output non-empty so the
+      // git enumeration path is actually exercised. Without it, a host global
+      // gitignore that hides every dotfile would make `git ls-files` return
+      // nothing, silently tripping the walker fallback (which is unaware of
+      // gitignore) and masking the #427 leak. With a sibling present, the git
+      // path is taken and the dotfiles must survive on their own merits.
+      'keep.ts': 'export const x = 1;\n',
       '.env': 'API_KEY=abc\n',
       '.env.local': 'LOCAL=1\n',
       '.env.production': 'PROD=1\n',

--- a/tests/skill/understand/test_scan_project.test.mjs
+++ b/tests/skill/understand/test_scan_project.test.mjs
@@ -8,7 +8,7 @@ import {
   chmodSync,
   existsSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { tmpdir, devNull } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -29,14 +29,17 @@ const SCRIPT = resolve(
  * $XDG_CONFIG_HOME/git/ignore (or ~/.config/git/ignore) even with no config
  * file, so the knob itself must be overridden. Passing this env to every git
  * invocation makes the fixtures hermetic against any host config.
+ *
+ * `os.devNull` is used instead of a literal '/dev/null' so the null sink is
+ * valid on Windows too (`NUL`), where contributors also run these tests.
  */
 const HERMETIC_GIT_ENV = {
   ...process.env,
-  GIT_CONFIG_GLOBAL: '/dev/null',
-  GIT_CONFIG_SYSTEM: '/dev/null',
+  GIT_CONFIG_GLOBAL: devNull,
+  GIT_CONFIG_SYSTEM: devNull,
   GIT_CONFIG_COUNT: '1',
   GIT_CONFIG_KEY_0: 'core.excludesFile',
-  GIT_CONFIG_VALUE_0: '/dev/null',
+  GIT_CONFIG_VALUE_0: devNull,
 };
 
 /**


### PR DESCRIPTION
## Problem

`scan-project.mjs` enumerates files via `git ls-files -co --exclude-standard`, which honors the host's `core.excludesFile` (the global gitignore). Many contributors keep `.env` / `.env.local` in their global gitignore. When they do, the test fixtures' dotfiles never reach the scanner, `byPath(r.output, '.env')` returns `undefined`, and the "dotfile configs" test dies with:

```
TypeError: Cannot read properties of undefined (reading 'fileCategory')
```

CI (ubuntu-latest) has no global gitignore, so it never reproduces this — it only bites local contributors. Nulling `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` is **not** enough, because `core.excludesFile` defaults to `$XDG_CONFIG_HOME/git/ignore` (or `~/.config/git/ignore`) even with no config file present — the knob itself must be overridden.

## Fix

Add a `HERMETIC_GIT_ENV` constant that nulls the global/system git config and overrides `core.excludesFile` via the `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` mechanism, then pass it as `env` to **both** spawnSync calls — the `git init` in `setupTree()` and the `node scan-project.mjs` invocation in `runScript()`. This makes the fixtures hermetic against any host git configuration. The dotfile test's lookup is also guarded with `toBeDefined()` for a clearer failure message if this ever regresses.

Only the test file `tests/skill/understand/test_scan_project.test.mjs` changes; the scanner itself is untouched.

## Testing

Reproduced the bug by simulating a host global gitignore that ignores `.env`:

```sh
export XDG_CONFIG_HOME="$(mktemp -d)"; mkdir -p "$XDG_CONFIG_HOME/git"
printf '.env\n.env.local\n' > "$XDG_CONFIG_HOME/git/ignore"
```

- **Before the fix**, with that env: the suite fails 1/32 with the `TypeError ... reading 'fileCategory'` at the `.env` dotfile test.
- **After the fix**, with that env: 32/32 pass.
- **After the fix**, without that env (clean): 32/32 pass.

Lint (`eslint`) and core typecheck (`tsc --noEmit`) are green; the package test suite (`vitest run tests/skill/understand/test_scan_project.test.mjs`) passes 32/32 both with and without the simulated global ignore.


## Hardening the regression (follow-up commit)

The original dotfile-config fixture was dotfile-only. When a host global gitignore hides every dotfile, `git ls-files` returns an empty list, so `scan-project.mjs` falls back to its (gitignore-unaware) recursive walker and re-discovers the dotfiles — masking the #427 leak even without the hermetic env. Adding a non-dotfile sibling (`keep.ts`) to that fixture keeps `git ls-files` output non-empty, forcing the git enumeration path so the regression reliably **fails without** the hermetic env (`expected undefined to be defined`) and **passes with** it. Verified red→green:

- Unpatched env + simulated `XDG_CONFIG_HOME` global ignore → the dotfile test FAILS.
- Unpatched env + no simulated ignore → 32/32 pass (explains why CI never caught it).
- Patched (`HERMETIC_GIT_ENV`) → 32/32 pass both with and without the simulated ignore.

Full root vitest suite (16 files, 207 tests) and `eslint` on the changed file are green.

Fixes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)
