### PR TITLE
feat(dashboard): support ?view=domain deep-link

### DIFF
--- a/understand-anything-plugin/packages/dashboard/src/App.tsx
+++ b/understand-anything-plugin/packages/dashboard/src/App.tsx
@@ -199,6 +199,12 @@ function Dashboard({ accessToken }: { accessToken: string }) {
         const result = validateGraph(data);
         if (result.success && result.data) {
           setDomainGraph(result.data);
+          // Deep-link: `?view=domain` opens straight on the domain flow view.
+          // Applied here (not at init) because the domain graph must be loaded
+          // before the domain view can render — otherwise App falls back to structural.
+          if (new URLSearchParams(window.location.search).get("view") === "domain") {
+            useDashboardStore.getState().setViewMode("domain");
+          }
         } else if (result.fatal) {
           console.warn(`[domain-graph] validation failed: ${result.fatal}`);
         }


### PR DESCRIPTION
## What

Adds a `?view=domain` URL parameter to the dashboard so it can open directly on the **domain flow view** instead of always starting on the structural graph.

## Why

Today the dashboard always loads on the structural view, and the only way to reach the domain view is to click the **Domain** toggle in the toolbar. That makes it impossible to bookmark or share a link that lands on the domain flow, or to have tooling launch the dashboard pointed straight at a domain graph. After running `/understand-domain`, jumping to the domain view is a common next step.

## How

In the `domain-graph.json` fetch handler in `App.tsx`, after the domain graph is set in the store, check for `?view=domain` and switch `viewMode` to `"domain"`.

```ts
if (result.success && result.data) {
  setDomainGraph(result.data);
  // Deep-link: `?view=domain` opens straight on the domain flow view.
  if (new URLSearchParams(window.location.search).get("view") === "domain") {
    useDashboardStore.getState().setViewMode("domain");
  }
}
```

The switch is intentionally applied **in the fetch handler, not at init** — the domain view can't render until the domain graph is loaded into the store (`App` falls back to structural otherwise). It also composes cleanly with the existing `token` param, which is stripped from the URL separately while `view` persists.

## Notes

- No new imports — `useDashboardStore` is already used the same way a few lines above for the `knowledge` view.
- Scope is minimal and additive: absent the param, behavior is unchanged (still defaults to structural).
- Only `domain` is handled here since `structural` is the default and `knowledge` is auto-selected for knowledge graphs; happy to extend to a general `view` switch if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)