### PR TITLE
Fix markdown parser dropping local files whose name starts with "http"

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts
@@ -47,6 +47,13 @@ describe("MarkdownParser", () => {
     expect(refs[0].target).toBe("./file.md");
   });
 
+  it("keeps local files whose name starts with 'http'", () => {
+    const content = "[client](http-client.md) and [ext](https://example.com)";
+    const refs = parser.extractReferences!("README.md", content);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].target).toBe("http-client.md");
+  });
+
   it("returns empty sections for empty content", () => {
     const result = parser.analyzeFile("empty.md", "");
     expect(result.sections).toHaveLength(0);

--- a/understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts
@@ -26,7 +26,9 @@ export class MarkdownParser implements AnalyzerPlugin {
     let match;
     while ((match = linkRegex.exec(content)) !== null) {
       const target = match[2];
-      if (target.startsWith("http")) continue; // Skip external URLs
+      // Skip external URLs (scheme://... or protocol-relative //...), but keep
+      // local files whose name merely begins with "http" (e.g. http-client.md).
+      if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(target) || target.startsWith("//")) continue;
       const line = content.slice(0, match.index).split("\n").length;
       refs.push({
         source: filePath,


### PR DESCRIPTION
## Summary

`MarkdownParser.extractReferences` is meant to extract local file/image references and skip external URLs (per its docstring). It does so with:

```ts
if (target.startsWith("http")) continue; // Skip external URLs
```

But `startsWith("http")` matches the bare substring, so any **local file whose name begins with "http"** is silently dropped — e.g. `[guide](http-client.md)`, `[notes](https-setup.md)`, `[x](httpie.md)`. These are relative links that should become `file` reference edges in the knowledge graph but are discarded, producing missing edges.

## Fix

Match an actual URL scheme instead of the `"http"` prefix:

```diff
-      if (target.startsWith("http")) continue; // Skip external URLs
+      // Skip external URLs (scheme://... or protocol-relative //...), but keep
+      // local files whose name merely begins with "http" (e.g. http-client.md).
+      if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(target) || target.startsWith("//")) continue;
```

This still skips `https://example.com`, `http://…`, `ftp://…`, and protocol-relative `//cdn/…`, while keeping local files like `http-client.md`.

## Testing

Added a case to the `MarkdownParser` suite in `parsers.test.ts`:

```ts
it("keeps local files whose name starts with 'http'", () => {
  const content = "[client](http-client.md) and [ext](https://example.com)";
  const refs = parser.extractReferences!("README.md", content);
  expect(refs).toHaveLength(1);
  expect(refs[0].target).toBe("http-client.md");
});
```

Verified standalone with the exact `extractReferences` regex/logic:

```
input: See [HTTP client](http-client.md) and [setup](./setup.md), but ignore [site](https://example.com) and ![img](pic.png).
BEFORE: ["file:./setup.md","image:pic.png"]                       (http-client.md dropped)
AFTER:  ["file:http-client.md","file:./setup.md","image:pic.png"] (kept; external URL still skipped)
```

The existing "extracts file references" and "skips external URLs in references" tests remain satisfied by the fix.
