### PR TITLE
fix(install): update kimi skill path to .agents/skills per-skill

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ vibe|$HOME/.vibe/skills|per-skill
 vscode|$HOME/.copilot/skills|per-skill
 hermes|$HOME/.hermes/skills|folder
 cline|$HOME/.cline/skills|folder
-kimi|$HOME/.kimi/skills|folder
+kimi|$HOME/.agents/skills|per-skill
 trae|$HOME/.trae/skills|per-skill
 nanobot|$HOME/.nanobot/workspace/skills|per-skill
 kiro|$HOME/.kiro/skills|per-skill


### PR DESCRIPTION
Kimi Code CLI currently discovers user skills under `~/.kimi-code/skills/` and `~/.agents/skills/`, and only scans direct subdirectories (it does not recursively load nested skill directories).

The previous installer mapping for `kimi` used the legacy `~/.kimi/skills/` path with a folder symlink, so none of the `/understand` skills were loaded.

This PR updates the kimi platform entry to use `~/.agents/skills` with per-skill symlinks, matching the current official Kimi Code CLI behavior.

Fixes the issue where `/understand` is unavailable after installing for kimi.