### PR TITLE
fix(ignore-filter): tolerate ./-prefixed and empty relative paths in isIgnored

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts
@@ -84,6 +84,17 @@ describe("IgnoreFilter", () => {
       expect(filter.isIgnored(".idea/workspace.xml")).toBe(true);
       expect(filter.isIgnored(".vscode/settings.json")).toBe(true);
     });
+
+    it("does not throw on './'-prefixed paths and matches correctly", () => {
+      const filter = createIgnoreFilter(testDir);
+      expect(filter.isIgnored("./dist/index.js")).toBe(true);
+      expect(filter.isIgnored("./src/index.ts")).toBe(false);
+    });
+
+    it("treats the empty relative path (project root) as not ignored", () => {
+      const filter = createIgnoreFilter(testDir);
+      expect(filter.isIgnored("")).toBe(false);
+    });
   });
 
   describe("createIgnoreFilter with user .understandignore", () => {

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts
@@ -95,6 +95,46 @@ describe("IgnoreFilter", () => {
       const filter = createIgnoreFilter(testDir);
       expect(filter.isIgnored("")).toBe(false);
     });
+
+    it("does not throw on the input shapes that ignore@7 rejects", () => {
+      const filter = createIgnoreFilter(testDir);
+      // These are the previously-throwing inputs from the PR body. The whole
+      // point of the fix is that they return a boolean rather than throw.
+      expect(() => filter.isIgnored("")).not.toThrow();
+      expect(() => filter.isIgnored("./")).not.toThrow();
+      expect(() => filter.isIgnored("./dist/index.js")).not.toThrow();
+      expect(() => filter.isIgnored("././foo.log")).not.toThrow();
+      expect(() => filter.isIgnored(".//foo.log")).not.toThrow();
+      expect(() => filter.isIgnored("../escapes/root.ts")).not.toThrow();
+      expect(() => filter.isIgnored("dist\\index.js")).not.toThrow();
+      expect(() => filter.isIgnored(".\\dist\\index.js")).not.toThrow();
+    });
+
+    it("treats a bare './' (trim-to-empty / project root) as not ignored", () => {
+      const filter = createIgnoreFilter(testDir);
+      expect(filter.isIgnored("./")).toBe(false);
+    });
+
+    it("collapses repeated leading './' and duplicate slash runs", () => {
+      const filter = createIgnoreFilter(testDir);
+      expect(filter.isIgnored("././dist/index.js")).toBe(true);
+      expect(filter.isIgnored(".//dist/index.js")).toBe(true);
+      expect(filter.isIgnored("./src//index.ts")).toBe(false);
+    });
+
+    it("normalizes Windows backslash separators", () => {
+      const filter = createIgnoreFilter(testDir);
+      expect(filter.isIgnored("dist\\index.js")).toBe(true);
+      expect(filter.isIgnored(".\\dist\\index.js")).toBe(true);
+      expect(filter.isIgnored("src\\index.ts")).toBe(false);
+    });
+
+    it("treats out-of-root '../' paths as not ignored instead of throwing", () => {
+      const filter = createIgnoreFilter(testDir);
+      expect(filter.isIgnored("../foo")).toBe(false);
+      expect(filter.isIgnored("..")).toBe(false);
+      expect(filter.isIgnored("..\\foo")).toBe(false);
+    });
   });
 
   describe("createIgnoreFilter with user .understandignore", () => {

--- a/understand-anything-plugin/packages/core/src/ignore-filter.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-filter.ts
@@ -105,7 +105,10 @@ export function createIgnoreFilter(projectRoot: string): IgnoreFilter {
 
   return {
     isIgnored(relativePath: string): boolean {
-      return ig.ignores(relativePath);
+      if (!relativePath) return false;
+      const normalized = relativePath.replace(/^\.\//, "");
+      if (!normalized) return false;
+      return ig.ignores(normalized);
     },
   };
 }

--- a/understand-anything-plugin/packages/core/src/ignore-filter.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-filter.ts
@@ -70,7 +70,16 @@ export const DEFAULT_IGNORE_PATTERNS: string[] = [
 ];
 
 export interface IgnoreFilter {
-  /** Returns true if the given relative path should be excluded from analysis. */
+  /**
+   * Returns true if the given path should be excluded from analysis.
+   *
+   * Accepts a root-relative path. Inputs are normalized before delegating to
+   * ignore@7 (which throws on anything that isn't a clean `path.relative()`d
+   * string): backslashes are converted to `/`, any leading `./` segments and
+   * duplicate slashes are collapsed, and an empty path (the project root)
+   * returns false. A path that escapes the root (`../...`) is treated as
+   * not-ignored (returns false) rather than throwing.
+   */
   isIgnored(relativePath: string): boolean;
 }
 
@@ -106,8 +115,20 @@ export function createIgnoreFilter(projectRoot: string): IgnoreFilter {
   return {
     isIgnored(relativePath: string): boolean {
       if (!relativePath) return false;
-      const normalized = relativePath.replace(/^\.\//, "");
-      if (!normalized) return false;
+      // ignore@7's ig.ignores() throws on any input that isn't a clean,
+      // root-relative POSIX path, so normalize the shapes path.relative() can
+      // produce before delegating. Production callers always pass
+      // toPosix(relative(root, target)), but normalizing here keeps the
+      // function total against the other shapes too.
+      const normalized = relativePath
+        .replace(/\\/g, "/") // Windows separators -> POSIX
+        .replace(/^(\.\/)+/, "") // collapse one-or-more leading "./"
+        .replace(/\/{2,}/g, "/") // collapse duplicate slash runs
+        .replace(/^\/+/, ""); // drop any leading root slash
+      if (!normalized) return false; // empty path == project root, not ignored
+      // A path that escapes the root can't be under analysis; report not-ignored
+      // instead of letting ig.ignores() throw on the "../" prefix.
+      if (normalized === ".." || normalized.startsWith("../")) return false;
       return ig.ignores(normalized);
     },
   };


### PR DESCRIPTION
## Problem
- isIgnored is typed as (relativePath: string): boolean — a total function that always returns a boolean. But it delegates straight to ignore@7's ig.ignores() without any normalization, and ig.ignores() THROWS on two classes of perfectly ordinary relative-path strings: (1) an empty string, and (2) a path with a leading './'. These are not exotic inputs: path.relative(projectRoot, projectRoot) returns "" (the root itself), and file-walkers / glob results very commonly emit './src/index.ts'-style relative paths. In both cases the caller does not get false (or true) back — the whole scan crashes with an uncaught exception. Verified at runtime against the package's pinned ignore@7.0.5: isIgnored("") throws `path must not be empty`; isIgnored("./src/a.ts") throws `path should be a path.relative()'d string, but got "./src/a.ts"`. The documented contract (boolean return) is silently violated for…

## Fix
- Normalize before delegating: treat falsy/empty as not-ignored and strip a leading './' so ignore@7 accepts it. e.g. isIgnored(relativePath: string): boolean { if (!relativePath) return false; const normalized = relativePath.replace(/^\.\//, ""); if (!normalized) return false; return ig.ignores(normalized); }, Verified this returns: isIgnored("") -> false, isIgnored("./dist/a.js") -> true, isIgnored("dist/a.js") -> true, isIgnored("src/a.ts") -> false. <30 LOC.

## Testing
Adds unit test(s) that fail before the change and pass after. The full core test suite, `eslint`, and `tsc --noEmit` all pass locally on this branch.

Found via a static correctness audit of the ignore filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)