### PR TITLE
fix(embedding-search): guard cosineSimilarity against mismatched-length vectors

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts
@@ -95,5 +95,55 @@ describe("embedding-search", () => {
       engine.addEmbedding("n1", [1, 0, 0, 0]);
       expect(engine.hasEmbeddings()).toBe(true);
     });
+
+    it("tolerates a mis-sized stored embedding without throwing", () => {
+      // n2 simulates a stale/corrupt index entry: it was persisted by a
+      // different model and has the wrong dimension relative to the query.
+      const mixedEmbeddings: Record<string, number[]> = {
+        n1: [1, 0, 0, 0],
+        n2: [0, 1, 0], // wrong length (3 vs 4)
+        n3: [0.9, 0, 0.1, 0],
+      };
+      const engine = new SemanticSearchEngine(nodes, mixedEmbeddings);
+      const queryEmbedding = [1, 0, 0, 0];
+
+      expect(() => engine.search(queryEmbedding)).not.toThrow();
+    });
+
+    it("ranks a mis-sized stored embedding last at the default threshold", () => {
+      const mixedEmbeddings: Record<string, number[]> = {
+        n1: [1, 0, 0, 0], // identical to query -> similarity 1, score 0 (best)
+        n2: [0, 1, 0], // wrong length -> similarity 0, score 1 (worst)
+        n3: [0.9, 0, 0.1, 0], // similar -> high similarity, low score
+      };
+      const engine = new SemanticSearchEngine(nodes, mixedEmbeddings);
+
+      const results = engine.search([1, 0, 0, 0]);
+      const ids = results.map((r) => r.nodeId);
+
+      // Correctly-sized neighbours come back in ascending-score (descending
+      // similarity) order; the mismatched node is included but ranked last
+      // because similarity 0 satisfies `0 >= 0` and scores `1 - 0 = 1`.
+      expect(ids).toEqual(["n1", "n3", "n2"]);
+      expect(results[results.length - 1].nodeId).toBe("n2");
+      expect(results[results.length - 1].score).toBe(1);
+    });
+
+    it("drops a mis-sized stored embedding under a positive threshold", () => {
+      const mixedEmbeddings: Record<string, number[]> = {
+        n1: [1, 0, 0, 0],
+        n2: [0, 1, 0], // wrong length -> similarity 0, filtered by threshold
+        n3: [0.9, 0, 0.1, 0],
+      };
+      const engine = new SemanticSearchEngine(nodes, mixedEmbeddings);
+
+      const results = engine.search([1, 0, 0, 0], { threshold: 0.5 });
+      const ids = results.map((r) => r.nodeId);
+
+      // similarity 0 fails `0 >= 0.5`, so the mismatched node is excluded while
+      // the correctly-sized neighbours remain in score order.
+      expect(ids).not.toContain("n2");
+      expect(ids).toEqual(["n1", "n3"]);
+    });
   });
 });

--- a/understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts
@@ -33,6 +33,13 @@ describe("embedding-search", () => {
     it("handles zero vectors", () => {
       expect(cosineSimilarity([0, 0, 0], [1, 0, 0])).toBe(0);
     });
+
+    it("returns 0 (not NaN) for mismatched vector lengths", () => {
+      // a longer than b
+      expect(cosineSimilarity([1, 0, 0, 0.5], [1, 0, 0])).toBe(0);
+      // a shorter than b — today silently returns 1, overstating similarity
+      expect(cosineSimilarity([1, 0, 0], [1, 0, 0, 5])).toBe(0);
+    });
   });
 
   describe("SemanticSearchEngine", () => {

--- a/understand-anything-plugin/packages/core/src/embedding-search.ts
+++ b/understand-anything-plugin/packages/core/src/embedding-search.ts
@@ -9,9 +9,20 @@ export interface SemanticSearchOptions {
 
 /**
  * Compute cosine similarity between two vectors.
- * Returns 0 if either vector has zero magnitude.
+ * Returns 0 if either vector has zero magnitude or if the two vectors have
+ * different lengths.
  */
 export function cosineSimilarity(a: number[], b: number[]): number {
+  // A length mismatch means the two vectors came from different embedding
+  // models/dimensions — i.e. a stale or corrupt index, not a meaningful data
+  // point. We swallow it as 0 (treated as "completely dissimilar") so callers
+  // never see NaN or an overstated similarity. This is intentionally silent
+  // here because cosineSimilarity is a pure helper invoked once per node per
+  // query in search()'s hot loop and has no state to dedupe a warning.
+  // TODO(follow-up): surface mismatches at the engine level (record the
+  // expected dimension and warn-once / count skipped stored embeddings) so a
+  // user re-running search after a model upgrade gets a signal instead of
+  // quietly degraded recall.
   if (a.length !== b.length) return 0;
 
   let dot = 0;
@@ -69,6 +80,11 @@ export class SemanticSearchEngine {
       const embedding = this.embeddings.get(node.id);
       if (!embedding) continue;
 
+      // If a stored embedding's length differs from queryEmbedding (e.g. a
+      // persisted index from a prior model/dimension loaded alongside a fresh
+      // query), cosineSimilarity returns 0, so the node is treated as fully
+      // dissimilar rather than throwing or scoring spuriously high. See the
+      // TODO in cosineSimilarity about surfacing these mismatches engine-side.
       const similarity = cosineSimilarity(queryEmbedding, embedding);
       if (similarity >= threshold) {
         scored.push({ nodeId: node.id, score: 1 - similarity });

--- a/understand-anything-plugin/packages/core/src/embedding-search.ts
+++ b/understand-anything-plugin/packages/core/src/embedding-search.ts
@@ -12,6 +12,8 @@ export interface SemanticSearchOptions {
  * Returns 0 if either vector has zero magnitude.
  */
 export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) return 0;
+
   let dot = 0;
   let magA = 0;
   let magB = 0;


### PR DESCRIPTION
## Problem
- cosineSimilarity loops only over a.length and dereferences b[i] without verifying the lengths match. Its docstring promises a defined numeric result ('Returns 0 if either vector has zero magnitude'), but the function silently returns garbage when the two vectors differ in length. I verified with the exact code: cosineSimilarity([1,0,0,0.5],[1,0,0]) returns NaN (because b[3] is undefined, so a[3]*b[3] is NaN), and cosineSimilarity([1,0,0],[1,0,0,5]) returns 1 (the extra dimension of b is silently ignored, overstating similarity). In SemanticSearchEngine.search, a NaN similarity then fails the 'similarity >= threshold' check and the node is silently dropped from results with no error — so a single mis-sized stored embedding (e.g. one produced by a different embedding model/version, which is realistic when an embeddings map is loaded from disk and reused across runs) makes that node…

## Fix
- Guard against length mismatch at the top of the function so the contract is honoured (return 0 for incompatible vectors instead of NaN): if (a.length !== b.length) return 0; placed before the loop. (Optionally, the caller in SemanticSearchEngine.search could skip such embeddings, but returning 0 keeps the pure function's numeric contract intact.)

## Testing
Adds unit test(s) that fail before the change and pass after. The full core test suite, `eslint`, and `tsc --noEmit` all pass locally on this branch.

Found via a static correctness audit of the semantic/embedding search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)