### PR TITLE
fix(staleness): read changed files with -z so non-ASCII/quoted paths are detected

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts
@@ -82,6 +82,26 @@ describe("getChangedFiles", () => {
     );
   });
 
+  it("tolerates paths containing literal newlines (the -z motivation)", () => {
+    // A path with an embedded newline is exactly what split("\n") would have
+    // corrupted; -z + split("\0") must keep it intact as a single token.
+    mockedExecFileSync.mockReturnValue("weird\nname.txt\0other.txt\0");
+
+    const result = getChangedFiles("/project", "abc123");
+
+    expect(result).toEqual(["weird\nname.txt", "other.txt"]);
+  });
+
+  it("preserves leading and trailing whitespace in path tokens", () => {
+    // git -z emits raw path bytes; tokens must not be trimmed, otherwise
+    // legitimate filenames with surrounding spaces/tabs are corrupted.
+    mockedExecFileSync.mockReturnValue("  leading.txt\0trailing.txt \0\ttabbed.txt\0");
+
+    const result = getChangedFiles("/project", "abc123");
+
+    expect(result).toEqual(["  leading.txt", "trailing.txt ", "\ttabbed.txt"]);
+  });
+
   it("returns empty array when no changes", () => {
     mockedExecFileSync.mockReturnValue("");
 

--- a/understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts
@@ -55,14 +55,29 @@ beforeEach(() => {
 
 describe("getChangedFiles", () => {
   it("returns changed file list from git diff", () => {
-    mockedExecFileSync.mockReturnValue("src/index.ts\nsrc/utils.ts\n");
+    mockedExecFileSync.mockReturnValue("src/index.ts\0src/utils.ts\0");
 
     const result = getChangedFiles("/project", "abc123");
 
     expect(result).toEqual(["src/index.ts", "src/utils.ts"]);
     expect(mockedExecFileSync).toHaveBeenCalledWith(
       "git",
-      ["diff", "abc123..HEAD", "--name-only"],
+      ["diff", "abc123..HEAD", "--name-only", "-z"],
+      { cwd: "/project", encoding: "utf-8" },
+    );
+  });
+
+  it("detects non-ASCII and quoted/spaced paths via NUL-terminated output", () => {
+    // git with -z emits unquoted, NUL-terminated paths (no C-quoting).
+    mockedExecFileSync.mockReturnValue("uni-café.txt\0with space.txt\0");
+
+    const result = getChangedFiles("/project", "abc123");
+
+    expect(result).toEqual(["uni-café.txt", "with space.txt"]);
+    // The -z flag must be passed so git does not C-quote non-ASCII paths.
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["diff", "abc123..HEAD", "--name-only", "-z"],
       { cwd: "/project", encoding: "utf-8" },
     );
   });
@@ -88,7 +103,7 @@ describe("getChangedFiles", () => {
 
 describe("isStale", () => {
   it("returns stale when files have changed", () => {
-    mockedExecFileSync.mockReturnValue("src/index.ts\n");
+    mockedExecFileSync.mockReturnValue("src/index.ts\0");
 
     const result = isStale("/project", "abc123");
 

--- a/understand-anything-plugin/packages/core/src/staleness.ts
+++ b/understand-anything-plugin/packages/core/src/staleness.ts
@@ -19,14 +19,20 @@ export function getChangedFiles(
     // C-quotes any path containing non-ASCII bytes (e.g. `uni-café.txt`
     // becomes `"uni-caf\303\251.txt"`), which never matches the stored
     // filePath and silently skips incremental updates for that file.
+    //
+    // This parser assumes --name-only, where each NUL-terminated token is a
+    // single path. Do NOT switch to --name-status or -M/-C without rewriting
+    // this: under -z those modes emit multi-token entries (e.g. a rename is
+    // `R100\0old\0new\0`), and naive splitting would treat the status prefix
+    // and the old path as bogus changed files.
     const output = execFileSync('git', ['diff', `${lastCommitHash}..HEAD`, '--name-only', '-z'], {
       cwd: projectDir,
       encoding: "utf-8",
     });
-    return output
-      .split("\0")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
+    // Split on NUL only. git -z preserves raw path bytes (including any
+    // leading/trailing whitespace), so we must NOT trim tokens. The final
+    // NUL produces an empty trailing token, dropped by the length filter.
+    return output.split("\0").filter((line) => line.length > 0);
   } catch {
     return [];
   }

--- a/understand-anything-plugin/packages/core/src/staleness.ts
+++ b/understand-anything-plugin/packages/core/src/staleness.ts
@@ -15,12 +15,16 @@ export function getChangedFiles(
   lastCommitHash: string,
 ): string[] {
   try {
-    const output = execFileSync('git', ['diff', `${lastCommitHash}..HEAD`, '--name-only'], {
+    // -z makes git emit NUL-terminated, unquoted paths. Without it git
+    // C-quotes any path containing non-ASCII bytes (e.g. `uni-café.txt`
+    // becomes `"uni-caf\303\251.txt"`), which never matches the stored
+    // filePath and silently skips incremental updates for that file.
+    const output = execFileSync('git', ['diff', `${lastCommitHash}..HEAD`, '--name-only', '-z'], {
       cwd: projectDir,
       encoding: "utf-8",
     });
     return output
-      .split("\n")
+      .split("\0")
       .map((line) => line.trim())
       .filter((line) => line.length > 0);
   } catch {


### PR DESCRIPTION
## Problem
- `git diff <hash>..HEAD --name-only` C-quotes any path containing non-ASCII bytes (or quotes/backslashes/control chars): it wraps the path in double quotes and octal-escapes the bytes. For a file `uni-café.txt`, git emits the literal line `"uni-caf\303\251.txt"`. getChangedFiles splits on `\n`, trims, and returns the raw lines verbatim with NO unquoting, so it returns the string `"uni-caf\303\251.txt"` instead of `uni-café.txt`. Verified against a real git repo: `git diff BASE..HEAD --name-only` on a repo containing `uni-café.txt` prints `"uni-caf\303\251.txt"`. Downstream, mergeGraphUpdate does `changedSet.has(node.filePath)` against the real stored path `uni-café.txt`, which never equals the quoted/escaped string — so the changed file's stale nodes are silently kept and never refreshed (and isStale's changedFiles list contains a bogus path). Repos with CJK/accented/emoji filenames are…

## Fix
- Disable git path quoting and split on NUL instead of newline. Add the `-z` flag (NUL-terminated, no quoting) and parse accordingly, or pass `-c core.quotePath=false`. With `-z`: `execFileSync('git', ['diff', `${lastCommitHash}..HEAD`, '--name-only', '-z'], {cwd: projectDir, encoding: 'utf-8'})` then `output.split('\0').map(l => l.trim()).filter(l => l.length > 0)`. The `-z` form also tolerates paths that contain literal newlines. (~3 LOC change.)

## Testing
Adds unit test(s) that fail before the change and pass after. The full core test suite, `eslint`, and `tsc --noEmit` all pass locally on this branch.

Found via a static correctness audit of the incremental staleness detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)