### PR TITLE
fix: prevent GraphQL scalar/union from inheriting a later type's fields and line range

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts
@@ -353,6 +353,53 @@ type Mutation {
     const result = parser.analyzeFile("schema.graphql", content);
     expect(result.definitions!.some(d => d.name === "Role" && d.kind === "enum")).toBe(true);
   });
+
+  it("does not let a scalar inherit a following type's fields or line range", () => {
+    // Arrange — a custom scalar declared above an object type (a ubiquitous
+    // pattern, e.g. `scalar DateTime`). scalar has no brace body of its own.
+    const content = `scalar DateTime
+
+type User {
+  id: ID!
+  name: String!
+}`;
+
+    // Act
+    const result = parser.analyzeFile("schema.graphql", content);
+
+    // Assert — the scalar is body-less: no stolen fields, single-line range.
+    const scalar = result.definitions!.find(d => d.name === "DateTime");
+    expect(scalar).toMatchObject({ kind: "scalar", lineRange: [1, 1] });
+    expect(scalar!.fields).toEqual([]);
+
+    // The following type keeps its own fields and range.
+    const user = result.definitions!.find(d => d.name === "User");
+    expect(user).toMatchObject({ kind: "type", lineRange: [3, 6] });
+    expect(user!.fields).toEqual(["id", "name"]);
+  });
+
+  it("does not let a union inherit a following type's fields or line range", () => {
+    // Arrange — a union declared above an object type. union has no brace body.
+    const content = `union SearchResult = User | Post
+
+type Post {
+  id: ID!
+  title: String!
+}`;
+
+    // Act
+    const result = parser.analyzeFile("schema.graphql", content);
+
+    // Assert — the union is body-less: no stolen fields, single-line range.
+    const union = result.definitions!.find(d => d.name === "SearchResult");
+    expect(union).toMatchObject({ kind: "union", lineRange: [1, 1] });
+    expect(union!.fields).toEqual([]);
+
+    // The following type is unaffected.
+    const post = result.definitions!.find(d => d.name === "Post");
+    expect(post).toMatchObject({ kind: "type", lineRange: [3, 6] });
+    expect(post!.fields).toEqual(["id", "title"]);
+  });
 });
 
 describe("ProtobufParser", () => {

--- a/understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts
@@ -34,12 +34,18 @@ export class GraphQLParser implements AnalyzerPlugin {
       if (name === "Query" || name === "Mutation" || name === "Subscription") continue;
       const startLine = content.slice(0, match.index).split("\n").length;
 
+      // scalar and union have no brace-delimited body. Without this guard the
+      // logic below would scan forward and capture the fields and closing brace
+      // of a later braced definition — e.g. `scalar DateTime` declared above a
+      // `type` would inherit that type's fields and line range.
+      const hasBody = kind !== "scalar" && kind !== "union";
+
       // Extract fields (for type/input/interface/enum)
-      const fields = this.extractFields(content, match.index);
+      const fields = hasBody ? this.extractFields(content, match.index) : [];
 
       // Find closing brace
       const afterMatch = content.slice(match.index);
-      const closeBrace = afterMatch.indexOf("}");
+      const closeBrace = hasBody ? afterMatch.indexOf("}") : -1;
       const endLine = closeBrace !== -1
         ? content.slice(0, match.index + closeBrace + 1).split("\n").length
         : startLine;


### PR DESCRIPTION
## Summary

`GraphQLParser.extractDefinitions` mis-parses **`scalar`** and **`union`** definitions. Both are matched by the definition regex but have no `{ ... }` body, yet the parser unconditionally calls `extractFields()` and searches for the next `}`. For a body-less definition this scans *forward into the next braced definition*, so the scalar/union steals that type's fields and its closing-brace line range.

This corrupts the knowledge graph for almost any real GraphQL schema, since a custom scalar above object types (`scalar DateTime`, `scalar JSON`, `scalar Upload`, …) is ubiquitous.

## Steps to reproduce

```graphql
scalar DateTime

type User {
  id: ID!
  name: String!
}
```

```ts
new GraphQLParser().analyzeFile(schema.graphql, content).definitions
```

**Expected:** `DateTime` → `{ kind: scalar, lineRange: [1, 1], fields: [] }`
**Actual (before fix):** `DateTime` → `{ kind: scalar, lineRange: [1, 6], fields: [id, name] }`

The `scalar` wrongly spans lines 1–6 and claims `User`'s `id`/`name` fields. A `union` declared above a braced type behaves identically.

## Fix

Guard field/brace extraction behind a `hasBody` check (`kind` is not `scalar` or `union`). Body-less definitions now report no fields and a single-line range. Braced definitions (`type` / `input` / `interface` / `enum`) are unchanged — only ~10 lines, scoped to `extractDefinitions`.

```ts
const hasBody = kind !== scalar && kind !== union;
const fields = hasBody ? this.extractFields(content, match.index) : [];
const afterMatch = content.slice(match.index);
const closeBrace = hasBody ? afterMatch.indexOf(}) : -1;
```

## Tests

Adds two regression tests (a `scalar` and a `union` each declared above a `type`) asserting the body-less definition gets no fields and a single-line range, and that the following type keeps its own fields/range.

- `pnpm --filter @understand-anything/core test` → **755 passed** (was 753; +2 new). Both new tests fail on `main` and pass with this change.
- `pnpm lint` → clean.

## PR checklist

- [x] Code follows the project's style guidelines
- [x] All tests pass (`pnpm test`)
- [x] New code has test coverage
- [x] Commit messages follow convention
- [x] No `console.log` or debug code left behind
- [x] Scope limited to the bug (no unrelated changes)

## Environment

Found while auditing the parser layer. Repro is platform-independent; verified on Node v24 / pnpm 10.6.2.