### PR TITLE
feat: add CodeBuddy platform support

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -41,6 +41,7 @@ $Platforms = [ordered]@{
     trae        = @{ Target = (Join-Path $HOME '.trae\skills');               Style = 'per-skill' }
     nanobot     = @{ Target = (Join-Path $HOME '.nanobot\workspace\skills');  Style = 'per-skill' }
     kiro        = @{ Target = (Join-Path $HOME '.kiro\skills');               Style = 'per-skill' }
+    codebuddy   = @{ Target = (Join-Path $HOME '.codebuddy\skills');          Style = 'per-skill' }
 }
 
 function Show-Usage {

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,7 @@ kimi|$HOME/.kimi/skills|folder
 trae|$HOME/.trae/skills|per-skill
 nanobot|$HOME/.nanobot/workspace/skills|per-skill
 kiro|$HOME/.kiro/skills|per-skill
+codebuddy|$HOME/.codebuddy/skills|per-skill
 EOF
 }
 

--- a/understand-anything-plugin/skills/understand-dashboard/SKILL.md
+++ b/understand-anything-plugin/skills/understand-dashboard/SKILL.md
@@ -36,6 +36,8 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
    SELF_RELATIVE=$([ -n "$SKILL_REAL" ] && cd "$SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
    COPILOT_SKILL_REAL=$(realpath ~/.copilot/skills/understand-dashboard 2>/dev/null || readlink -f ~/.copilot/skills/understand-dashboard 2>/dev/null || echo "")
    COPILOT_SELF_RELATIVE=$([ -n "$COPILOT_SKILL_REAL" ] && cd "$COPILOT_SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
+   CODEBUDDY_SKILL_REAL=$(realpath ~/.codebuddy/skills/understand-dashboard 2>/dev/null || readlink -f ~/.codebuddy/skills/understand-dashboard 2>/dev/null || echo "")
+   CODEBUDDY_SELF_RELATIVE=$([ -n "$CODEBUDDY_SKILL_REAL" ] && cd "$CODEBUDDY_SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
 
    PLUGIN_ROOT=""
    for candidate in \
@@ -43,6 +45,7 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
      "$HOME/.understand-anything-plugin" \
      "$SELF_RELATIVE" \
      "$COPILOT_SELF_RELATIVE" \
+     "$CODEBUDDY_SELF_RELATIVE" \
      "$HOME/.codex/understand-anything/understand-anything-plugin" \
      "$HOME/.opencode/understand-anything/understand-anything-plugin" \
      "$HOME/.pi/understand-anything/understand-anything-plugin" \
@@ -59,6 +62,7 @@ Start the Understand Anything dashboard to visualize the knowledge graph for the
      echo "  - $HOME/.understand-anything-plugin"
      echo "  - ${SELF_RELATIVE:-<unresolved path derived from ~/.agents/skills/understand-dashboard>}"
      echo "  - ${COPILOT_SELF_RELATIVE:-<unresolved path derived from ~/.copilot/skills/understand-dashboard>}"
+     echo "  - ${CODEBUDDY_SELF_RELATIVE:-<unresolved path derived from ~/.codebuddy/skills/understand-dashboard>}"
      echo "  - $HOME/.codex/understand-anything/understand-anything-plugin"
      echo "  - $HOME/.opencode/understand-anything/understand-anything-plugin"
      echo "  - $HOME/.pi/understand-anything/understand-anything-plugin"

--- a/understand-anything-plugin/skills/understand-domain/SKILL.md
+++ b/understand-anything-plugin/skills/understand-domain/SKILL.md
@@ -51,6 +51,8 @@ SKILL_REAL=$(realpath ~/.agents/skills/understand-domain 2>/dev/null || readlink
 SELF_RELATIVE=$([ -n "$SKILL_REAL" ] && cd "$SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
 COPILOT_SKILL_REAL=$(realpath ~/.copilot/skills/understand-domain 2>/dev/null || readlink -f ~/.copilot/skills/understand-domain 2>/dev/null || echo "")
 COPILOT_SELF_RELATIVE=$([ -n "$COPILOT_SKILL_REAL" ] && cd "$COPILOT_SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
+CODEBUDDY_SKILL_REAL=$(realpath ~/.codebuddy/skills/understand-domain 2>/dev/null || readlink -f ~/.codebuddy/skills/understand-domain 2>/dev/null || echo "")
+CODEBUDDY_SELF_RELATIVE=$([ -n "$CODEBUDDY_SKILL_REAL" ] && cd "$CODEBUDDY_SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
 
 PLUGIN_ROOT=""
 for candidate in \
@@ -58,6 +60,7 @@ for candidate in \
   "$HOME/.understand-anything-plugin" \
   "$SELF_RELATIVE" \
   "$COPILOT_SELF_RELATIVE" \
+  "$CODEBUDDY_SELF_RELATIVE" \
   "$HOME/.codex/understand-anything/understand-anything-plugin" \
   "$HOME/.opencode/understand-anything/understand-anything-plugin" \
   "$HOME/.pi/understand-anything/understand-anything-plugin" \
@@ -75,6 +78,7 @@ if [ -z "$PLUGIN_ROOT" ]; then
   echo "  - $HOME/.understand-anything-plugin"
   echo "  - ${SELF_RELATIVE:-<unresolved path derived from ~/.agents/skills/understand-domain>}"
   echo "  - ${COPILOT_SELF_RELATIVE:-<unresolved path derived from ~/.copilot/skills/understand-domain>}"
+  echo "  - ${CODEBUDDY_SELF_RELATIVE:-<unresolved path derived from ~/.codebuddy/skills/understand-domain>}"
   echo "  - $HOME/.codex/understand-anything/understand-anything-plugin"
   echo "  - $HOME/.opencode/understand-anything/understand-anything-plugin"
   echo "  - $HOME/.pi/understand-anything/understand-anything-plugin"

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -81,6 +81,8 @@ Determine whether to run a full analysis or incremental update.
    SELF_RELATIVE=$([ -n "$SKILL_REAL" ] && cd "$SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
    COPILOT_SKILL_REAL=$(realpath ~/.copilot/skills/understand 2>/dev/null || readlink -f ~/.copilot/skills/understand 2>/dev/null || echo "")
    COPILOT_SELF_RELATIVE=$([ -n "$COPILOT_SKILL_REAL" ] && cd "$COPILOT_SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
+   CODEBUDDY_SKILL_REAL=$(realpath ~/.codebuddy/skills/understand 2>/dev/null || readlink -f ~/.codebuddy/skills/understand 2>/dev/null || echo "")
+   CODEBUDDY_SELF_RELATIVE=$([ -n "$CODEBUDDY_SKILL_REAL" ] && cd "$CODEBUDDY_SKILL_REAL/../.." 2>/dev/null && pwd || echo "")
 
    PLUGIN_ROOT=""
    for candidate in \
@@ -88,6 +90,7 @@ Determine whether to run a full analysis or incremental update.
      "$HOME/.understand-anything-plugin" \
      "$SELF_RELATIVE" \
      "$COPILOT_SELF_RELATIVE" \
+     "$CODEBUDDY_SELF_RELATIVE" \
      "$HOME/.codex/understand-anything/understand-anything-plugin" \
      "$HOME/.opencode/understand-anything/understand-anything-plugin" \
      "$HOME/.pi/understand-anything/understand-anything-plugin" \
@@ -105,6 +108,7 @@ Determine whether to run a full analysis or incremental update.
      echo "  - $HOME/.understand-anything-plugin"
      echo "  - ${SELF_RELATIVE:-<unresolved path derived from ~/.agents/skills/understand>}"
      echo "  - ${COPILOT_SELF_RELATIVE:-<unresolved path derived from ~/.copilot/skills/understand>}"
+     echo "  - ${CODEBUDDY_SELF_RELATIVE:-<unresolved path derived from ~/.codebuddy/skills/understand>}"
      echo "  - $HOME/.codex/understand-anything/understand-anything-plugin"
      echo "  - $HOME/.opencode/understand-anything/understand-anything-plugin"
      echo "  - $HOME/.pi/understand-anything/understand-anything-plugin"


### PR DESCRIPTION
Add Tencent Cloud CodeBuddy IDE as a supported platform.

## Changes (5 files, +14 lines)

- `install.sh`: register `codebuddy` in platform registry (per-skill, `~/.codebuddy/skills/`)
- `install.ps1`: register `codebuddy` for Windows
- `skills/understand/SKILL.md`: add `~/.codebuddy/skills/` to PLUGIN_ROOT detection
- `skills/understand-dashboard/SKILL.md`: same
- `skills/understand-domain/SKILL.md`: same

## Why

CodeBuddy reads user-level skills from `~/.codebuddy/skills/<name>/SKILL.md`,
matching the per-skill symlink approach used by Codex, Gemini, Pi, etc.

## Testing

- [x] `install.sh codebuddy` creates all 8 skill symlinks
- [x] PLUGIN_ROOT resolves via `~/.codebuddy/skills/` symlink
- [x] Dashboard path detection works
- [x] Fallback works without universal `~/.understand-anything-plugin` link
- [x] Core package builds (`tsc`)
- [x] All 753 existing tests pass, zero regressions
