### PR TITLE
[codex] parse tsconfig JSONC without stripping globs

### DIFF
--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -146,13 +146,53 @@ function dirOf(p) {
  * with the exact tsconfig path that failed; bubbling the error would
  * conceal which file was at fault when many tsconfigs are loaded.
  */
-function parseTsConfigText(raw) {
+function stripJsoncComments(raw) {
+  let out = '';
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i];
+    const next = raw[i + 1];
+
+    if (inString) {
+      out += c;
+      if (escaped) escaped = false;
+      else if (c === '\\') escaped = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+
+    if (c === '"') {
+      inString = true;
+      out += c;
+      continue;
+    }
+
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < raw.length && !(raw[i] === '*' && raw[i + 1] === '/')) i++;
+      i++;
+      continue;
+    }
+
+    if (c === '/' && next === '/') {
+      while (i < raw.length && raw[i] !== '\n') i++;
+      out += '\n';
+      continue;
+    }
+
+    out += c;
+  }
+
+  return out.replace(/,(\s*[}\]])/g, '$1');
+}
+
+export function parseTsConfigText(raw) {
   // tsconfig.json often contains JSONC-style comments; strip line and block
-  // comments before parsing. The strip is naive (it doesn't honor string
-  // contents), so we fall back to the raw text on failure.
-  const stripped = raw
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+  // comments before parsing. Keep comment-looking tokens inside strings, such
+  // as the `/*` in common include globs like `**/*.ts`.
+  const stripped = stripJsoncComments(raw);
   let parsed;
   try {
     parsed = JSON.parse(stripped);

--- a/understand-anything-plugin/src/__tests__/extract-import-map.test.mjs
+++ b/understand-anything-plugin/src/__tests__/extract-import-map.test.mjs
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseTsConfigText } from '../../skills/understand/extract-import-map.mjs';
+
+describe('parseTsConfigText', () => {
+  it('keeps path aliases when glob strings contain comment-looking tokens', () => {
+    const parsed = parseTsConfigText(`{
+      "include": ["**/*.ts", "**/*.tsx"],
+      "compilerOptions": {
+        "paths": { "#/*": ["./src/*"] },
+        /* block comment */
+      }
+    }`);
+
+    expect(parsed?.paths.get('#/*')).toEqual(['./src/*']);
+  });
+});


### PR DESCRIPTION
## Summary
- replace the naive tsconfig JSONC comment stripping with a string-aware scanner
- preserve comment-looking tokens inside string literals such as **/*.ts
- add a regression test that keeps path aliases when include globs and block comments are both present

Fixes #502

## Validation
- npm exec --yes --package=pnpm@10.6.2 -- pnpm install --frozen-lockfile
- npm exec --yes --package=pnpm@10.6.2 -- pnpm vitest run understand-anything-plugin/src/__tests__/extract-import-map.test.mjs
- npm exec --yes --package=pnpm@10.6.2 -- pnpm eslint understand-anything-plugin/skills/understand/extract-import-map.mjs understand-anything-plugin/src/__tests__/extract-import-map.test.mjs
- node --check understand-anything-plugin/skills/understand/extract-import-map.mjs
- git diff --check