### PR TITLE
feat: dogfood Understand Anything on this repo (#508)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build skill
         run: pnpm --filter @understand-anything/skill build
 
+      - name: Check knowledge graph
+        run: node scripts/check-graph.mjs
+
       - name: Test core
         run: pnpm --filter @understand-anything/core test
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules
 dist
-.understand-anything
+.understand-anything/intermediate/
+.understand-anything/diff-overlay.json
+.understand-anything/tmp/
+.understand-anything/.trash-*/
 *.tsbuildinfo
 .DS_Store
 .env

--- a/.understand-anything/.understandignore
+++ b/.understand-anything/.understandignore
@@ -1,0 +1,48 @@
+# .understandignore — patterns for files/dirs to exclude from analysis
+# Syntax: same as .gitignore (globs, # comments, ! negation, trailing / for dirs)
+# Lines below are suggestions — uncomment to activate.
+# Use ! prefix to force-include something excluded by defaults.
+#
+# Built-in defaults (always excluded unless negated):
+#   node_modules/, .git/, dist/, build/, obj/, *.lock, *.min.js, etc.
+#
+
+# --- From .gitignore (uncomment to exclude) ---
+
+# .understand-anything
+# *.tsbuildinfo
+# .DS_Store
+# .env
+# .env.*
+# .claude/
+# .worktrees/
+# homepage/public/demo/
+# .private/
+# *.pyc
+# *.pyo
+# Thumbs.db
+
+# --- Detected directories (uncomment to exclude) ---
+
+# docs/
+# scripts/
+# tests/
+
+# --- Test file patterns (uncomment to exclude) ---
+
+# JS / TS
+# *.test.*
+# *.spec.*
+# *.snap
+# C# / .NET
+# **/*Tests.cs
+# **/*Test.cs
+# **/*Fixture.cs
+# **/*.Tests.csproj
+# Java / Kotlin
+# **/src/test/**
+# **/*Test.java
+# **/*IT.java
+# **/*Spec.kt
+# Go
+# **/*_test.go

--- a/.understand-anything/config.json
+++ b/.understand-anything/config.json
@@ -1,0 +1,4 @@
+{
+  "autoUpdate": true,
+  "outputLanguage": "en"
+}

--- a/.understand-anything/domain-graph.json
+++ b/.understand-anything/domain-graph.json
@@ -1,0 +1,1610 @@
+{
+  "version": "1.0.0",
+  "project": {
+    "name": "understand-anything",
+    "languages": [
+      "typescript",
+      "javascript",
+      "python",
+      "markdown",
+      "json",
+      "yaml",
+      "css",
+      "html",
+      "shell",
+      "powershell",
+      "astro",
+      "wasm"
+    ],
+    "frameworks": [
+      "Astro",
+      "GitHub Actions",
+      "React",
+      "Tailwind CSS",
+      "Vite",
+      "Vitest",
+      "Zustand"
+    ],
+    "description": "An open-source tool combining LLM intelligence + static analysis to produce interactive dashboards for understanding codebases.",
+    "analyzedAt": "2026-06-24T15:35:52.539Z",
+    "gitCommitHash": "dee750facc588fc860744f8c6061a150e6852d9f"
+  },
+  "nodes": [
+    {
+      "id": "domain:codebase-analysis-pipeline",
+      "type": "domain",
+      "name": "Codebase Analysis Pipeline",
+      "summary": "The end-to-end /understand orchestration that turns a raw repository into a committed knowledge graph. It scans the project, batches files, analyzes each batch with LLM + structural extraction, merges and normalizes results, assembles the graph, detects layers, builds a guided tour, validates, and persists.",
+      "tags": [
+        "pipeline",
+        "orchestration",
+        "knowledge-graph",
+        "llm"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entities": [
+          "ProjectScan",
+          "FileBatch",
+          "BatchGraph",
+          "KnowledgeGraph",
+          "Layer",
+          "Tour"
+        ],
+        "businessRules": [
+          "Every node must pass schema validation before the graph is saved",
+          "Each source file is assigned to exactly one architectural layer",
+          "Merge must dedupe node IDs and normalize edge direction across batches",
+          "Tour has 5-15 pedagogical steps ordered for learning"
+        ],
+        "crossDomainInteractions": [
+          "Invokes the Structural Extraction Engine to parse each file batch",
+          "Reuses fingerprints from Incremental Update & Staleness to skip unchanged files",
+          "Produces the knowledge-graph.json consumed by Dashboard Visualization and Graph-Powered Skill Flows"
+        ]
+      }
+    },
+    {
+      "id": "flow:run-understand-scan",
+      "type": "flow",
+      "name": "Run Full Codebase Analysis",
+      "summary": "Drives the /understand command through scanning, batched analysis, merge, assembly, layering, tour generation, validation, and save to produce knowledge-graph.json.",
+      "tags": [
+        "scan",
+        "merge",
+        "assemble",
+        "tour"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entryPoint": "/understand",
+        "entryType": "cli"
+      }
+    },
+    {
+      "id": "step:run-understand-scan:scan-project",
+      "type": "step",
+      "name": "Scan project inventory",
+      "summary": "project-scanner agent walks the repo to inventory files, detect languages/frameworks, build the import map, and estimate complexity.",
+      "tags": [
+        "scan",
+        "inventory"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/agents/project-scanner.md"
+    },
+    {
+      "id": "step:run-understand-scan:analyze-batches",
+      "type": "step",
+      "name": "Analyze file batches",
+      "summary": "file-analyzer agent processes each batch with structural extraction plus LLM semantic analysis to emit per-batch nodes and edges.",
+      "tags": [
+        "llm",
+        "batch",
+        "extraction"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/agents/file-analyzer.md"
+    },
+    {
+      "id": "step:run-understand-scan:merge-batches",
+      "type": "step",
+      "name": "Merge batch graphs",
+      "summary": "merge-batch-graphs.py combines all batch outputs, normalizes node IDs, links tests to production files, and reconciles edge direction.",
+      "tags": [
+        "merge",
+        "normalize"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "lineRange": [
+        724,
+        908
+      ]
+    },
+    {
+      "id": "step:run-understand-scan:assemble-graph",
+      "type": "step",
+      "name": "Assemble and review graph",
+      "summary": "GraphBuilder assembles the merged graph and the assemble-reviewer agent recovers dropped nodes/edges and fills cross-batch gaps.",
+      "tags": [
+        "assemble",
+        "review"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "lineRange": [
+        60,
+        337
+      ]
+    },
+    {
+      "id": "step:run-understand-scan:detect-layers",
+      "type": "step",
+      "name": "Detect architectural layers",
+      "summary": "layer-detector uses LLM prompting plus heuristics to group files into layers and assign each file to exactly one layer.",
+      "tags": [
+        "layers",
+        "architecture"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "lineRange": [
+        105,
+        144
+      ]
+    },
+    {
+      "id": "step:run-understand-scan:generate-tour",
+      "type": "step",
+      "name": "Generate guided tour",
+      "summary": "tour-generator builds an ordered set of pedagogical steps (heuristic or LLM) that teach the codebase architecture.",
+      "tags": [
+        "tour",
+        "pedagogy"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "lineRange": [
+        135,
+        293
+      ]
+    },
+    {
+      "id": "step:run-understand-scan:validate-graph",
+      "type": "step",
+      "name": "Validate and auto-fix graph",
+      "summary": "schema.ts sanitizes and auto-fixes the assembled graph, and the graph-reviewer agent renders an approval/rejection decision.",
+      "tags": [
+        "validation",
+        "schema"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/core/src/schema.ts",
+      "lineRange": [
+        196,
+        351
+      ]
+    },
+    {
+      "id": "step:run-understand-scan:save-and-fingerprint",
+      "type": "step",
+      "name": "Save graph and write fingerprints",
+      "summary": "Persistence writes knowledge-graph.json and build-fingerprints.mjs records per-file fingerprints so later runs can detect staleness.",
+      "tags": [
+        "persistence",
+        "fingerprint"
+      ],
+      "complexity": "simple",
+      "filePath": "understand-anything-plugin/skills/understand/build-fingerprints.mjs"
+    },
+    {
+      "id": "domain:structural-extraction-engine",
+      "type": "domain",
+      "name": "Structural Extraction Engine",
+      "summary": "The shared static-analysis core that parses source files into structural facts. It registers tree-sitter language extractors and config parsers, resolves language/framework detection, and produces functions, classes, imports, and an import map without any LLM involvement.",
+      "tags": [
+        "tree-sitter",
+        "static-analysis",
+        "parsers",
+        "core"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entities": [
+          "TreeSitterPlugin",
+          "Extractor",
+          "Parser",
+          "LanguageRegistry",
+          "FrameworkRegistry",
+          "ImportMap"
+        ],
+        "businessRules": [
+          "Uses web-tree-sitter (WASM) rather than native bindings for cross-platform compatibility",
+          "Every supported language registers exactly one extractor in the plugin registry",
+          "Config formats (JSON/YAML/TOML/etc.) route to dedicated non-tree-sitter parsers"
+        ],
+        "crossDomainInteractions": [
+          "Supplies parsed structure to the Codebase Analysis Pipeline's batch analysis step",
+          "Provides import-map data reused by Incremental Update & Staleness during merges"
+        ]
+      }
+    },
+    {
+      "id": "flow:extract-file-structure",
+      "type": "flow",
+      "name": "Extract Structure From a File",
+      "summary": "Selects the right language plugin/parser for a file, parses it via tree-sitter or a config parser, and walks the AST to emit structural nodes and import edges.",
+      "tags": [
+        "extraction",
+        "ast",
+        "tree-sitter"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entryPoint": "PluginRegistry.extract(file)",
+        "entryType": "manual"
+      }
+    },
+    {
+      "id": "step:extract-file-structure:detect-language",
+      "type": "step",
+      "name": "Detect language and framework",
+      "summary": "LanguageRegistry and FrameworkRegistry resolve a file's language and any framework signals from extension and content.",
+      "tags": [
+        "detection",
+        "registry"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "lineRange": [
+        9,
+        64
+      ]
+    },
+    {
+      "id": "step:extract-file-structure:select-plugin",
+      "type": "step",
+      "name": "Select extractor or parser",
+      "summary": "PluginRegistry dispatches to the matching tree-sitter extractor or, for config formats, to a registered config parser.",
+      "tags": [
+        "registry",
+        "dispatch"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "lineRange": [
+        11,
+        81
+      ]
+    },
+    {
+      "id": "step:extract-file-structure:parse-tree-sitter",
+      "type": "step",
+      "name": "Parse with tree-sitter plugin",
+      "summary": "TreeSitterPlugin loads the WASM grammar and produces a parse tree for the source file.",
+      "tags": [
+        "tree-sitter",
+        "wasm"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "lineRange": [
+        31,
+        299
+      ]
+    },
+    {
+      "id": "step:extract-file-structure:walk-ast",
+      "type": "step",
+      "name": "Walk AST with language extractor",
+      "summary": "A language-specific extractor (e.g. TypeScriptExtractor, PythonExtractor) traverses the tree to capture functions, classes, and imports.",
+      "tags": [
+        "ast",
+        "extractor"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "lineRange": [
+        106,
+        494
+      ]
+    },
+    {
+      "id": "step:extract-file-structure:parse-config",
+      "type": "step",
+      "name": "Parse config formats",
+      "summary": "Dedicated parsers (JSON/YAML/TOML/SQL/Dockerfile/etc.) handle non-tree-sitter config files via registerAllParsers.",
+      "tags": [
+        "config",
+        "parsers"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "lineRange": [
+        31,
+        44
+      ]
+    },
+    {
+      "id": "domain:incremental-update-staleness",
+      "type": "domain",
+      "name": "Incremental Update & Staleness",
+      "summary": "Keeps a committed knowledge graph in sync with a changing codebase. It fingerprints files, compares against the stored fingerprint store, classifies the scope of change, and feeds only affected files back through analysis for an incremental merge. A deterministic CI guard validates the self-graph and flags staleness.",
+      "tags": [
+        "incremental",
+        "fingerprint",
+        "staleness",
+        "ci-guard"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entities": [
+          "FileFingerprint",
+          "FingerprintStore",
+          "ChangeSet",
+          "UpdateClassification"
+        ],
+        "businessRules": [
+          "Unchanged files (matching fingerprints) are skipped on re-analysis",
+          "Change classification decides between incremental update and full re-scan",
+          "The committed self-graph must validate against the schema and not be stale relative to tracked source"
+        ],
+        "crossDomainInteractions": [
+          "Triggers targeted runs of the Codebase Analysis Pipeline for changed files only",
+          "Reuses import-map data from the Structural Extraction Engine",
+          "Its check-graph guard runs inside the Packaging & Distribution CI workflow"
+        ]
+      }
+    },
+    {
+      "id": "flow:incremental-graph-update",
+      "type": "flow",
+      "name": "Incrementally Update the Graph",
+      "summary": "Detects changed files via fingerprints, classifies the change scope, and merges fresh analysis of affected files back into the existing graph.",
+      "tags": [
+        "fingerprint",
+        "diff",
+        "merge"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entryPoint": "/understand (with existing graph)",
+        "entryType": "cli"
+      }
+    },
+    {
+      "id": "step:incremental-graph-update:build-fingerprints",
+      "type": "step",
+      "name": "Compute file fingerprints",
+      "summary": "extractFileFingerprint and buildFingerprintStore compute per-file content fingerprints for the current working tree.",
+      "tags": [
+        "fingerprint"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "lineRange": [
+        79,
+        122
+      ]
+    },
+    {
+      "id": "step:incremental-graph-update:detect-changes",
+      "type": "step",
+      "name": "Detect changed files",
+      "summary": "compareFingerprints and analyzeChanges diff the new fingerprints against the stored store to find added/modified/removed files.",
+      "tags": [
+        "diff",
+        "staleness"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "lineRange": [
+        131,
+        246
+      ]
+    },
+    {
+      "id": "step:incremental-graph-update:classify-change",
+      "type": "step",
+      "name": "Classify update scope",
+      "summary": "classifyUpdate and detectDirectoryChanges decide whether changes warrant an incremental update or a full re-scan.",
+      "tags": [
+        "classification"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "lineRange": [
+        21,
+        87
+      ]
+    },
+    {
+      "id": "step:incremental-graph-update:merge-subgraphs",
+      "type": "step",
+      "name": "Merge updated subgraphs",
+      "summary": "merge-subdomain-graphs.py folds freshly analyzed subgraphs of affected files back into the existing knowledge graph.",
+      "tags": [
+        "merge",
+        "incremental"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/skills/understand/merge-subdomain-graphs.py",
+      "lineRange": [
+        52,
+        232
+      ]
+    },
+    {
+      "id": "flow:guard-committed-graph",
+      "type": "flow",
+      "name": "Guard the Committed Self-Graph",
+      "summary": "A deterministic CI check that loads the committed knowledge graph, validates it against the schema, and verifies it is not stale relative to tracked source files or the domain graph.",
+      "tags": [
+        "ci-guard",
+        "validation",
+        "staleness"
+      ],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entryPoint": "node scripts/check-graph.mjs",
+        "entryType": "cron"
+      }
+    },
+    {
+      "id": "step:guard-committed-graph:load-core",
+      "type": "step",
+      "name": "Load core validators",
+      "summary": "loadCore dynamically imports the built core schema utilities used to validate the committed graphs.",
+      "tags": [
+        "bootstrap"
+      ],
+      "complexity": "simple",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        54,
+        66
+      ]
+    },
+    {
+      "id": "step:guard-committed-graph:validate-schema",
+      "type": "step",
+      "name": "Validate graph schema",
+      "summary": "validateOne runs schema validation against each committed graph and reports any structural errors.",
+      "tags": [
+        "schema",
+        "validation"
+      ],
+      "complexity": "moderate",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        68,
+        93
+      ]
+    },
+    {
+      "id": "step:guard-committed-graph:check-source-staleness",
+      "type": "step",
+      "name": "Check source staleness",
+      "summary": "trackedSourceFiles and checkStaleness compare the committed graph against git-tracked source files to detect drift.",
+      "tags": [
+        "staleness",
+        "git"
+      ],
+      "complexity": "moderate",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        109,
+        168
+      ]
+    },
+    {
+      "id": "step:guard-committed-graph:check-domain-sync",
+      "type": "step",
+      "name": "Check domain graph sync",
+      "summary": "checkDomainSync verifies the domain graph stays version-matched (commit hash) with the knowledge graph.",
+      "tags": [
+        "domain",
+        "sync"
+      ],
+      "complexity": "moderate",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        175,
+        215
+      ]
+    },
+    {
+      "id": "domain:domain-knowledge-extraction",
+      "type": "domain",
+      "name": "Domain & Knowledge Extraction",
+      "summary": "Produces higher-level graphs beyond raw structure. /understand-domain extracts business domains, flows, and steps either standalone or derived from an existing knowledge graph, while /understand-knowledge parses Karpathy-pattern wiki knowledge bases into entity/relationship graphs.",
+      "tags": [
+        "domain-graph",
+        "knowledge-base",
+        "extraction",
+        "llm"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entities": [
+          "DomainGraph",
+          "BusinessFlow",
+          "ProcessStep",
+          "WikiEntity",
+          "TopicCluster"
+        ],
+        "businessRules": [
+          "Domain graphs carry empty layers/tour and render in a dedicated dashboard view",
+          "When a knowledge graph exists, domains are derived from it without rescanning source files",
+          "The domain graph's commit hash is matched to the knowledge graph it derives from"
+        ],
+        "crossDomainInteractions": [
+          "Derives domain graphs from the Codebase Analysis Pipeline's knowledge-graph.json",
+          "Outputs graphs consumed by Dashboard Visualization's domain view",
+          "Standalone mode uses lightweight scanning instead of the Structural Extraction Engine"
+        ]
+      }
+    },
+    {
+      "id": "flow:extract-domain-graph",
+      "type": "flow",
+      "name": "Extract Business Domain Graph",
+      "summary": "Builds domain context (standalone or from the knowledge graph), runs the domain-analyzer agent to identify domains/flows/steps, and persists a validated domain graph.",
+      "tags": [
+        "domain",
+        "business-flow"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entryPoint": "/understand-domain",
+        "entryType": "cli"
+      }
+    },
+    {
+      "id": "step:extract-domain-graph:build-context",
+      "type": "step",
+      "name": "Build domain context",
+      "summary": "extract-domain-context.py scans the file tree, detects entry points, and extracts file signatures when no knowledge graph is present.",
+      "tags": [
+        "scan",
+        "context"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "lineRange": [
+        376,
+        424
+      ]
+    },
+    {
+      "id": "step:extract-domain-graph:analyze-domains",
+      "type": "step",
+      "name": "Analyze domains, flows, steps",
+      "summary": "domain-analyzer agent derives the three-level hierarchy from the context or knowledge graph node summaries.",
+      "tags": [
+        "llm",
+        "domain-analysis"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/agents/domain-analyzer.md"
+    },
+    {
+      "id": "step:extract-domain-graph:persist-domain-graph",
+      "type": "step",
+      "name": "Persist domain graph",
+      "summary": "loadDomainGraph and persistence utilities save and reload the domain graph with its version-matched commit hash.",
+      "tags": [
+        "persistence"
+      ],
+      "complexity": "simple",
+      "filePath": "understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "lineRange": [
+        162,
+        182
+      ]
+    },
+    {
+      "id": "flow:extract-knowledge-base-graph",
+      "type": "flow",
+      "name": "Extract Knowledge-Base Graph",
+      "summary": "Parses a Karpathy-pattern wiki/knowledge base, runs the article-analyzer agent to extract entities and implicit relationships, and merges results into a topic-clustered knowledge graph.",
+      "tags": [
+        "knowledge-base",
+        "wiki",
+        "entities"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entryPoint": "/understand-knowledge",
+        "entryType": "cli"
+      }
+    },
+    {
+      "id": "step:extract-knowledge-base-graph:parse-knowledge-base",
+      "type": "step",
+      "name": "Parse knowledge base",
+      "summary": "parse-knowledge-base.py detects the wiki format, resolves wikilinks, and parses index/log/wiki structures into raw entries.",
+      "tags": [
+        "parse",
+        "wiki"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "lineRange": [
+        278,
+        479
+      ]
+    },
+    {
+      "id": "step:extract-knowledge-base-graph:analyze-articles",
+      "type": "step",
+      "name": "Analyze articles for entities",
+      "summary": "article-analyzer agent extracts entities, claims, and implicit relationships from parsed markdown.",
+      "tags": [
+        "llm",
+        "entities"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/agents/article-analyzer.md"
+    },
+    {
+      "id": "step:extract-knowledge-base-graph:merge-knowledge-graph",
+      "type": "step",
+      "name": "Merge knowledge graph",
+      "summary": "merge-knowledge-graph.py combines per-article outputs into a single topic-clustered knowledge graph.",
+      "tags": [
+        "merge",
+        "clustering"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py",
+      "lineRange": [
+        92,
+        380
+      ]
+    },
+    {
+      "id": "domain:dashboard-visualization",
+      "type": "domain",
+      "name": "Dashboard Visualization",
+      "summary": "The React + TypeScript web dashboard that renders knowledge and domain graphs interactively. It loads and validates the graph, computes layout via ELK/Dagre, draws React Flow overview/layer/domain views, and serves source through a token-gated, path-allowlisted code viewer.",
+      "tags": [
+        "dashboard",
+        "react-flow",
+        "visualization",
+        "elk"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entities": [
+          "KnowledgeGraph",
+          "DomainGraph",
+          "Layer",
+          "Tour",
+          "ReactFlowNode",
+          "CodeViewer"
+        ],
+        "businessRules": [
+          "Graph is schema-validated on load with an error banner on failure",
+          "Source content is gated by an access token plus a graph-derived path allowlist",
+          "Domain graphs render in a dedicated view that ignores layers and tours"
+        ],
+        "crossDomainInteractions": [
+          "Consumes knowledge-graph.json from the Codebase Analysis Pipeline",
+          "Renders domain graphs produced by Domain & Knowledge Extraction",
+          "Built and deployed as a demo by the Packaging & Distribution CI workflow"
+        ]
+      }
+    },
+    {
+      "id": "flow:render-graph-dashboard",
+      "type": "flow",
+      "name": "Render Interactive Graph",
+      "summary": "Loads and validates the graph, computes a layout, and renders the overview, layer-detail, or domain view in React Flow.",
+      "tags": [
+        "render",
+        "layout",
+        "react-flow"
+      ],
+      "complexity": "complex",
+      "domainMeta": {
+        "entryPoint": "pnpm dev:dashboard",
+        "entryType": "http"
+      }
+    },
+    {
+      "id": "step:render-graph-dashboard:load-validate",
+      "type": "step",
+      "name": "Load and validate graph",
+      "summary": "The Dashboard app fetches the graph JSON, runs schema validation, and shows an error banner if validation fails.",
+      "tags": [
+        "load",
+        "validation"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "lineRange": [
+        222,
+        713
+      ]
+    },
+    {
+      "id": "step:render-graph-dashboard:compute-layout",
+      "type": "step",
+      "name": "Compute ELK layout",
+      "summary": "elk-layout utilities repair the ELK input and apply hierarchical layout to position nodes and edges.",
+      "tags": [
+        "layout",
+        "elk"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "lineRange": [
+        225,
+        244
+      ]
+    },
+    {
+      "id": "step:render-graph-dashboard:render-views",
+      "type": "step",
+      "name": "Render graph views",
+      "summary": "GraphView composes overview, layer-detail, and topology hooks to render the structural graph in React Flow.",
+      "tags": [
+        "react-flow",
+        "views"
+      ],
+      "complexity": "complex",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "lineRange": [
+        1299,
+        1573
+      ]
+    },
+    {
+      "id": "step:render-graph-dashboard:render-domain-view",
+      "type": "step",
+      "name": "Render domain view",
+      "summary": "DomainGraphView builds the domain overview and per-domain detail graphs for the dedicated domain rendering.",
+      "tags": [
+        "domain",
+        "view"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "lineRange": [
+        167,
+        271
+      ]
+    },
+    {
+      "id": "step:render-graph-dashboard:serve-source",
+      "type": "step",
+      "name": "Serve gated source",
+      "summary": "The dev server's readSourceFile endpoint serves file content gated by access token and a graph-derived path allowlist for the CodeViewer.",
+      "tags": [
+        "code-viewer",
+        "security"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "lineRange": [
+        114,
+        177
+      ]
+    },
+    {
+      "id": "domain:graph-powered-skill-flows",
+      "type": "domain",
+      "name": "Graph-Powered Skill Flows",
+      "summary": "The TypeScript-backed slash-command skills that answer questions over an existing knowledge graph. They build graph-derived context and prompts for codebase Q&A, git-diff impact analysis, deep file/function explanations, and new-hire onboarding guides.",
+      "tags": [
+        "skills",
+        "chat",
+        "diff",
+        "explain",
+        "onboard"
+      ],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entities": [
+          "ChatContext",
+          "DiffContext",
+          "ExplainContext",
+          "OnboardingGuide"
+        ],
+        "businessRules": [
+          "All flows operate on a previously built knowledge graph rather than rescanning source",
+          "Context is assembled from graph nodes/edges before being formatted into an LLM prompt"
+        ],
+        "crossDomainInteractions": [
+          "Read the knowledge-graph.json produced by the Codebase Analysis Pipeline",
+          "The diff flow overlaps with Incremental Update & Staleness in identifying affected components"
+        ]
+      }
+    },
+    {
+      "id": "flow:answer-codebase-question",
+      "type": "flow",
+      "name": "Answer a Codebase Question",
+      "summary": "Builds chat context from the knowledge graph and formats a prompt so the LLM can answer questions about architecture and components.",
+      "tags": [
+        "chat",
+        "qa"
+      ],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entryPoint": "/understand-chat",
+        "entryType": "cli"
+      }
+    },
+    {
+      "id": "step:answer-codebase-question:build-context",
+      "type": "step",
+      "name": "Build chat context",
+      "summary": "buildChatContext selects relevant graph nodes and edges to ground the question.",
+      "tags": [
+        "context"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/src/context-builder.ts",
+      "lineRange": [
+        25,
+        80
+      ]
+    },
+    {
+      "id": "step:answer-codebase-question:format-prompt",
+      "type": "step",
+      "name": "Format chat prompt",
+      "summary": "formatContextForPrompt and buildChatPrompt render the context into the final LLM prompt.",
+      "tags": [
+        "prompt"
+      ],
+      "complexity": "simple",
+      "filePath": "understand-anything-plugin/src/understand-chat.ts",
+      "lineRange": [
+        8,
+        29
+      ]
+    },
+    {
+      "id": "flow:analyze-diff-impact",
+      "type": "flow",
+      "name": "Analyze Diff Impact",
+      "summary": "Builds context from a git diff against the knowledge graph and formats an analysis of changed files, affected components, and risks.",
+      "tags": [
+        "diff",
+        "impact"
+      ],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entryPoint": "/understand-diff",
+        "entryType": "cli"
+      }
+    },
+    {
+      "id": "step:analyze-diff-impact:build-diff-context",
+      "type": "step",
+      "name": "Build diff context",
+      "summary": "buildDiffContext maps changed files to graph nodes to identify affected components.",
+      "tags": [
+        "diff",
+        "context"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/src/diff-analyzer.ts",
+      "lineRange": [
+        22,
+        88
+      ]
+    },
+    {
+      "id": "step:analyze-diff-impact:format-analysis",
+      "type": "step",
+      "name": "Format diff analysis",
+      "summary": "formatDiffAnalysis renders the affected components and risk summary for the diff.",
+      "tags": [
+        "analysis"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/src/diff-analyzer.ts",
+      "lineRange": [
+        93,
+        198
+      ]
+    },
+    {
+      "id": "flow:explain-and-onboard",
+      "type": "flow",
+      "name": "Explain Code & Onboard",
+      "summary": "Produces deep explanations of a file/function and generates onboarding guides for new team members, both grounded in the knowledge graph.",
+      "tags": [
+        "explain",
+        "onboard"
+      ],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entryPoint": "/understand-explain, /understand-onboard",
+        "entryType": "cli"
+      }
+    },
+    {
+      "id": "step:explain-and-onboard:build-explain-context",
+      "type": "step",
+      "name": "Build explain context",
+      "summary": "buildExplainContext gathers the target file/function plus its neighbors from the graph.",
+      "tags": [
+        "explain",
+        "context"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/src/explain-builder.ts",
+      "lineRange": [
+        22,
+        103
+      ]
+    },
+    {
+      "id": "step:explain-and-onboard:format-explain-prompt",
+      "type": "step",
+      "name": "Format explain prompt",
+      "summary": "formatExplainPrompt renders the deep-dive explanation prompt for the LLM.",
+      "tags": [
+        "prompt"
+      ],
+      "complexity": "simple",
+      "filePath": "understand-anything-plugin/src/explain-builder.ts",
+      "lineRange": [
+        108,
+        196
+      ]
+    },
+    {
+      "id": "step:explain-and-onboard:build-onboarding-guide",
+      "type": "step",
+      "name": "Build onboarding guide",
+      "summary": "buildOnboardingGuide assembles a new-hire onboarding guide from the graph's layers and key components.",
+      "tags": [
+        "onboard",
+        "guide"
+      ],
+      "complexity": "moderate",
+      "filePath": "understand-anything-plugin/src/onboard-builder.ts",
+      "lineRange": [
+        7,
+        124
+      ]
+    },
+    {
+      "id": "domain:packaging-distribution",
+      "type": "domain",
+      "name": "Packaging & Distribution",
+      "summary": "Installs the plugin across Claude Code and other platforms and runs CI/CD. Shell and PowerShell installers link skills/agents into the host platform, while GitHub Actions workflows lint/build/test the monorepo and deploy the homepage and demo dashboard.",
+      "tags": [
+        "install",
+        "ci-cd",
+        "distribution",
+        "deploy"
+      ],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entities": [
+          "Installer",
+          "PlatformTarget",
+          "CIWorkflow",
+          "DeployArtifact"
+        ],
+        "businessRules": [
+          "Installers must support multiple host platforms (Claude Code, opencode, cursor, copilot)",
+          "CI runs lint, build, and tests on pull requests and pushes to main",
+          "Homepage deploy publishes the combined homepage + demo dashboard to GitHub Pages"
+        ],
+        "crossDomainInteractions": [
+          "Builds and deploys the Dashboard Visualization demo",
+          "Runs the Incremental Update & Staleness check-graph guard as a CI step",
+          "Distributes the skills that drive all other domains"
+        ]
+      }
+    },
+    {
+      "id": "flow:install-plugin",
+      "type": "flow",
+      "name": "Install the Plugin",
+      "summary": "Resolves the host platform, clones or updates the repo, and links skills/agents into the platform's plugin directory.",
+      "tags": [
+        "install",
+        "multi-platform"
+      ],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entryPoint": "./install.sh / install.ps1",
+        "entryType": "cli"
+      }
+    },
+    {
+      "id": "step:install-plugin:resolve-platform",
+      "type": "step",
+      "name": "Resolve target platform",
+      "summary": "resolve_platform / prompt_platform determine which host platform (Claude Code, cursor, etc.) to install into.",
+      "tags": [
+        "platform"
+      ],
+      "complexity": "simple",
+      "filePath": "install.sh",
+      "lineRange": [
+        50,
+        60
+      ]
+    },
+    {
+      "id": "step:install-plugin:link-skills",
+      "type": "step",
+      "name": "Link skills and agents",
+      "summary": "link_skills wires the plugin's skills and agents into the resolved platform's directory.",
+      "tags": [
+        "link"
+      ],
+      "complexity": "moderate",
+      "filePath": "install.sh",
+      "lineRange": [
+        120,
+        142
+      ]
+    },
+    {
+      "id": "step:install-plugin:run-install",
+      "type": "step",
+      "name": "Run install command",
+      "summary": "cmd_install orchestrates clone/update and linking; cmd_uninstall reverses it.",
+      "tags": [
+        "orchestration"
+      ],
+      "complexity": "moderate",
+      "filePath": "install.sh",
+      "lineRange": [
+        181,
+        232
+      ]
+    },
+    {
+      "id": "flow:ci-cd-pipeline",
+      "type": "flow",
+      "name": "Run CI/CD",
+      "summary": "On pull requests and pushes, lints/builds/tests the monorepo (including the graph guard) and deploys the homepage and demo dashboard to GitHub Pages.",
+      "tags": [
+        "ci",
+        "deploy",
+        "github-actions"
+      ],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entryPoint": "GitHub Actions (push/PR)",
+        "entryType": "event"
+      }
+    },
+    {
+      "id": "step:ci-cd-pipeline:ci-lint-build-test",
+      "type": "step",
+      "name": "Lint, build, and test",
+      "summary": "The CI job checks out the repo, sets up pnpm and Node, installs dependencies, then lints, builds core, and runs tests.",
+      "tags": [
+        "ci",
+        "test"
+      ],
+      "complexity": "moderate",
+      "filePath": ".github/workflows/ci.yml"
+    },
+    {
+      "id": "step:ci-cd-pipeline:guard-graph",
+      "type": "step",
+      "name": "Guard committed graph",
+      "summary": "CI runs scripts/check-graph.mjs to validate the committed self-graph and flag schema or staleness regressions.",
+      "tags": [
+        "ci-guard",
+        "staleness"
+      ],
+      "complexity": "moderate",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        217,
+        239
+      ]
+    },
+    {
+      "id": "step:ci-cd-pipeline:build-deploy-homepage",
+      "type": "step",
+      "name": "Build and deploy homepage",
+      "summary": "The deploy workflow builds the homepage, core, and demo dashboard, then publishes the artifact to GitHub Pages.",
+      "tags": [
+        "deploy",
+        "homepage"
+      ],
+      "complexity": "moderate",
+      "filePath": ".github/workflows/deploy-homepage.yml"
+    }
+  ],
+  "edges": [
+    {
+      "source": "domain:codebase-analysis-pipeline",
+      "target": "flow:run-understand-scan",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:run-understand-scan",
+      "target": "step:run-understand-scan:scan-project",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.1
+    },
+    {
+      "source": "flow:run-understand-scan",
+      "target": "step:run-understand-scan:analyze-batches",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.2
+    },
+    {
+      "source": "flow:run-understand-scan",
+      "target": "step:run-understand-scan:merge-batches",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.3
+    },
+    {
+      "source": "flow:run-understand-scan",
+      "target": "step:run-understand-scan:assemble-graph",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.4
+    },
+    {
+      "source": "flow:run-understand-scan",
+      "target": "step:run-understand-scan:detect-layers",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "flow:run-understand-scan",
+      "target": "step:run-understand-scan:generate-tour",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "flow:run-understand-scan",
+      "target": "step:run-understand-scan:validate-graph",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "flow:run-understand-scan",
+      "target": "step:run-understand-scan:save-and-fingerprint",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "domain:structural-extraction-engine",
+      "target": "flow:extract-file-structure",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:extract-file-structure",
+      "target": "step:extract-file-structure:detect-language",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.2
+    },
+    {
+      "source": "flow:extract-file-structure",
+      "target": "step:extract-file-structure:select-plugin",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.4
+    },
+    {
+      "source": "flow:extract-file-structure",
+      "target": "step:extract-file-structure:parse-tree-sitter",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "flow:extract-file-structure",
+      "target": "step:extract-file-structure:walk-ast",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "flow:extract-file-structure",
+      "target": "step:extract-file-structure:parse-config",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "domain:incremental-update-staleness",
+      "target": "flow:incremental-graph-update",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:incremental-graph-update",
+      "target": "step:incremental-graph-update:build-fingerprints",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.3
+    },
+    {
+      "source": "flow:incremental-graph-update",
+      "target": "step:incremental-graph-update:detect-changes",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "flow:incremental-graph-update",
+      "target": "step:incremental-graph-update:classify-change",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "flow:incremental-graph-update",
+      "target": "step:incremental-graph-update:merge-subgraphs",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "domain:incremental-update-staleness",
+      "target": "flow:guard-committed-graph",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:guard-committed-graph",
+      "target": "step:guard-committed-graph:load-core",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.3
+    },
+    {
+      "source": "flow:guard-committed-graph",
+      "target": "step:guard-committed-graph:validate-schema",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "flow:guard-committed-graph",
+      "target": "step:guard-committed-graph:check-source-staleness",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "flow:guard-committed-graph",
+      "target": "step:guard-committed-graph:check-domain-sync",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "domain:domain-knowledge-extraction",
+      "target": "flow:extract-domain-graph",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:extract-domain-graph",
+      "target": "step:extract-domain-graph:build-context",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.3
+    },
+    {
+      "source": "flow:extract-domain-graph",
+      "target": "step:extract-domain-graph:analyze-domains",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "flow:extract-domain-graph",
+      "target": "step:extract-domain-graph:persist-domain-graph",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "domain:domain-knowledge-extraction",
+      "target": "flow:extract-knowledge-base-graph",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:extract-knowledge-base-graph",
+      "target": "step:extract-knowledge-base-graph:parse-knowledge-base",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.3
+    },
+    {
+      "source": "flow:extract-knowledge-base-graph",
+      "target": "step:extract-knowledge-base-graph:analyze-articles",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "flow:extract-knowledge-base-graph",
+      "target": "step:extract-knowledge-base-graph:merge-knowledge-graph",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "domain:dashboard-visualization",
+      "target": "flow:render-graph-dashboard",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:render-graph-dashboard",
+      "target": "step:render-graph-dashboard:load-validate",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.2
+    },
+    {
+      "source": "flow:render-graph-dashboard",
+      "target": "step:render-graph-dashboard:compute-layout",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.4
+    },
+    {
+      "source": "flow:render-graph-dashboard",
+      "target": "step:render-graph-dashboard:render-views",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "flow:render-graph-dashboard",
+      "target": "step:render-graph-dashboard:render-domain-view",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "flow:render-graph-dashboard",
+      "target": "step:render-graph-dashboard:serve-source",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "domain:graph-powered-skill-flows",
+      "target": "flow:answer-codebase-question",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:answer-codebase-question",
+      "target": "step:answer-codebase-question:build-context",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "flow:answer-codebase-question",
+      "target": "step:answer-codebase-question:format-prompt",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "domain:graph-powered-skill-flows",
+      "target": "flow:analyze-diff-impact",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:analyze-diff-impact",
+      "target": "step:analyze-diff-impact:build-diff-context",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "flow:analyze-diff-impact",
+      "target": "step:analyze-diff-impact:format-analysis",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "domain:graph-powered-skill-flows",
+      "target": "flow:explain-and-onboard",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:explain-and-onboard",
+      "target": "step:explain-and-onboard:build-explain-context",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.3
+    },
+    {
+      "source": "flow:explain-and-onboard",
+      "target": "step:explain-and-onboard:format-explain-prompt",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "flow:explain-and-onboard",
+      "target": "step:explain-and-onboard:build-onboarding-guide",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "domain:packaging-distribution",
+      "target": "flow:install-plugin",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:install-plugin",
+      "target": "step:install-plugin:resolve-platform",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.3
+    },
+    {
+      "source": "flow:install-plugin",
+      "target": "step:install-plugin:link-skills",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "flow:install-plugin",
+      "target": "step:install-plugin:run-install",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "domain:packaging-distribution",
+      "target": "flow:ci-cd-pipeline",
+      "type": "contains_flow",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "flow:ci-cd-pipeline",
+      "target": "step:ci-cd-pipeline:ci-lint-build-test",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.3
+    },
+    {
+      "source": "flow:ci-cd-pipeline",
+      "target": "step:ci-cd-pipeline:guard-graph",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "flow:ci-cd-pipeline",
+      "target": "step:ci-cd-pipeline:build-deploy-homepage",
+      "type": "flow_step",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "domain:codebase-analysis-pipeline",
+      "target": "domain:structural-extraction-engine",
+      "type": "cross_domain",
+      "direction": "forward",
+      "description": "Batch analysis invokes the extraction engine to parse each file into structural facts",
+      "weight": 0.8
+    },
+    {
+      "source": "domain:codebase-analysis-pipeline",
+      "target": "domain:incremental-update-staleness",
+      "type": "cross_domain",
+      "direction": "forward",
+      "description": "Saves fingerprints and reuses them so later runs only re-analyze changed files",
+      "weight": 0.7
+    },
+    {
+      "source": "domain:incremental-update-staleness",
+      "target": "domain:structural-extraction-engine",
+      "type": "cross_domain",
+      "direction": "forward",
+      "description": "Reuses import-map data from the extraction engine during incremental merges",
+      "weight": 0.5
+    },
+    {
+      "source": "domain:domain-knowledge-extraction",
+      "target": "domain:codebase-analysis-pipeline",
+      "type": "cross_domain",
+      "direction": "forward",
+      "description": "Derives domain graphs from the knowledge-graph.json produced by the pipeline",
+      "weight": 0.7
+    },
+    {
+      "source": "domain:dashboard-visualization",
+      "target": "domain:codebase-analysis-pipeline",
+      "type": "cross_domain",
+      "direction": "forward",
+      "description": "Loads and renders the knowledge graph produced by the pipeline",
+      "weight": 0.8
+    },
+    {
+      "source": "domain:dashboard-visualization",
+      "target": "domain:domain-knowledge-extraction",
+      "type": "cross_domain",
+      "direction": "forward",
+      "description": "Renders domain graphs in a dedicated layer-free view",
+      "weight": 0.6
+    },
+    {
+      "source": "domain:graph-powered-skill-flows",
+      "target": "domain:codebase-analysis-pipeline",
+      "type": "cross_domain",
+      "direction": "forward",
+      "description": "Build context from the knowledge graph produced by the pipeline",
+      "weight": 0.7
+    },
+    {
+      "source": "domain:graph-powered-skill-flows",
+      "target": "domain:incremental-update-staleness",
+      "type": "cross_domain",
+      "direction": "forward",
+      "description": "The diff flow overlaps in mapping changed files to affected graph components",
+      "weight": 0.5
+    },
+    {
+      "source": "domain:packaging-distribution",
+      "target": "domain:dashboard-visualization",
+      "type": "cross_domain",
+      "direction": "forward",
+      "description": "CI builds and deploys the dashboard as a demo to GitHub Pages",
+      "weight": 0.6
+    },
+    {
+      "source": "domain:packaging-distribution",
+      "target": "domain:incremental-update-staleness",
+      "type": "cross_domain",
+      "direction": "forward",
+      "description": "CI runs the check-graph staleness guard as a build step",
+      "weight": 0.6
+    }
+  ],
+  "layers": [],
+  "tour": []
+}

--- a/.understand-anything/fingerprints.json
+++ b/.understand-anything/fingerprints.json
@@ -1,0 +1,14708 @@
+{
+  "version": "1.0.0",
+  "gitCommitHash": "dee750facc588fc860744f8c6061a150e6852d9f",
+  "generatedAt": "2026-06-24T15:31:48.565Z",
+  "files": {
+    ".claude-plugin/marketplace.json": {
+      "filePath": ".claude-plugin/marketplace.json",
+      "contentHash": "d059b94d2024b6e5e116bb183af66992cc15c79f7aa1d46c8b460136927461e5",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    ".claude-plugin/plugin.json": {
+      "filePath": ".claude-plugin/plugin.json",
+      "contentHash": "0709dd4dc5883e5a8117a81a618b0a790ee53e3b3e253a97ea0d343cdee9a635",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 19,
+      "hasStructuralAnalysis": true
+    },
+    ".copilot-plugin/plugin.json": {
+      "filePath": ".copilot-plugin/plugin.json",
+      "contentHash": "96879a3008d617dbc856371886ac2c24b73b7445db71c0665baf439fd622a343",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    ".cursor-plugin/plugin.json": {
+      "filePath": ".cursor-plugin/plugin.json",
+      "contentHash": "94599298db5de85651fd2efd9445b6cacfe5eb0aefac75d019fbc6cb1d9158a9",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    ".github/ISSUE_TEMPLATE/bug_report.yml": {
+      "filePath": ".github/ISSUE_TEMPLATE/bug_report.yml",
+      "contentHash": "44f62a309d6bf2d35f6e50fc205ae7c7235ef6ab123ad5736361edbe6d487cfc",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 86,
+      "hasStructuralAnalysis": true
+    },
+    ".github/ISSUE_TEMPLATE/config.yml": {
+      "filePath": ".github/ISSUE_TEMPLATE/config.yml",
+      "contentHash": "ffdc268222a7c675c57226acd712c5cbee3134c6ad8f8834ec3941c227fa3ca8",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 9,
+      "hasStructuralAnalysis": true
+    },
+    ".github/ISSUE_TEMPLATE/feature_request.yml": {
+      "filePath": ".github/ISSUE_TEMPLATE/feature_request.yml",
+      "contentHash": "8b462bce591a05bd44a9186f1ad45571940a381c15661b15ee51f81394647460",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 35,
+      "hasStructuralAnalysis": true
+    },
+    ".github/ISSUE_TEMPLATE/question.yml": {
+      "filePath": ".github/ISSUE_TEMPLATE/question.yml",
+      "contentHash": "5b60b9142f3e31ab41a94c67fe76ecc8fcca9de79d378195db9048edcf4bac02",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 25,
+      "hasStructuralAnalysis": true
+    },
+    ".github/PULL_REQUEST_TEMPLATE.md": {
+      "filePath": ".github/PULL_REQUEST_TEMPLATE.md",
+      "contentHash": "5d34b46f4378b9b9793973e61b04bee2f99e3dfdb514e9368439ac0cb902359a",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 27,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflows/ci.yml": {
+      "filePath": ".github/workflows/ci.yml",
+      "contentHash": "f14b8e9e898337949d2728705f9815a7b07529cbdbafa03ac9f8ca14a7a33393",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 54,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflows/deploy-homepage.yml": {
+      "filePath": ".github/workflows/deploy-homepage.yml",
+      "contentHash": "f8bb0cd50a6ce8a998d775298ef47d75b374461722767c2d7996a7ab29f50521",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 69,
+      "hasStructuralAnalysis": true
+    },
+    ".npmrc": {
+      "filePath": ".npmrc",
+      "contentHash": "24cade6ac50ff12fc176817d9d9fd9fcc4662a970516aad401a3a08b8411bb6b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 3,
+      "hasStructuralAnalysis": false
+    },
+    "CLAUDE.md": {
+      "filePath": "CLAUDE.md",
+      "contentHash": "3659adc3836e86af84a7c6a5f269894a2cc07a18d1a0b3728a60b04713da6679",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 107,
+      "hasStructuralAnalysis": true
+    },
+    "CODE_OF_CONDUCT.md": {
+      "filePath": "CODE_OF_CONDUCT.md",
+      "contentHash": "9d68137aacef8b8ff664da1731fe3fb9033b3e8f5b381e7afac3995af32538bf",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 40,
+      "hasStructuralAnalysis": true
+    },
+    "CONTRIBUTING.md": {
+      "filePath": "CONTRIBUTING.md",
+      "contentHash": "4ea08f2da8d15d111fc19c4ca790d782c7b9aab4fba0752676eadf5b45b7a0a1",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 286,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-14-phase1-implementation.md": {
+      "filePath": "docs/superpowers/plans/2026-03-14-phase1-implementation.md",
+      "contentHash": "3178fc1d11740b1c551a853b4889788d6f5ed6156baad8596f972b7aaa837870",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2470,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-14-phase2-implementation.md": {
+      "filePath": "docs/superpowers/plans/2026-03-14-phase2-implementation.md",
+      "contentHash": "77eb7398739a3e55daeabb5e5dcd829d022bc88908ec873388d8f747659920e7",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1848,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-14-phase3-implementation.md": {
+      "filePath": "docs/superpowers/plans/2026-03-14-phase3-implementation.md",
+      "contentHash": "386e20a99f5507c5bf5c5cca9ea9bd1f88e11b4ca6545b345caee4210a7e1900",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1659,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-14-phase4-implementation.md": {
+      "filePath": "docs/superpowers/plans/2026-03-14-phase4-implementation.md",
+      "contentHash": "fd3e1e3144a1410c14bfae0ae953bd513991e7b64b14d24994f7fa481c803c92",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1873,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-15-homepage-implementation.md": {
+      "filePath": "docs/superpowers/plans/2026-03-15-homepage-implementation.md",
+      "contentHash": "d3cd24bafa1260ff4a1d9ea2cf842eff8351d6f2266c627dc2b06089b9d0dbe3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1239,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-18-multi-platform-simple-implementation.md": {
+      "filePath": "docs/superpowers/plans/2026-03-18-multi-platform-simple-implementation.md",
+      "contentHash": "381ff182fd80579ba0bdfe9542f983549b9dcf3d4276bae3e53702dc6f925bc6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 561,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-21-language-agnostic-plan.md": {
+      "filePath": "docs/superpowers/plans/2026-03-21-language-agnostic-plan.md",
+      "contentHash": "d2da39b7bdb156cd1865749757ab4a1c55bee58b6547d57ccecbfcb282155471",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1393,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-25-dashboard-robustness-impl.md": {
+      "filePath": "docs/superpowers/plans/2026-03-25-dashboard-robustness-impl.md",
+      "contentHash": "c5be35433c8ce38c61c1f39f095d16da1450451e4b68f6e61f4cca6051848a21",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1278,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-25-dashboard-robustness-plan.md": {
+      "filePath": "docs/superpowers/plans/2026-03-25-dashboard-robustness-plan.md",
+      "contentHash": "ddeb7bd96b066b10c6b59a61a5d8819626ccac840e0ce6dc4d9450099237083b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 150,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-26-theme-system-implementation.md": {
+      "filePath": "docs/superpowers/plans/2026-03-26-theme-system-implementation.md",
+      "contentHash": "4901c4c73e92df84ca43f22fe505c4e0fd8c0716932b15232f549ded252d2bd3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1167,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-27-token-reduction-impl.md": {
+      "filePath": "docs/superpowers/plans/2026-03-27-token-reduction-impl.md",
+      "contentHash": "1b1a23a19f7e39385dd8d008835b709d605f9a22b3462e20ff26055f4fa364f4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 972,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-28-understand-anything-extension-impl.md": {
+      "filePath": "docs/superpowers/plans/2026-03-28-understand-anything-extension-impl.md",
+      "contentHash": "47a2f78e54e5640f26a4c223568c67b7c7c7ee3685529e83df902f4204f1b08d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1427,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-03-29-homepage-update-impl.md": {
+      "filePath": "docs/superpowers/plans/2026-03-29-homepage-update-impl.md",
+      "contentHash": "309a1ffdf2794553ca707acf0190bcd64c97b6554b761312f42517e75cfa6246",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 139,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-04-01-business-domain-knowledge-impl.md": {
+      "filePath": "docs/superpowers/plans/2026-04-01-business-domain-knowledge-impl.md",
+      "contentHash": "61255644fb532e9c2bada60311168008fe24f8556a6e4b8b50fe2c7cb5160080",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1785,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-04-09-understand-knowledge.md": {
+      "filePath": "docs/superpowers/plans/2026-04-09-understand-knowledge.md",
+      "contentHash": "e2b6b170f8b400e631c549f5d24ab771accf2b602aa53ae75ab5b8fa8da72f5b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1741,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-04-10-understandignore-impl.md": {
+      "filePath": "docs/superpowers/plans/2026-04-10-understandignore-impl.md",
+      "contentHash": "d4b31dac32d738ce9653b6db95e38d991fe150ee79efe5e23523f7724ff99fee",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 777,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-04-15-language-extractors-impl.md": {
+      "filePath": "docs/superpowers/plans/2026-04-15-language-extractors-impl.md",
+      "contentHash": "794fbf1c57ecc2e272ce4d3052daf4f337f0132ea050036bd661d1f63554d2bc",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 857,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-05-03-graph-layout-scaling.md": {
+      "filePath": "docs/superpowers/plans/2026-05-03-graph-layout-scaling.md",
+      "contentHash": "7868eedf89518a468799abdbe9bcce9263e516e6716b9f3d875dc924f992655a",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2305,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-05-24-semantic-batching-and-output-chunking-impl.md": {
+      "filePath": "docs/superpowers/plans/2026-05-24-semantic-batching-and-output-chunking-impl.md",
+      "contentHash": "139f5890892ac1887a0720420beadf2d61361b2b6660bccadd04e2fa44674c0c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2354,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/plans/2026-06-03-language-auto-detection.md": {
+      "filePath": "docs/superpowers/plans/2026-06-03-language-auto-detection.md",
+      "contentHash": "a86c3881afdd447bac61a701ec5eaf116c9fe31ca743fa0bfbab89d743b60fea",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 211,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-03-14-understand-anything-design.md": {
+      "filePath": "docs/superpowers/specs/2026-03-14-understand-anything-design.md",
+      "contentHash": "1ddfdbb2649cae18c390375658c42b4220d42d8bcf7aa7e36659fadf3a649775",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 269,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-03-15-homepage-design.md": {
+      "filePath": "docs/superpowers/specs/2026-03-15-homepage-design.md",
+      "contentHash": "c79f4f6fda58deab7319e26831fc5041c34b4f72f3d89dc3ec5463e5b17dbec8",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 84,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-03-18-multi-platform-simple-design.md": {
+      "filePath": "docs/superpowers/specs/2026-03-18-multi-platform-simple-design.md",
+      "contentHash": "5c623cf251038ec7b41969c5775efbe27588e14be77081f617e3481c20bea1d7",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 122,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-03-21-language-agnostic-design.md": {
+      "filePath": "docs/superpowers/specs/2026-03-21-language-agnostic-design.md",
+      "contentHash": "c0ca0798482378238e8617f317ec2f31d4e5498561a6cc3ddc581e633fa56006",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 250,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-03-26-theme-system-design.md": {
+      "filePath": "docs/superpowers/specs/2026-03-26-theme-system-design.md",
+      "contentHash": "b364f48b35b42021bfa7bc2f607ff79a7060daa5afcf07a977449b8a8ff631d2",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 416,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-03-27-token-reduction-design.md": {
+      "filePath": "docs/superpowers/specs/2026-03-27-token-reduction-design.md",
+      "contentHash": "ec8148fe6faff891be068c7fe463971829964531374b84f0be620a9cfe89797e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 396,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-03-28-understand-anything-extension-design.md": {
+      "filePath": "docs/superpowers/specs/2026-03-28-understand-anything-extension-design.md",
+      "contentHash": "029b518d20af4ecc00d1c788da1defb0acb2bbba80b4616839173af574305caa",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 267,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-03-29-homepage-update-design.md": {
+      "filePath": "docs/superpowers/specs/2026-03-29-homepage-update-design.md",
+      "contentHash": "705825c9cfb6f0cdb48c13dc6416e78147607cc17bc2b5c42c921e9a669cb7f7",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 54,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-04-01-business-domain-knowledge-design.md": {
+      "filePath": "docs/superpowers/specs/2026-04-01-business-domain-knowledge-design.md",
+      "contentHash": "b1b4fc655235974473e403ffaca7bdcc58d21172aafbe33d122444a09dfae5a9",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 336,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-04-09-understand-knowledge-design.md": {
+      "filePath": "docs/superpowers/specs/2026-04-09-understand-knowledge-design.md",
+      "contentHash": "5a2f5d1bfc305bc3db8cd96a116b53102b939e9d605abf9f51799c14383a5ee4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 336,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-04-10-understandignore-design.md": {
+      "filePath": "docs/superpowers/specs/2026-04-10-understandignore-design.md",
+      "contentHash": "25e51e8df9d7ac10f581565ad965d3fed1e34682df787567f6dcd451913344e1",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 259,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-05-03-graph-layout-scaling-design.md": {
+      "filePath": "docs/superpowers/specs/2026-05-03-graph-layout-scaling-design.md",
+      "contentHash": "4f2145049d29b6fc89a8375a01a9306d6c5f1867dd9f68eca740a3ed2388aaf2",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 489,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-05-24-semantic-batching-and-output-chunking-design.md": {
+      "filePath": "docs/superpowers/specs/2026-05-24-semantic-batching-and-output-chunking-design.md",
+      "contentHash": "b86379d0ad933258f963def793de11ca1749407e46d0c6f3f92071f8b33f3a80",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 588,
+      "hasStructuralAnalysis": true
+    },
+    "docs/superpowers/specs/2026-06-03-language-auto-detection-design.md": {
+      "filePath": "docs/superpowers/specs/2026-06-03-language-auto-detection-design.md",
+      "contentHash": "ee0e2d6c8b64fc53c5a289950550d01ceee0ceea6984d5b3ed5d296856953057",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 148,
+      "hasStructuralAnalysis": true
+    },
+    "eslint.config.mjs": {
+      "filePath": "eslint.config.mjs",
+      "contentHash": "9705afb648edacb1d1b446047507fc13069c6c8a31bbd4c41949ab8dc70246cb",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@eslint/js",
+          "specifiers": [
+            "eslint"
+          ]
+        },
+        {
+          "source": "typescript-eslint",
+          "specifiers": [
+            "tseslint"
+          ]
+        },
+        {
+          "source": "globals",
+          "specifiers": [
+            "globals"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 57,
+      "hasStructuralAnalysis": true
+    },
+    "homepage/astro.config.mjs": {
+      "filePath": "homepage/astro.config.mjs",
+      "contentHash": "47ec3394cac6019d9b91acd06b9f095bf26ccf4c0c4e16cf9e43f4811599a402",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "astro/config",
+          "specifiers": [
+            "defineConfig"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 8,
+      "hasStructuralAnalysis": true
+    },
+    "homepage/package.json": {
+      "filePath": "homepage/package.json",
+      "contentHash": "ad37ab71c03bce154cdc611106487cff39920796906736f70068930124d249ec",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 17,
+      "hasStructuralAnalysis": true
+    },
+    "homepage/public/.gitkeep": {
+      "filePath": "homepage/public/.gitkeep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/public/CNAME": {
+      "filePath": "homepage/public/CNAME",
+      "contentHash": "79e63b53004a149c9b5a2eca3ff5cb2872801c03a36bb8f86324e5122ffab232",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/README.md": {
+      "filePath": "homepage/README.md",
+      "contentHash": "b982a81b9d2c8b0e4f17695667a2c869f00f199a6f6b47756e1d9fafbb17f4bf",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 29,
+      "hasStructuralAnalysis": true
+    },
+    "homepage/src/components/CommunityVideo.astro": {
+      "filePath": "homepage/src/components/CommunityVideo.astro",
+      "contentHash": "c26650f2b5a90ad38f09926bce2494232d740bbf2db810ec7aec4c9faf5777be",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 148,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/src/components/Features.astro": {
+      "filePath": "homepage/src/components/Features.astro",
+      "contentHash": "bd9f596abb1c83df57c708af1c68749c33ed167041ece68d3612fb5168f4a287",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 114,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/src/components/Footer.astro": {
+      "filePath": "homepage/src/components/Footer.astro",
+      "contentHash": "72a1cc1610c7b0a7d0d8475123bbdf6dc4049bc3173a65b8a9ea200fb74966f5",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 89,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/src/components/Hero.astro": {
+      "filePath": "homepage/src/components/Hero.astro",
+      "contentHash": "52639cbea549c697681629c6729355c43153cfb4fbf72f7f6e44ce3323cdd106",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 595,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/src/components/Install.astro": {
+      "filePath": "homepage/src/components/Install.astro",
+      "contentHash": "cfb16f6086425da42390fbaac849c5c06911da3665fe073e28355b45e4261fdd",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 149,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/src/components/Nav.astro": {
+      "filePath": "homepage/src/components/Nav.astro",
+      "contentHash": "8fcbd596a1872a7900733d7a9830da721c115f8f3805fa0c88206d66f0ecae72",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 134,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/src/components/Problem.astro": {
+      "filePath": "homepage/src/components/Problem.astro",
+      "contentHash": "b233d6b239e44dcd295d6f74eb697ff200d33ab9dead210ea975a9b504f74abc",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 233,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/src/components/Showcase.astro": {
+      "filePath": "homepage/src/components/Showcase.astro",
+      "contentHash": "9c56fc64beecb386f7f06eab02932ccaeeadc796f6ad6501a4a2483186b9c214",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 210,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/src/layouts/Layout.astro": {
+      "filePath": "homepage/src/layouts/Layout.astro",
+      "contentHash": "2f18e1cc8b58324f536dd2383f70cbcabf0f2bce6da723066e1a9452d4395948",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 26,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/src/pages/index.astro": {
+      "filePath": "homepage/src/pages/index.astro",
+      "contentHash": "e8298cf6f5b6158077ea55d7c1d40fb9d2f6efd684c2784b6e7e4aeee1841def",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 39,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/src/styles/global.css": {
+      "filePath": "homepage/src/styles/global.css",
+      "contentHash": "2ffb683c654e9f892bb60587cd9c10473da74d4ce7ad1f73e9d594743ac38408",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 160,
+      "hasStructuralAnalysis": false
+    },
+    "homepage/tsconfig.json": {
+      "filePath": "homepage/tsconfig.json",
+      "contentHash": "b5b0a5b04a14cddd7713c5e1c82e86c79c17c2f86b170e26e9b170b3d5e01cd9",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 6,
+      "hasStructuralAnalysis": true
+    },
+    "install.ps1": {
+      "filePath": "install.ps1",
+      "contentHash": "f0c7701c0b619cdb8555da5a5b998b34eabd267d31467397612c8e33bcc2908c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 280,
+      "hasStructuralAnalysis": false
+    },
+    "install.sh": {
+      "filePath": "install.sh",
+      "contentHash": "d9efceaffe008f84faf39f66db9ea6a862ee79bd6c32139bd0843f0c0645fe67",
+      "functions": [
+        {
+          "name": "platforms_table",
+          "params": [],
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "platform_ids",
+          "params": [],
+          "exported": false,
+          "lineCount": 1
+        },
+        {
+          "name": "resolve_platform",
+          "params": [],
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "prompt_platform",
+          "params": [],
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "clone_or_update",
+          "params": [],
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "skills_root",
+          "params": [],
+          "exported": false,
+          "lineCount": 1
+        },
+        {
+          "name": "list_skills",
+          "params": [],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "link_skills",
+          "params": [],
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "unlink_skills",
+          "params": [],
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "link_plugin_root",
+          "params": [],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "cmd_install",
+          "params": [],
+          "exported": false,
+          "lineCount": 52
+        },
+        {
+          "name": "cmd_uninstall",
+          "params": [],
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "cmd_update",
+          "params": [],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "usage",
+          "params": [],
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "main",
+          "params": [],
+          "exported": false,
+          "lineCount": 32
+        }
+      ],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 319,
+      "hasStructuralAnalysis": true
+    },
+    "package.json": {
+      "filePath": "package.json",
+      "contentHash": "736487336e2c6dbd02491f5adc16fc0e75ca2ce3ce71c1ba6a2cdc64040456ed",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 62,
+      "hasStructuralAnalysis": true
+    },
+    "pnpm-workspace.yaml": {
+      "filePath": "pnpm-workspace.yaml",
+      "contentHash": "4afdf6d159ef0712f8458bc24343dfb1c9f845684bb46189e919d74b3011503f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 5,
+      "hasStructuralAnalysis": true
+    },
+    "README.md": {
+      "filePath": "README.md",
+      "contentHash": "9af36b88f241cebff485bde0cdd77644af665455af67616e4ffb6182fe465aa4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 379,
+      "hasStructuralAnalysis": true
+    },
+    "READMEs/README.es-ES.md": {
+      "filePath": "READMEs/README.es-ES.md",
+      "contentHash": "69681d4a5d7f3a9c954d4b6c82061b7a62b0476cf83c4c8f4470febb4dbe675b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 363,
+      "hasStructuralAnalysis": true
+    },
+    "READMEs/README.ja-JP.md": {
+      "filePath": "READMEs/README.ja-JP.md",
+      "contentHash": "672a4f9f8765d74a74de841966bdafeefbc6f659c88bf8478f6c50f4ceb0e3b3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 364,
+      "hasStructuralAnalysis": true
+    },
+    "READMEs/README.ko-KR.md": {
+      "filePath": "READMEs/README.ko-KR.md",
+      "contentHash": "6db88c5f0075a46b35cdb0005e1c235e5e46761b5d3dba2fc4e65508563642de",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 363,
+      "hasStructuralAnalysis": true
+    },
+    "READMEs/README.ru-RU.md": {
+      "filePath": "READMEs/README.ru-RU.md",
+      "contentHash": "10b0447cb6e073d251e442a3fd84284bec6bc86b4c53f8f22851bb6215fe8126",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 364,
+      "hasStructuralAnalysis": true
+    },
+    "READMEs/README.tr-TR.md": {
+      "filePath": "READMEs/README.tr-TR.md",
+      "contentHash": "99eb8f5ca56ecdc980d4cd2679f75c5fe033c837829df05d071e7c5aa9e818ee",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 364,
+      "hasStructuralAnalysis": true
+    },
+    "READMEs/README.zh-CN.md": {
+      "filePath": "READMEs/README.zh-CN.md",
+      "contentHash": "b5d1e6a2a5a6c1ffe70a42a13e964fd47573397167fd301194062907a87caefc",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 363,
+      "hasStructuralAnalysis": true
+    },
+    "READMEs/README.zh-TW.md": {
+      "filePath": "READMEs/README.zh-TW.md",
+      "contentHash": "593b8e32801bf7b9dde43a84571b8eaa9f44e95aec4903ec676994fcc28782af",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 363,
+      "hasStructuralAnalysis": true
+    },
+    "scripts/generate-large-graph.mjs": {
+      "filePath": "scripts/generate-large-graph.mjs",
+      "contentHash": "fa5a604057cbe0566471551a353e929a1cc9315d68ffa42bb07f4e005f72114c",
+      "functions": [
+        {
+          "name": "pick",
+          "params": [
+            "arr"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "generateNodes",
+          "params": [
+            "count"
+          ],
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "generateEdges",
+          "params": [
+            "nodes",
+            "edgeCount"
+          ],
+          "exported": false,
+          "lineCount": 25
+        },
+        {
+          "name": "generateLayers",
+          "params": [
+            "nodes"
+          ],
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "generateTour",
+          "params": [
+            "nodes"
+          ],
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "injectTier1",
+          "params": [
+            "node"
+          ],
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "injectTier2Node",
+          "params": [
+            "node"
+          ],
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "injectTier2Edge",
+          "params": [
+            "edge"
+          ],
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "injectTier3Node",
+          "params": [
+            "node"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "injectTier3Edge",
+          "params": [
+            "edge",
+            "_validNodeIds"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "applyMessy",
+          "params": [
+            "nodes",
+            "edges"
+          ],
+          "exported": false,
+          "lineCount": 35
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "writeFileSync",
+            "mkdirSync"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "resolve"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 298,
+      "hasStructuralAnalysis": true
+    },
+    "SECURITY.md": {
+      "filePath": "SECURITY.md",
+      "contentHash": "62e1963d7c185b42c26e72d57fea696df3117e9004cf4e04be044177c4c5ed89",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 52,
+      "hasStructuralAnalysis": true
+    },
+    "tests/skill/understand/fixtures/scan-result-3-cliques.json": {
+      "filePath": "tests/skill/understand/fixtures/scan-result-3-cliques.json",
+      "contentHash": "ac943c3bb158c9a88bb99590d0e10b04808f85b104596160d4991a73b8340621",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 32,
+      "hasStructuralAnalysis": true
+    },
+    "tests/skill/understand/fixtures/scan-result-large-community.json": {
+      "filePath": "tests/skill/understand/fixtures/scan-result-large-community.json",
+      "contentHash": "5b417a9f69ced0afe27fd66ba8193697a0bb39fe5893992d032f70882a1d088c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1896,
+      "hasStructuralAnalysis": true
+    },
+    "tests/skill/understand/fixtures/scan-result-merge-respects-non-mergeable.json": {
+      "filePath": "tests/skill/understand/fixtures/scan-result-merge-respects-non-mergeable.json",
+      "contentHash": "dd667a048dd43d98953d5d861a6f1c87ec2a5f6aba79a0ef40871c2d697728e4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 233,
+      "hasStructuralAnalysis": true
+    },
+    "tests/skill/understand/fixtures/scan-result-non-code.json": {
+      "filePath": "tests/skill/understand/fixtures/scan-result-non-code.json",
+      "contentHash": "d6605b66750a5ef2dd6437f5128e3844441c16fce831fca88d02206eb837beec",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 39,
+      "hasStructuralAnalysis": true
+    },
+    "tests/skill/understand/fixtures/scan-result-singletons.json": {
+      "filePath": "tests/skill/understand/fixtures/scan-result-singletons.json",
+      "contentHash": "7043ff3f13f53b4297734dc526ba3f3a6dc3d813b70a0151bb01002a31bde86e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 716,
+      "hasStructuralAnalysis": true
+    },
+    "tests/skill/understand/test_compute_batches.test.mjs": {
+      "filePath": "tests/skill/understand/test_compute_batches.test.mjs",
+      "contentHash": "777cca067baf73a06f50ef2cd4aa2eb8f43cfbbf67ed21c4afbc82e455e531dc",
+      "functions": [
+        {
+          "name": "runScript",
+          "params": [
+            "projectRoot"
+          ],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "setupProject",
+          "params": [
+            "fixtureName"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "readBatches",
+          "params": [
+            "projectRoot"
+          ],
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeEach",
+            "afterEach"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "mkdtempSync",
+            "mkdirSync",
+            "writeFileSync",
+            "readFileSync",
+            "rmSync"
+          ]
+        },
+        {
+          "source": "node:os",
+          "specifiers": [
+            "tmpdir"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join"
+          ]
+        },
+        {
+          "source": "node:child_process",
+          "specifiers": [
+            "spawnSync"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname",
+            "resolve"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 603,
+      "hasStructuralAnalysis": true
+    },
+    "tests/skill/understand/test_extract_import_map.test.mjs": {
+      "filePath": "tests/skill/understand/test_extract_import_map.test.mjs",
+      "contentHash": "5abe8664acdf533b4333d59ff593229989e637836db910f5256bffc0c557bd67",
+      "functions": [
+        {
+          "name": "setupTree",
+          "params": [
+            "files"
+          ],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "runScript",
+          "params": [
+            "projectRoot",
+            "input"
+          ],
+          "exported": false,
+          "lineCount": 17
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "afterEach"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "mkdtempSync",
+            "mkdirSync",
+            "writeFileSync",
+            "readFileSync",
+            "rmSync"
+          ]
+        },
+        {
+          "source": "node:os",
+          "specifiers": [
+            "tmpdir"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join",
+            "dirname",
+            "resolve"
+          ]
+        },
+        {
+          "source": "node:child_process",
+          "specifiers": [
+            "spawnSync"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 1796,
+      "hasStructuralAnalysis": true
+    },
+    "tests/skill/understand/test_merge_batch_graphs.py": {
+      "filePath": "tests/skill/understand/test_merge_batch_graphs.py",
+      "contentHash": "4e0e3dc0d5abe7c5d5ffea15aefb586461d3f1341b98ec4bd710340d94910b16",
+      "functions": [
+        {
+          "name": "_load_module",
+          "params": [],
+          "returnType": "Any",
+          "exported": true,
+          "lineCount": 8
+        },
+        {
+          "name": "_file_node",
+          "params": [
+            "path"
+          ],
+          "returnType": "dict[str, Any]",
+          "exported": true,
+          "lineCount": 13
+        }
+      ],
+      "classes": [
+        {
+          "name": "IsTestPathTests",
+          "methods": [
+            "test_js_ts_sibling_test_extensions",
+            "test_underscore_test_dir_with_test_extension",
+            "test_tests_directory_with_test_extension",
+            "test_go_test_files",
+            "test_python_test_files",
+            "test_java_test_files",
+            "test_kotlin_test_files",
+            "test_csharp_test_files",
+            "test_c_cpp_test_files",
+            "test_production_files_rejected",
+            "test_helper_in_tests_dir_without_test_extension_is_not_test"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 82
+        },
+        {
+          "name": "ProductionCandidatesTests",
+          "methods": [
+            "test_js_ts_sibling",
+            "test_js_ts_spec_sibling",
+            "test_underscore_tests_dir",
+            "test_mirrored_tests_tree",
+            "test_go_sibling",
+            "test_python_test_prefix",
+            "test_python_test_suffix",
+            "test_java_maven_layout",
+            "test_java_tests_suffix",
+            "test_java_it_suffix",
+            "test_kotlin_maven_layout",
+            "test_js_ts_test_subdir_walkout",
+            "test_python_in_package_tests_walkout",
+            "test_csharp_tests_subdir_mirror_to_src",
+            "test_csharp_dotnet_sibling_project_mirror",
+            "test_priority_underscore_tests_sibling_before_walkup",
+            "test_priority_mirrored_tree_sibling_before_mirror"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 120
+        },
+        {
+          "name": "LinkTestsTests",
+          "methods": [
+            "test_basic_pairing_emits_forward_edge",
+            "test_no_production_counterpart_no_edge",
+            "test_inverted_llm_edge_is_swapped_not_stripped",
+            "test_canonical_llm_edge_kept_unchanged",
+            "test_drops_test_to_test_edge",
+            "test_drops_orphan_endpoint_edge",
+            "test_dup_keeps_higher_weight_canonical",
+            "test_dup_lighter_inverted_dropped_no_swap_counted",
+            "test_dup_replaces_with_heavier_inverted",
+            "test_dup_swapped_then_canonical_heavier_clears_swapped_count",
+            "test_dup_two_inverted_keeps_heavier_swapped_once",
+            "test_drops_duplicate_canonical_edges",
+            "test_supplement_skips_pair_already_covered_by_llm",
+            "test_swap_recovers_real_world_one_test_many_production",
+            "test_unrelated_edges_pass_through",
+            "test_direction_always_forward_production_to_test",
+            "test_idempotent",
+            "test_first_matching_candidate_wins",
+            "test_does_not_match_test_to_test",
+            "test_does_not_duplicate_existing_tag",
+            "test_empty_input",
+            "test_node_without_filepath_falls_back_to_id",
+            "test_malformed_tags_is_replaced_not_crashed"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 551
+        },
+        {
+          "name": "MergeIntegrationTests",
+          "methods": [
+            "test_linker_runs_during_merge"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 48
+        },
+        {
+          "name": "NormalizeDirectionTests",
+          "methods": [
+            "test_missing_defaults_to_forward",
+            "test_valid_values_pass_through",
+            "test_case_is_normalized",
+            "test_aliases_are_mapped",
+            "test_unknown_values_fall_back_to_forward"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 23
+        },
+        {
+          "name": "MergeEdgeDirectionTests",
+          "methods": [
+            "_two_node_batch",
+            "test_missing_direction_is_persisted_as_forward",
+            "test_alias_is_canonicalized_before_dedup"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 44
+        },
+        {
+          "name": "TestMultiPart",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "_write_batch",
+            "_run_merge",
+            "test_two_parts_of_one_logical_batch_merge",
+            "test_three_parts_of_one_logical_batch_merge",
+            "test_malformed_part_is_skipped_with_warning",
+            "test_mixed_single_and_multi_part",
+            "test_missing_part_emits_warning",
+            "test_stderr_report_format"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 113
+        },
+        {
+          "name": "TestUnrecognizedBatchFilename",
+          "methods": [
+            "setUp",
+            "tearDown",
+            "_write_batch",
+            "_run_merge",
+            "test_fused_filename_emits_stderr_warning",
+            "test_fused_filename_surfaces_in_report",
+            "test_recognized_batches_still_loaded",
+            "test_range_filename_also_unrecognized"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 112
+        }
+      ],
+      "imports": [
+        {
+          "source": "importlib.util",
+          "specifiers": [
+            "importlib.util"
+          ]
+        },
+        {
+          "source": "sys",
+          "specifiers": [
+            "sys"
+          ]
+        },
+        {
+          "source": "unittest",
+          "specifiers": [
+            "unittest"
+          ]
+        },
+        {
+          "source": "pathlib",
+          "specifiers": [
+            "Path"
+          ]
+        },
+        {
+          "source": "typing",
+          "specifiers": [
+            "Any"
+          ]
+        }
+      ],
+      "exports": [
+        "_load_module",
+        "_file_node",
+        "IsTestPathTests",
+        "ProductionCandidatesTests",
+        "LinkTestsTests",
+        "MergeIntegrationTests",
+        "NormalizeDirectionTests",
+        "MergeEdgeDirectionTests",
+        "TestMultiPart",
+        "TestUnrecognizedBatchFilename"
+      ],
+      "totalLines": 1188,
+      "hasStructuralAnalysis": true
+    },
+    "tests/skill/understand/test_scan_project.test.mjs": {
+      "filePath": "tests/skill/understand/test_scan_project.test.mjs",
+      "contentHash": "dc7fe54b948b3a312d01eaa4136cf3a0556b61c5e9ecde42e45b6537de441de2",
+      "functions": [
+        {
+          "name": "setupTree",
+          "params": [
+            "files"
+          ],
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "runScript",
+          "params": [
+            "projectRoot"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "byPath",
+          "params": [
+            "output",
+            "path"
+          ],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "afterEach"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "mkdtempSync",
+            "mkdirSync",
+            "writeFileSync",
+            "readFileSync",
+            "rmSync",
+            "chmodSync",
+            "existsSync"
+          ]
+        },
+        {
+          "source": "node:os",
+          "specifiers": [
+            "tmpdir"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join",
+            "dirname",
+            "resolve"
+          ]
+        },
+        {
+          "source": "node:child_process",
+          "specifiers": [
+            "spawnSync"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 739,
+      "hasStructuralAnalysis": true
+    },
+    "tsconfig.json": {
+      "filePath": "tsconfig.json",
+      "contentHash": "b3a11d3a2362abe4644a9547ef6d20a36d04d2f5c64d6b884b90d7997447b0da",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 17,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/.claude-plugin/plugin.json": {
+      "filePath": "understand-anything-plugin/.claude-plugin/plugin.json",
+      "contentHash": "0709dd4dc5883e5a8117a81a618b0a790ee53e3b3e253a97ea0d343cdee9a635",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 19,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/agents/architecture-analyzer.md": {
+      "filePath": "understand-anything-plugin/agents/architecture-analyzer.md",
+      "contentHash": "bed5f5835166dd43d66e3303b372055b6880c8783a406f211a0e572758a51a86",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 481,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/agents/article-analyzer.md": {
+      "filePath": "understand-anything-plugin/agents/article-analyzer.md",
+      "contentHash": "322609af02f9b2ab8dfd5e22d2062857c23006a31df9545b5fa5ac96b08de6ae",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 93,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/agents/assemble-reviewer.md": {
+      "filePath": "understand-anything-plugin/agents/assemble-reviewer.md",
+      "contentHash": "6b5c4ad7526dd373a2a9734ecac1e811a99f6257300e5db57d806eb9e2b05667",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 97,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/agents/domain-analyzer.md": {
+      "filePath": "understand-anything-plugin/agents/domain-analyzer.md",
+      "contentHash": "74314e7dea253cf07d4fe11f3a6b075c3d93321a490fcc8a3edf89a843489473",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 125,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/agents/file-analyzer.md": {
+      "filePath": "understand-anything-plugin/agents/file-analyzer.md",
+      "contentHash": "b047de6c683bde9ae729f48a16850eb48bcf7b0d1c2c1114564d24bd1a4337d3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 521,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/agents/graph-reviewer.md": {
+      "filePath": "understand-anything-plugin/agents/graph-reviewer.md",
+      "contentHash": "9e6a0b47cb14702d0f4a52c9de500b372e31eb17dbef0668912116861401f490",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 240,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/agents/knowledge-graph-guide.md": {
+      "filePath": "understand-anything-plugin/agents/knowledge-graph-guide.md",
+      "contentHash": "5c2ba123c992d0abae937352869d905d1f2900b2d0093cf43d968b36b4572912",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 99,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/agents/project-scanner.md": {
+      "filePath": "understand-anything-plugin/agents/project-scanner.md",
+      "contentHash": "9c5be14c31a729e4252a0d2d5cf973f30f6995555fe4544ac080eca91026b413",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 234,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/agents/tour-builder.md": {
+      "filePath": "understand-anything-plugin/agents/tour-builder.md",
+      "contentHash": "b341b80adef9323905b4b3c815186dcc8519325fcc54846a3fef66302bfba68e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 379,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/hooks/auto-update-prompt.md": {
+      "filePath": "understand-anything-plugin/hooks/auto-update-prompt.md",
+      "contentHash": "dd51080f3e363e363ad1f5ce136e361196dcbb3b04dbc46002cc5caf34f6e113",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 321,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/hooks/hooks.json": {
+      "filePath": "understand-anything-plugin/hooks/hooks.json",
+      "contentHash": "737705ea6a069f6bad2c4f9b821901d240b430c166ecf7a19ed100004a7b657f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 26,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/package.json": {
+      "filePath": "understand-anything-plugin/package.json",
+      "contentHash": "6b82d2966ee637512c893f8787d628dbcfe5eec771c9bf9bea7324bccf202f46",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 22,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/package.json": {
+      "filePath": "understand-anything-plugin/packages/core/package.json",
+      "contentHash": "11265a9cfe6842bd8964831ef9cf54e6a9c1b8ea992c4b033a560b42939daaab",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 59,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts",
+      "contentHash": "e9901bc0fd7d09a54d1b50f6366957c7741f761ae3efc58ab8026edafa99c61f",
+      "functions": [
+        {
+          "name": "makeAnalysis",
+          "params": [
+            "overrides"
+          ],
+          "returnType": "ChangeAnalysis",
+          "exported": false,
+          "lineCount": 11
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../change-classifier.js",
+          "specifiers": [
+            "classifyUpdate"
+          ]
+        },
+        {
+          "source": "../fingerprint.js",
+          "specifiers": [
+            "ChangeAnalysis"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 184,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/domain-normalize.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/domain-normalize.test.ts",
+      "contentHash": "67401881c292ac8a8c078f18ea49499e286ce353733dbc0c3a1688972bef73cf",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../analyzer/normalize-graph.js",
+          "specifiers": [
+            "normalizeNodeId"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/domain-persistence.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/domain-persistence.test.ts",
+      "contentHash": "524f831f9a99ddccfeacf6f5b67ca00b04bc76253c02b1c718b7350af61882b4",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeEach",
+            "afterEach"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "mkdirSync",
+            "rmSync",
+            "existsSync"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join"
+          ]
+        },
+        {
+          "source": "node:os",
+          "specifiers": [
+            "tmpdir"
+          ]
+        },
+        {
+          "source": "../persistence/index.js",
+          "specifiers": [
+            "saveDomainGraph",
+            "loadDomainGraph"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 65,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/domain-types.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/domain-types.test.ts",
+      "contentHash": "802633ac5c17200e8ccb5dcb7ea83a12feef4650f8548a1bb5ab895823bf0134",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../schema.js",
+          "specifiers": [
+            "validateGraph"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 142,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts",
+      "contentHash": "50286dec2bcec9013655b6796ca4ee040435d9bc4adea98b4ac03f5e056265ee",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../embedding-search.js",
+          "specifiers": [
+            "SemanticSearchEngine",
+            "cosineSimilarity"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "GraphNode"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 93,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/fingerprint.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/fingerprint.test.ts",
+      "contentHash": "4372804f5cf79dc44e1e265b3cebca1b8ba5a2f0e4a319c1918f88426585de71",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "vi",
+            "beforeEach"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "StructuralAnalysis"
+          ]
+        },
+        {
+          "source": "../fingerprint.js",
+          "specifiers": [
+            "contentHash",
+            "extractFileFingerprint",
+            "compareFingerprints",
+            "analyzeChanges",
+            "FileFingerprint",
+            "FingerprintStore"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "readFileSync",
+            "existsSync"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 428,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts",
+      "contentHash": "2f238ce7494de8750bc58c020f141111397737ca4bc3fdb67063d0209758365b",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../languages/framework-registry.js",
+          "specifiers": [
+            "FrameworkRegistry"
+          ]
+        },
+        {
+          "source": "../languages/frameworks/django.js",
+          "specifiers": [
+            "djangoConfig"
+          ]
+        },
+        {
+          "source": "../languages/frameworks/react.js",
+          "specifiers": [
+            "reactConfig"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 124,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts",
+      "contentHash": "a924d960b18a03ff5fd67a4997c9c3034ed7fb7399ff481838a0bd68d0d8e00e",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeEach",
+            "afterEach"
+          ]
+        },
+        {
+          "source": "../ignore-filter",
+          "specifiers": [
+            "createIgnoreFilter",
+            "DEFAULT_IGNORE_PATTERNS"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "mkdirSync",
+            "writeFileSync",
+            "rmSync"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join"
+          ]
+        },
+        {
+          "source": "node:os",
+          "specifiers": [
+            "tmpdir"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 156,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts",
+      "contentHash": "5c23cb8f8ec5559accbcbbab769d646af84b8f177f442dd40fdae2b8307e05e8",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeEach",
+            "afterEach"
+          ]
+        },
+        {
+          "source": "../ignore-generator",
+          "specifiers": [
+            "generateStarterIgnoreFile"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "mkdirSync",
+            "rmSync",
+            "writeFileSync"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join"
+          ]
+        },
+        {
+          "source": "node:os",
+          "specifiers": [
+            "tmpdir"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 263,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts",
+      "contentHash": "7a56445185c79e7aebbc829b87ac724d0142356d9efaca8598b145cfc2d7931e",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../analyzer/language-lesson.js",
+          "specifiers": [
+            "buildLanguageLessonPrompt",
+            "parseLanguageLessonResponse",
+            "detectLanguageConcepts"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "GraphNode",
+            "GraphEdge"
+          ]
+        },
+        {
+          "source": "../languages/configs/typescript.js",
+          "specifiers": [
+            "typescriptConfig"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 158,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts",
+      "contentHash": "72e56ecb44e479a3a91b35a0cee5351234bd04110135fba5717a995da5dd4ec1",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../languages/language-registry.js",
+          "specifiers": [
+            "LanguageRegistry"
+          ]
+        },
+        {
+          "source": "../languages/types.js",
+          "specifiers": [
+            "StrictLanguageConfigSchema"
+          ]
+        },
+        {
+          "source": "../languages/configs/typescript.js",
+          "specifiers": [
+            "typescriptConfig"
+          ]
+        },
+        {
+          "source": "../languages/configs/python.js",
+          "specifiers": [
+            "pythonConfig"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 199,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/layer-detector.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/layer-detector.test.ts",
+      "contentHash": "20a1da6af3ee477f1fe4a19813780cdd90a60b0931e50b2168bd45c232228147",
+      "functions": [
+        {
+          "name": "makeNode",
+          "params": [
+            "overrides"
+          ],
+          "returnType": "GraphNode",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "makeGraph",
+          "params": [
+            "nodes"
+          ],
+          "returnType": "KnowledgeGraph",
+          "exported": false,
+          "lineCount": 15
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../analyzer/layer-detector.js",
+          "specifiers": [
+            "detectLayers",
+            "buildLayerDetectionPrompt",
+            "parseLayerDetectionResponse",
+            "applyLLMLayers"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph",
+            "GraphNode"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 189,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts",
+      "contentHash": "9ebaab628ae7607056ff17e964967f2fcc7dff9c8ecf38c38388527ee3df3ce4",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../analyzer/normalize-graph.js",
+          "specifiers": [
+            "normalizeNodeId",
+            "normalizeComplexity",
+            "normalizeBatchOutput"
+          ]
+        },
+        {
+          "source": "../schema.js",
+          "specifiers": [
+            "validateGraph"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 499,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "contentHash": "d1a34539d56867d2cc3c83e16a3955af50ae2d9863985dcaaa8a58d06cd78c09",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/markdown-parser.js",
+          "specifiers": [
+            "MarkdownParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/yaml-parser.js",
+          "specifiers": [
+            "YAMLConfigParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/json-parser.js",
+          "specifiers": [
+            "JSONConfigParser",
+            "stripJsoncSyntax"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/toml-parser.js",
+          "specifiers": [
+            "TOMLParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/env-parser.js",
+          "specifiers": [
+            "EnvParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/dockerfile-parser.js",
+          "specifiers": [
+            "DockerfileParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/sql-parser.js",
+          "specifiers": [
+            "SQLParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/graphql-parser.js",
+          "specifiers": [
+            "GraphQLParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/protobuf-parser.js",
+          "specifiers": [
+            "ProtobufParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/terraform-parser.js",
+          "specifiers": [
+            "TerraformParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/makefile-parser.js",
+          "specifiers": [
+            "MakefileParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/shell-parser.js",
+          "specifiers": [
+            "ShellParser"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/index.js",
+          "specifiers": [
+            "registerAllParsers"
+          ]
+        },
+        {
+          "source": "../plugins/registry.js",
+          "specifiers": [
+            "PluginRegistry"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 630,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/plugin-discovery.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/plugin-discovery.test.ts",
+      "contentHash": "01e17402e56c492aacdf23e11d518b1841c5904ec8c13b00735e4ce11c54f17e",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../plugins/discovery.js",
+          "specifiers": [
+            "parsePluginConfig",
+            "serializePluginConfig",
+            "PluginConfig",
+            "DEFAULT_PLUGIN_CONFIG"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 116,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/plugin-registry.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/plugin-registry.test.ts",
+      "contentHash": "9c159264ff363a54db8de150adeb08195d0f836cef2419f3f34519a0080415d4",
+      "functions": [
+        {
+          "name": "createMockPlugin",
+          "params": [
+            "name",
+            "languages"
+          ],
+          "returnType": "AnalyzerPlugin",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../plugins/registry.js",
+          "specifiers": [
+            "PluginRegistry"
+          ]
+        },
+        {
+          "source": "../plugins/parsers/index.js",
+          "specifiers": [
+            "registerAllParsers"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "ImportResolution"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 229,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/schema.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/schema.test.ts",
+      "contentHash": "20ebc9dcccad2772bf97c9e2d4a1e2a2790ce1d91c5a3cb226d97b7a68231003",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../schema.js",
+          "specifiers": [
+            "validateGraph",
+            "sanitizeGraph",
+            "autoFixGraph",
+            "NODE_TYPE_ALIASES",
+            "EDGE_TYPE_ALIASES"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 730,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/search.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/search.test.ts",
+      "contentHash": "362b87f5b49ca7ed8a72f06806c81d9eeb562dece9f0aaa2a91745cf1336b002",
+      "functions": [
+        {
+          "name": "makeNode",
+          "params": [
+            "overrides"
+          ],
+          "returnType": "GraphNode",
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../search.js",
+          "specifiers": [
+            "SearchEngine"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "GraphNode"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 159,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts",
+      "contentHash": "ac7a5a27dfb87cbd27f0384e49bbc6e409837aac14ecee5a36787ef910098e22",
+      "functions": [
+        {
+          "name": "makeNode",
+          "params": [
+            "overrides"
+          ],
+          "returnType": "GraphNode",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "makeEdge",
+          "params": [
+            "overrides"
+          ],
+          "returnType": "GraphEdge",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "makeGraph",
+          "params": [
+            "overrides"
+          ],
+          "returnType": "KnowledgeGraph",
+          "exported": false,
+          "lineCount": 18
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "vi",
+            "beforeEach"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph",
+            "GraphNode",
+            "GraphEdge"
+          ]
+        },
+        {
+          "source": "child_process",
+          "specifiers": [
+            "execFileSync"
+          ]
+        },
+        {
+          "source": "../staleness.js",
+          "specifiers": [
+            "getChangedFiles",
+            "isStale",
+            "mergeGraphUpdate"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 254,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/__tests__/tour-generator.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/tour-generator.test.ts",
+      "contentHash": "8e7bf331d659c05742271af104f31f95203257f1ecd2a21d58e83a7b3aed4629",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../analyzer/tour-generator.js",
+          "specifiers": [
+            "buildTourGenerationPrompt",
+            "parseTourGenerationResponse",
+            "generateHeuristicTour"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 270,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/analyzer/graph-builder.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/graph-builder.test.ts",
+      "contentHash": "5243f94d7eaa97affab2a03d3f8b83a0b41efaf6bde1eb84f55714789aa85867",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "vi"
+          ]
+        },
+        {
+          "source": "./graph-builder.js",
+          "specifiers": [
+            "GraphBuilder"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "StructuralAnalysis"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 405,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "contentHash": "e08369943951d65e31cce36da4c34333e6c622690c2651f4ccf3c497b3a8f240",
+      "functions": [],
+      "classes": [
+        {
+          "name": "GraphBuilder",
+          "methods": [
+            "constructor",
+            "detectLanguage",
+            "basename",
+            "addFile",
+            "addFileWithAnalysis",
+            "addImportEdge",
+            "addCallEdge",
+            "addNonCodeFile",
+            "addNonCodeFileWithAnalysis",
+            "addChildNode",
+            "mapKindToNodeType",
+            "build"
+          ],
+          "properties": [
+            "nodes",
+            "edges",
+            "languages",
+            "nodeIds",
+            "edgeKeys",
+            "projectName",
+            "gitHash",
+            "languageRegistry"
+          ],
+          "exported": true,
+          "lineCount": 278
+        }
+      ],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph",
+            "GraphNode",
+            "GraphEdge",
+            "StructuralAnalysis",
+            "DefinitionInfo",
+            "ServiceInfo",
+            "EndpointInfo",
+            "StepInfo",
+            "ResourceInfo",
+            "SectionInfo"
+          ]
+        },
+        {
+          "source": "../languages/language-registry.js",
+          "specifiers": [
+            "LanguageRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "GraphBuilder"
+      ],
+      "totalLines": 338,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "contentHash": "a6c053e101db795b83fdd07585383a17ef397cf60d0f2e64824ea513151a5d87",
+      "functions": [
+        {
+          "name": "buildConceptPatterns",
+          "params": [
+            "langConfig"
+          ],
+          "returnType": "Record<string, string[]>",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "detectLanguageConcepts",
+          "params": [
+            "node",
+            "language",
+            "langConfig"
+          ],
+          "returnType": "string[]",
+          "exported": true,
+          "lineCount": 25
+        },
+        {
+          "name": "getLanguageDisplayName",
+          "params": [
+            "language",
+            "langConfig"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "buildLanguageLessonPrompt",
+          "params": [
+            "node",
+            "edges",
+            "language",
+            "langConfig"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 44
+        },
+        {
+          "name": "extractJson",
+          "params": [
+            "response"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "parseLanguageLessonResponse",
+          "params": [
+            "response"
+          ],
+          "returnType": "LanguageLessonResult",
+          "exported": true,
+          "lineCount": 33
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "GraphNode",
+            "GraphEdge"
+          ]
+        },
+        {
+          "source": "../languages/types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "detectLanguageConcepts",
+        "getLanguageDisplayName",
+        "buildLanguageLessonPrompt",
+        "parseLanguageLessonResponse"
+      ],
+      "totalLines": 211,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "contentHash": "eb8003be844e2638b8821a00753e75cc21ab69c5d3f62153107695087e6c30a6",
+      "functions": [
+        {
+          "name": "toLayerId",
+          "params": [
+            "name"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "matchFileToLayer",
+          "params": [
+            "filePath"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "detectLayers",
+          "params": [
+            "graph"
+          ],
+          "returnType": "Layer[]",
+          "exported": true,
+          "lineCount": 40
+        },
+        {
+          "name": "buildLayerDetectionPrompt",
+          "params": [
+            "graph"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 21
+        },
+        {
+          "name": "parseLayerDetectionResponse",
+          "params": [
+            "response"
+          ],
+          "returnType": "LLMLayerResponse[] | null",
+          "exported": true,
+          "lineCount": 44
+        },
+        {
+          "name": "applyLLMLayers",
+          "params": [
+            "graph",
+            "llmLayers"
+          ],
+          "returnType": "Layer[]",
+          "exported": true,
+          "lineCount": 58
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph",
+            "Layer"
+          ]
+        }
+      ],
+      "exports": [
+        "detectLayers",
+        "buildLayerDetectionPrompt",
+        "parseLayerDetectionResponse",
+        "applyLLMLayers"
+      ],
+      "totalLines": 285,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.test.ts",
+      "contentHash": "5f4fe5ac5629606ef293f08443bd4a5a2955adfe128b75540214915c8a753b24",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "./llm-analyzer.js",
+          "specifiers": [
+            "buildFileAnalysisPrompt",
+            "buildProjectSummaryPrompt",
+            "parseFileAnalysisResponse",
+            "parseProjectSummaryResponse"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 249,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "contentHash": "2c27b6183b8fa2857df989f25086205d6f885df805a3cd1c91cfd091aa237270",
+      "functions": [
+        {
+          "name": "buildFileAnalysisPrompt",
+          "params": [
+            "filePath",
+            "content",
+            "projectContext"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 25
+        },
+        {
+          "name": "buildProjectSummaryPrompt",
+          "params": [
+            "fileList",
+            "sampleFiles"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 29
+        },
+        {
+          "name": "extractJson",
+          "params": [
+            "response"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "parseFileAnalysisResponse",
+          "params": [
+            "response"
+          ],
+          "returnType": "LLMFileAnalysis | null",
+          "exported": true,
+          "lineCount": 42
+        },
+        {
+          "name": "parseProjectSummaryResponse",
+          "params": [
+            "response"
+          ],
+          "returnType": "LLMProjectSummary | null",
+          "exported": true,
+          "lineCount": 39
+        }
+      ],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "buildFileAnalysisPrompt",
+        "buildProjectSummaryPrompt",
+        "parseFileAnalysisResponse",
+        "parseProjectSummaryResponse"
+      ],
+      "totalLines": 187,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "contentHash": "5149ce3855c1b29147798b5c98ece156f7e7d94c63d1dfc1ecf85f9b88d59d9b",
+      "functions": [
+        {
+          "name": "stripToValidPrefix",
+          "params": [
+            "id"
+          ],
+          "returnType": "{ prefix: string | null; path: string }",
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "normalizeNodeId",
+          "params": [
+            "id",
+            "node"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 48
+        },
+        {
+          "name": "normalizeComplexity",
+          "params": [
+            "value"
+          ],
+          "returnType": "\"simple\" | \"moderate\" | \"complex\"",
+          "exported": true,
+          "lineCount": 19
+        },
+        {
+          "name": "inferTypeFromId",
+          "params": [
+            "id"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "normalizeBatchOutput",
+          "params": [
+            "data"
+          ],
+          "returnType": "NormalizeBatchResult",
+          "exported": true,
+          "lineCount": 128
+        }
+      ],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "normalizeNodeId",
+        "normalizeComplexity",
+        "normalizeBatchOutput"
+      ],
+      "totalLines": 330,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "contentHash": "b028b344463460278b89c6cea0c28ac35766e520e96940923d547c1c61659c56",
+      "functions": [
+        {
+          "name": "buildTourGenerationPrompt",
+          "params": [
+            "graph"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 56
+        },
+        {
+          "name": "parseTourGenerationResponse",
+          "params": [
+            "response"
+          ],
+          "returnType": "TourStep[]",
+          "exported": true,
+          "lineCount": 51
+        },
+        {
+          "name": "generateHeuristicTour",
+          "params": [
+            "graph"
+          ],
+          "returnType": "TourStep[]",
+          "exported": true,
+          "lineCount": 159
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph",
+            "TourStep"
+          ]
+        }
+      ],
+      "exports": [
+        "buildTourGenerationPrompt",
+        "parseTourGenerationResponse",
+        "generateHeuristicTour"
+      ],
+      "totalLines": 294,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/change-classifier.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "contentHash": "7458aa39d5de1f7dad64f149ec8fb31384226c87af24c2cd80d668987dccf5ce",
+      "functions": [
+        {
+          "name": "classifyUpdate",
+          "params": [
+            "analysis",
+            "totalFilesInGraph",
+            "allKnownFiles"
+          ],
+          "returnType": "UpdateDecision",
+          "exported": true,
+          "lineCount": 67
+        },
+        {
+          "name": "detectDirectoryChanges",
+          "params": [
+            "newFiles",
+            "deletedFiles",
+            "allKnownFiles"
+          ],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "topDirectory",
+          "params": [
+            "filePath"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "summarizeChanges",
+          "params": [
+            "analysis"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 15
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname"
+          ]
+        },
+        {
+          "source": "./fingerprint.js",
+          "specifiers": [
+            "ChangeAnalysis"
+          ]
+        }
+      ],
+      "exports": [
+        "classifyUpdate"
+      ],
+      "totalLines": 144,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/embedding-search.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "contentHash": "3b77a912b7395a8977c3179fb752d4bbbb4a54515e7e04f773f99ad0b2d052da",
+      "functions": [
+        {
+          "name": "cosineSimilarity",
+          "params": [
+            "a",
+            "b"
+          ],
+          "returnType": "number",
+          "exported": true,
+          "lineCount": 17
+        }
+      ],
+      "classes": [
+        {
+          "name": "SemanticSearchEngine",
+          "methods": [
+            "constructor",
+            "hasEmbeddings",
+            "addEmbedding",
+            "search",
+            "updateNodes"
+          ],
+          "properties": [
+            "nodes",
+            "embeddings"
+          ],
+          "exported": true,
+          "lineCount": 47
+        }
+      ],
+      "imports": [
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "GraphNode"
+          ]
+        },
+        {
+          "source": "./search.js",
+          "specifiers": [
+            "SearchResult"
+          ]
+        }
+      ],
+      "exports": [
+        "cosineSimilarity",
+        "SemanticSearchEngine"
+      ],
+      "totalLines": 84,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/fingerprint.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "contentHash": "1bdac3ca76e50b3c4cd814222d4d45118b5cc36db9482324896eec71f67e0efb",
+      "functions": [
+        {
+          "name": "contentHash",
+          "params": [
+            "content"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "extractFileFingerprint",
+          "params": [
+            "filePath",
+            "content",
+            "analysis"
+          ],
+          "returnType": "FileFingerprint",
+          "exported": true,
+          "lineCount": 44
+        },
+        {
+          "name": "compareFingerprints",
+          "params": [
+            "oldFp",
+            "newFp"
+          ],
+          "returnType": "FileChangeResult",
+          "exported": true,
+          "lineCount": 116
+        },
+        {
+          "name": "buildFingerprintStore",
+          "params": [
+            "projectDir",
+            "filePaths",
+            "registry",
+            "gitCommitHash"
+          ],
+          "returnType": "FingerprintStore",
+          "exported": true,
+          "lineCount": 39
+        },
+        {
+          "name": "analyzeChanges",
+          "params": [
+            "projectDir",
+            "changedFiles",
+            "existingStore",
+            "registry"
+          ],
+          "returnType": "ChangeAnalysis",
+          "exported": true,
+          "lineCount": 89
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:crypto",
+          "specifiers": [
+            "createHash"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "readFileSync",
+            "existsSync"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "StructuralAnalysis"
+          ]
+        },
+        {
+          "source": "./plugins/registry.js",
+          "specifiers": [
+            "PluginRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "contentHash",
+        "extractFileFingerprint",
+        "compareFingerprints",
+        "buildFingerprintStore",
+        "analyzeChanges"
+      ],
+      "totalLines": 386,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/ignore-filter.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/ignore-filter.ts",
+      "contentHash": "eb8bc7cc613451a5aa740a5476f694b2e7a9edcb462631a80e7d2f4c6fe3473e",
+      "functions": [
+        {
+          "name": "createIgnoreFilter",
+          "params": [
+            "projectRoot"
+          ],
+          "returnType": "IgnoreFilter",
+          "exported": true,
+          "lineCount": 26
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "ignore",
+          "specifiers": [
+            "ignore",
+            "Ignore"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "readFileSync",
+            "existsSync"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join"
+          ]
+        }
+      ],
+      "exports": [
+        "DEFAULT_IGNORE_PATTERNS",
+        "createIgnoreFilter"
+      ],
+      "totalLines": 112,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/ignore-generator.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "contentHash": "a82b70851fa4acf71cb0dda3b035e0cc482ab6349c795bf1a12ea42c68bf50bb",
+      "functions": [
+        {
+          "name": "parseGitignorePatterns",
+          "params": [
+            "gitignorePath"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "isCoveredByDefaults",
+          "params": [
+            "pattern"
+          ],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "detectDirectories",
+          "params": [
+            "projectRoot"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "generateStarterIgnoreFile",
+          "params": [
+            "projectRoot"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 39
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "existsSync",
+            "readdirSync",
+            "readFileSync",
+            "Dirent"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join"
+          ]
+        },
+        {
+          "source": "./ignore-filter.js",
+          "specifiers": [
+            "DEFAULT_IGNORE_PATTERNS"
+          ]
+        }
+      ],
+      "exports": [
+        "generateStarterIgnoreFile"
+      ],
+      "totalLines": 169,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/index.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/index.ts",
+      "contentHash": "99d309472c19d50cda144d360e1a8cf57e5d4dd0695c9a66d21f81da51382bb4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "KnowledgeGraphSchema",
+        "validateGraph",
+        "sanitizeGraph",
+        "autoFixGraph",
+        "COMPLEXITY_ALIASES",
+        "DIRECTION_ALIASES",
+        "ValidationResult",
+        "GraphIssue",
+        "TreeSitterPlugin",
+        "LanguageExtractor",
+        "builtinExtractors",
+        "GraphBuilder",
+        "buildFileAnalysisPrompt",
+        "buildProjectSummaryPrompt",
+        "parseFileAnalysisResponse",
+        "parseProjectSummaryResponse",
+        "LLMFileAnalysis",
+        "LLMProjectSummary",
+        "normalizeNodeId",
+        "normalizeComplexity",
+        "normalizeBatchOutput",
+        "DroppedEdge",
+        "NormalizationStats",
+        "NormalizeBatchResult",
+        "SearchEngine",
+        "SearchResult",
+        "SearchOptions",
+        "getChangedFiles",
+        "isStale",
+        "mergeGraphUpdate",
+        "StalenessResult",
+        "detectLayers",
+        "buildLayerDetectionPrompt",
+        "parseLayerDetectionResponse",
+        "applyLLMLayers",
+        "LLMLayerResponse",
+        "buildTourGenerationPrompt",
+        "parseTourGenerationResponse",
+        "generateHeuristicTour",
+        "buildLanguageLessonPrompt",
+        "parseLanguageLessonResponse",
+        "detectLanguageConcepts",
+        "LanguageLessonResult",
+        "PluginRegistry",
+        "LanguageRegistry",
+        "FrameworkRegistry",
+        "builtinLanguageConfigs",
+        "builtinFrameworkConfigs",
+        "LanguageConfigSchema",
+        "FrameworkConfigSchema",
+        "LanguageConfig",
+        "FrameworkConfig",
+        "TreeSitterConfig",
+        "FilePatternConfig",
+        "parsePluginConfig",
+        "serializePluginConfig",
+        "DEFAULT_PLUGIN_CONFIG",
+        "PluginConfig",
+        "PluginEntry",
+        "SemanticSearchEngine",
+        "cosineSimilarity",
+        "SemanticSearchOptions",
+        "extractFileFingerprint",
+        "compareFingerprints",
+        "analyzeChanges",
+        "buildFingerprintStore",
+        "contentHash",
+        "FunctionFingerprint",
+        "ClassFingerprint",
+        "ImportFingerprint",
+        "FileFingerprint",
+        "FingerprintStore",
+        "ChangeLevel",
+        "FileChangeResult",
+        "ChangeAnalysis",
+        "classifyUpdate",
+        "UpdateDecision",
+        "MarkdownParser",
+        "YAMLConfigParser",
+        "JSONConfigParser",
+        "TOMLParser",
+        "EnvParser",
+        "DockerfileParser",
+        "SQLParser",
+        "GraphQLParser",
+        "ProtobufParser",
+        "TerraformParser",
+        "MakefileParser",
+        "ShellParser",
+        "registerAllParsers",
+        "createIgnoreFilter",
+        "DEFAULT_IGNORE_PATTERNS",
+        "IgnoreFilter",
+        "generateStarterIgnoreFile"
+      ],
+      "totalLines": 125,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/batch.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/batch.ts",
+      "contentHash": "0435e12e73c604a4eebd5b323f94fcb080d4c92582b5618e5c1bfdd9f0dd10cb",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "batchConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/c.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/c.ts",
+      "contentHash": "33b63954469b7058fdec280109f5e193a7892cf677656645277ceff88389e6c2",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "cConfig"
+      ],
+      "totalLines": 28,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/cpp.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/cpp.ts",
+      "contentHash": "ae356e83bd6a6f95e1d1eb7c47fca19db1cdce8e0583efe5ebfda4ab3544d845",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "cppConfig"
+      ],
+      "totalLines": 30,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/csharp.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/csharp.ts",
+      "contentHash": "a990cad08e6ba7198cf3604a278fbb2a599470b7fe6449b45b8b89e2a6bd9943",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "csharpConfig"
+      ],
+      "totalLines": 30,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/css.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/css.ts",
+      "contentHash": "827e5b582ed404174afd832b2fb6a347930e16ed91870300b97816e4b67293a0",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "cssConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/csv.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/csv.ts",
+      "contentHash": "48cd43241ff9c13b8ab5f4e89200ace18e7f50708d051a05d62f1ae999ff51a0",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "csvConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/dart.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/dart.ts",
+      "contentHash": "7bb6412a801c173d80b2cb0b03d3920ec78782ab4c1c719bed208bed134f1a96",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "dartConfig"
+      ],
+      "totalLines": 30,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/docker-compose.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/docker-compose.ts",
+      "contentHash": "d29301580b7349b9bc43b9774bc64d670e81d29b4c85067dbc03154cef2dfebe",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "dockerComposeConfig"
+      ],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/dockerfile.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/dockerfile.ts",
+      "contentHash": "73290f6cd4099f1bdbeda82d81786df77bdfd831d093822ef31ee097fd542b52",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "dockerfileConfig"
+      ],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/env.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/env.ts",
+      "contentHash": "7c4dfcd9dfb26963ce87e9b26f61bb48e31452cebd4a8beb8e502e43ab3aaba2",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "envConfig"
+      ],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/github-actions.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/github-actions.ts",
+      "contentHash": "0aaf0265574abf3c5fcbc18f8db1b4e8949385db9cf27aa93369bdceeb5352af",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "githubActionsConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/go.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/go.ts",
+      "contentHash": "e8987c5521eeab47f608608cc09c46657e31df0afaff9a98be037b0221c70aee",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "goConfig"
+      ],
+      "totalLines": 29,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/graphql.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/graphql.ts",
+      "contentHash": "6bbcd6a5556218a3b86ba5d2d2a46fa5a25ee52304d9fcda5b7af1a5a29b6124",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "graphqlConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/html.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/html.ts",
+      "contentHash": "c0f78e0ee4502d5fe8aa855cf2ec74b095cd6716e2dc14ccf960f1716ccce2ca",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "htmlConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/index.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "contentHash": "394fa069df5b317905cfbf00d1db0734c9543b2e10d566d0965b66e7bf0af233",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        },
+        {
+          "source": "./typescript.js",
+          "specifiers": [
+            "typescriptConfig"
+          ]
+        },
+        {
+          "source": "./javascript.js",
+          "specifiers": [
+            "javascriptConfig"
+          ]
+        },
+        {
+          "source": "./python.js",
+          "specifiers": [
+            "pythonConfig"
+          ]
+        },
+        {
+          "source": "./go.js",
+          "specifiers": [
+            "goConfig"
+          ]
+        },
+        {
+          "source": "./rust.js",
+          "specifiers": [
+            "rustConfig"
+          ]
+        },
+        {
+          "source": "./java.js",
+          "specifiers": [
+            "javaConfig"
+          ]
+        },
+        {
+          "source": "./ruby.js",
+          "specifiers": [
+            "rubyConfig"
+          ]
+        },
+        {
+          "source": "./php.js",
+          "specifiers": [
+            "phpConfig"
+          ]
+        },
+        {
+          "source": "./swift.js",
+          "specifiers": [
+            "swiftConfig"
+          ]
+        },
+        {
+          "source": "./kotlin.js",
+          "specifiers": [
+            "kotlinConfig"
+          ]
+        },
+        {
+          "source": "./c.js",
+          "specifiers": [
+            "cConfig"
+          ]
+        },
+        {
+          "source": "./cpp.js",
+          "specifiers": [
+            "cppConfig"
+          ]
+        },
+        {
+          "source": "./dart.js",
+          "specifiers": [
+            "dartConfig"
+          ]
+        },
+        {
+          "source": "./csharp.js",
+          "specifiers": [
+            "csharpConfig"
+          ]
+        },
+        {
+          "source": "./lua.js",
+          "specifiers": [
+            "luaConfig"
+          ]
+        },
+        {
+          "source": "./markdown.js",
+          "specifiers": [
+            "markdownConfig"
+          ]
+        },
+        {
+          "source": "./yaml.js",
+          "specifiers": [
+            "yamlConfig"
+          ]
+        },
+        {
+          "source": "./json-config.js",
+          "specifiers": [
+            "jsonConfigConfig"
+          ]
+        },
+        {
+          "source": "./toml.js",
+          "specifiers": [
+            "tomlConfig"
+          ]
+        },
+        {
+          "source": "./env.js",
+          "specifiers": [
+            "envConfig"
+          ]
+        },
+        {
+          "source": "./xml.js",
+          "specifiers": [
+            "xmlConfig"
+          ]
+        },
+        {
+          "source": "./dockerfile.js",
+          "specifiers": [
+            "dockerfileConfig"
+          ]
+        },
+        {
+          "source": "./sql.js",
+          "specifiers": [
+            "sqlConfig"
+          ]
+        },
+        {
+          "source": "./graphql.js",
+          "specifiers": [
+            "graphqlConfig"
+          ]
+        },
+        {
+          "source": "./protobuf.js",
+          "specifiers": [
+            "protobufConfig"
+          ]
+        },
+        {
+          "source": "./terraform.js",
+          "specifiers": [
+            "terraformConfig"
+          ]
+        },
+        {
+          "source": "./github-actions.js",
+          "specifiers": [
+            "githubActionsConfig"
+          ]
+        },
+        {
+          "source": "./makefile.js",
+          "specifiers": [
+            "makefileConfig"
+          ]
+        },
+        {
+          "source": "./shell.js",
+          "specifiers": [
+            "shellConfig"
+          ]
+        },
+        {
+          "source": "./html.js",
+          "specifiers": [
+            "htmlConfig"
+          ]
+        },
+        {
+          "source": "./css.js",
+          "specifiers": [
+            "cssConfig"
+          ]
+        },
+        {
+          "source": "./openapi.js",
+          "specifiers": [
+            "openapiConfig"
+          ]
+        },
+        {
+          "source": "./kubernetes.js",
+          "specifiers": [
+            "kubernetesConfig"
+          ]
+        },
+        {
+          "source": "./docker-compose.js",
+          "specifiers": [
+            "dockerComposeConfig"
+          ]
+        },
+        {
+          "source": "./json-schema.js",
+          "specifiers": [
+            "jsonSchemaConfig"
+          ]
+        },
+        {
+          "source": "./csv.js",
+          "specifiers": [
+            "csvConfig"
+          ]
+        },
+        {
+          "source": "./restructuredtext.js",
+          "specifiers": [
+            "restructuredtextConfig"
+          ]
+        },
+        {
+          "source": "./powershell.js",
+          "specifiers": [
+            "powershellConfig"
+          ]
+        },
+        {
+          "source": "./batch.js",
+          "specifiers": [
+            "batchConfig"
+          ]
+        },
+        {
+          "source": "./jenkinsfile.js",
+          "specifiers": [
+            "jenkinsfileConfig"
+          ]
+        },
+        {
+          "source": "./plaintext.js",
+          "specifiers": [
+            "plaintextConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "builtinLanguageConfigs",
+        "typescriptConfig",
+        "javascriptConfig",
+        "pythonConfig",
+        "goConfig",
+        "rustConfig",
+        "javaConfig",
+        "rubyConfig",
+        "phpConfig",
+        "swiftConfig",
+        "kotlinConfig",
+        "luaConfig",
+        "cConfig",
+        "cppConfig",
+        "dartConfig",
+        "csharpConfig",
+        "markdownConfig",
+        "yamlConfig",
+        "jsonConfigConfig",
+        "tomlConfig",
+        "envConfig",
+        "xmlConfig",
+        "dockerfileConfig",
+        "sqlConfig",
+        "graphqlConfig",
+        "protobufConfig",
+        "terraformConfig",
+        "githubActionsConfig",
+        "makefileConfig",
+        "shellConfig",
+        "htmlConfig",
+        "cssConfig",
+        "openapiConfig",
+        "kubernetesConfig",
+        "dockerComposeConfig",
+        "jsonSchemaConfig",
+        "csvConfig",
+        "restructuredtextConfig",
+        "powershellConfig",
+        "batchConfig",
+        "jenkinsfileConfig",
+        "plaintextConfig"
+      ],
+      "totalLines": 136,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/java.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/java.ts",
+      "contentHash": "35cd4ddcd8730073230150a17c0b3a245f50698666142dbad79da080ad85e354",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "javaConfig"
+      ],
+      "totalLines": 34,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/javascript.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/javascript.ts",
+      "contentHash": "dedb9e3ab9e2b1c21c102212e8489382ccb078e5554453ca514b53e4b914029a",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "javascriptConfig"
+      ],
+      "totalLines": 30,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/jenkinsfile.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/jenkinsfile.ts",
+      "contentHash": "7bde6a64bdf481aab8b0d2163f58c2a4eb1c6f5d6a687f9165e5d20f1dd14dd3",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "jenkinsfileConfig"
+      ],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/json-config.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/json-config.ts",
+      "contentHash": "42fb52fbc7d8de4bc70bc2fa034395c300cee49b61b4f0e35af421c9576241fa",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "jsonConfigConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/json-schema.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/json-schema.ts",
+      "contentHash": "722b955d13beb90b5493357fc661f78758b9f59b23392b7817c8f666497d97aa",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "jsonSchemaConfig"
+      ],
+      "totalLines": 19,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/kotlin.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/kotlin.ts",
+      "contentHash": "2410031b05d8b60ee86f9b0a8d13c41a443ffe9d72aa69fd5da423d0b2ffaa43",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "kotlinConfig"
+      ],
+      "totalLines": 30,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/kubernetes.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/kubernetes.ts",
+      "contentHash": "fa2d8cdd699d3d973900de5df6c00e5b581eb23a6803bbb92be1dddbb587ef88",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "kubernetesConfig"
+      ],
+      "totalLines": 20,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/lua.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/lua.ts",
+      "contentHash": "6bb85a8462b878ab84c62adff8a50db1e25e33909458110565e84147b88cd7f0",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "luaConfig"
+      ],
+      "totalLines": 24,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/makefile.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/makefile.ts",
+      "contentHash": "b8bc272b88bd078062086ef4f6c41e5d0ef1560f4ce9adfb4c2dd042b4f0b32b",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "makefileConfig"
+      ],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/markdown.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/markdown.ts",
+      "contentHash": "945b87846fb2c8a7319fc3cc304979d1bb0552c6922298a10b883ea1df06b75c",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "markdownConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/openapi.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/openapi.ts",
+      "contentHash": "750284c9f704c63e52f9ff290a4a6399296d3ee0d536138219c2ab773e7133c7",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "openapiConfig"
+      ],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/php.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/php.ts",
+      "contentHash": "9a7102d3c7d8dabf69671cca3cd26c7e55adf3a5fcf40e27826d26ea4ac9d51a",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "phpConfig"
+      ],
+      "totalLines": 30,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/plaintext.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/plaintext.ts",
+      "contentHash": "1ce9ad20c964816480ad6e43cb3551b455c46094da6d846241f90826d8202b5e",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "plaintextConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/powershell.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/powershell.ts",
+      "contentHash": "9f9b84449b52089ac5306b0bfafff944431f6ae19aed3912f38f51e81e311555",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "powershellConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/protobuf.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/protobuf.ts",
+      "contentHash": "936e343669a7f40925bf25c92e68c511c56bd44a8653f940ec5ce3a5cad2c729",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "protobufConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/python.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/python.ts",
+      "contentHash": "f55c580979f5d3bf62ccbc9d33cd4a15ad13570cdbae09738b1128507c60cd71",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "pythonConfig"
+      ],
+      "totalLines": 45,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/restructuredtext.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/restructuredtext.ts",
+      "contentHash": "e9519f888a1f7383aa0c999d698cb9482d76fb1a4cc5c183971c87f0ea5f27a5",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "restructuredtextConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/ruby.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/ruby.ts",
+      "contentHash": "0a787bc700925cad605c6b6cf4f0673412be1a3d18390cadf54a3527efd599ef",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "rubyConfig"
+      ],
+      "totalLines": 29,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/rust.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/rust.ts",
+      "contentHash": "dec8c7699cb11e95162b1a59c3b6d1526d46bb9a1490073b866c6fa0b78398c2",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "rustConfig"
+      ],
+      "totalLines": 32,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/shell.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/shell.ts",
+      "contentHash": "a5ff9ffc87ed0694e7697f45b9d7fff4ef67c25b672a818cf5d8d280405f0a7c",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "shellConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/sql.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/sql.ts",
+      "contentHash": "6fd9e9461c81f6823258cca8fbdecd4b14ec8f17d2ee53f9c1e3a117af5d75a7",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "sqlConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/swift.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/swift.ts",
+      "contentHash": "4e43147ef5c9cb90f9f4c6bb0828d6149303db405ddcbed43cb6221aabd91035",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "swiftConfig"
+      ],
+      "totalLines": 26,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/terraform.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/terraform.ts",
+      "contentHash": "dfea8da2a2896b36d0cd8603109a49acdf5430a4591ce217ebd6a844fae1a3e9",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "terraformConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/toml.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/toml.ts",
+      "contentHash": "f8d90748d1ddff207014df536e76587a7c386e10431fc6840a04e1667ec0225c",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "tomlConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/typescript.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/typescript.ts",
+      "contentHash": "5827d48f5343d189a3a817d2fe15e878aaa2f2443a03d2db2de160baeaaf7d44",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "typescriptConfig"
+      ],
+      "totalLines": 31,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/xml.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/xml.ts",
+      "contentHash": "e65473160317f50701c340a7c876cd020dc6625904132ae4a0e365e258645131",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "xmlConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/configs/yaml.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/yaml.ts",
+      "contentHash": "09996d9b5b2d2fd634000cb25df2902020a216afbc8425d611bf36fccfc99e84",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "yamlConfig"
+      ],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/framework-registry.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+      "contentHash": "fbeefabd8a3558a8464449391ba2d09096d10ca66734612b7e753f27a115fc6c",
+      "functions": [],
+      "classes": [
+        {
+          "name": "FrameworkRegistry",
+          "methods": [
+            "register",
+            "getById",
+            "getForLanguage",
+            "getAllFrameworks",
+            "detectFrameworks",
+            "createDefault"
+          ],
+          "properties": [
+            "byId",
+            "byLanguage"
+          ],
+          "exported": true,
+          "lineCount": 78
+        }
+      ],
+      "imports": [
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "FrameworkConfigSchema"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        },
+        {
+          "source": "./frameworks/index.js",
+          "specifiers": [
+            "builtinFrameworkConfigs"
+          ]
+        }
+      ],
+      "exports": [
+        "FrameworkRegistry"
+      ],
+      "totalLines": 87,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/django.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/django.ts",
+      "contentHash": "64a1cd0a763e7f30bcea6e5d70c336458eaeacb856d194123ae3bc1590b2cc9c",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "djangoConfig"
+      ],
+      "totalLines": 37,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/express.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/express.ts",
+      "contentHash": "3bd8de6da6783b42141286835f4d1568521ed30a16df39f9ff413f07db17adb9",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "expressConfig"
+      ],
+      "totalLines": 27,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/fastapi.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/fastapi.ts",
+      "contentHash": "95d22224c4dba40d6b547954683eb9f57f10573452ca515565552528e9a03be1",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "fastapiConfig"
+      ],
+      "totalLines": 26,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/flask.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/flask.ts",
+      "contentHash": "4b8d7fd31e36a581038a6b3012a9eb4b1b1e15132d9d2406b3f10ceaa1da0041",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "flaskConfig"
+      ],
+      "totalLines": 32,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/gin.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/gin.ts",
+      "contentHash": "b32a5db961993874117e929963acc51051686de6765419a64838414eca17f318",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "ginConfig"
+      ],
+      "totalLines": 20,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/index.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "contentHash": "db476e809116e7f458c814699bc5590799fa5c99eb0215b5ecf463ff01d45e3e",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        },
+        {
+          "source": "./django.js",
+          "specifiers": [
+            "djangoConfig"
+          ]
+        },
+        {
+          "source": "./fastapi.js",
+          "specifiers": [
+            "fastapiConfig"
+          ]
+        },
+        {
+          "source": "./flask.js",
+          "specifiers": [
+            "flaskConfig"
+          ]
+        },
+        {
+          "source": "./react.js",
+          "specifiers": [
+            "reactConfig"
+          ]
+        },
+        {
+          "source": "./nextjs.js",
+          "specifiers": [
+            "nextjsConfig"
+          ]
+        },
+        {
+          "source": "./express.js",
+          "specifiers": [
+            "expressConfig"
+          ]
+        },
+        {
+          "source": "./vue.js",
+          "specifiers": [
+            "vueConfig"
+          ]
+        },
+        {
+          "source": "./spring.js",
+          "specifiers": [
+            "springConfig"
+          ]
+        },
+        {
+          "source": "./rails.js",
+          "specifiers": [
+            "railsConfig"
+          ]
+        },
+        {
+          "source": "./gin.js",
+          "specifiers": [
+            "ginConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "builtinFrameworkConfigs",
+        "djangoConfig",
+        "fastapiConfig",
+        "flaskConfig",
+        "reactConfig",
+        "nextjsConfig",
+        "expressConfig",
+        "vueConfig",
+        "springConfig",
+        "railsConfig",
+        "ginConfig"
+      ],
+      "totalLines": 39,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/nextjs.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/nextjs.ts",
+      "contentHash": "1154549de6b8273db301cc0fde1234d43567a6565944e453d28c5c62599b4723",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "nextjsConfig"
+      ],
+      "totalLines": 24,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/rails.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/rails.ts",
+      "contentHash": "5657fe0b210b310ed05013b04b11c3b0fd38b8d215289d02f8d0d4724a5cc621",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "railsConfig"
+      ],
+      "totalLines": 29,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/react.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/react.ts",
+      "contentHash": "39b6d264f8cc35185529b9f6ee2906082f4642f3dde94acc54ab2f1b25bfa3f9",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "reactConfig"
+      ],
+      "totalLines": 20,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/spring.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/spring.ts",
+      "contentHash": "91168e119937dd2d6db85e83bf613ffe9a6f1aa602f0212d113ff7735da4e131",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "springConfig"
+      ],
+      "totalLines": 28,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/frameworks/vue.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/vue.ts",
+      "contentHash": "82cab979c5a60c436603ce3a4633c57057f23f328ee47b478b788b431f9e9c53",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "FrameworkConfig"
+          ]
+        }
+      ],
+      "exports": [
+        "vueConfig"
+      ],
+      "totalLines": 20,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/index.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/index.ts",
+      "contentHash": "8385b2fc6a90935eb18a79b32836bf6c110fcce8cc070197bcfd3818304d332c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "LanguageConfig",
+        "TreeSitterConfig",
+        "FilePatternConfig",
+        "FrameworkConfig",
+        "LanguageConfigSchema",
+        "TreeSitterConfigSchema",
+        "FilePatternConfigSchema",
+        "FrameworkConfigSchema",
+        "LanguageRegistry",
+        "FrameworkRegistry",
+        "builtinLanguageConfigs",
+        "builtinFrameworkConfigs"
+      ],
+      "totalLines": 23,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/language-registry.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "contentHash": "7f736d509ba4aabb67f4de1f23d07545a9e76ad25c6aac3d08ef448d4220aeb5",
+      "functions": [],
+      "classes": [
+        {
+          "name": "LanguageRegistry",
+          "methods": [
+            "register",
+            "getById",
+            "getByExtension",
+            "getForFile",
+            "getAllLanguages",
+            "createDefault"
+          ],
+          "properties": [
+            "byId",
+            "byExtension",
+            "byFilename"
+          ],
+          "exported": true,
+          "lineCount": 56
+        }
+      ],
+      "imports": [
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageConfigSchema"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        },
+        {
+          "source": "./configs/index.js",
+          "specifiers": [
+            "builtinLanguageConfigs"
+          ]
+        }
+      ],
+      "exports": [
+        "LanguageRegistry"
+      ],
+      "totalLines": 65,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/languages/types.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/languages/types.ts",
+      "contentHash": "1f107c0e099ab6b29710f8f81d2e4dbe8116378d3be5fc1568f71d4dfd81c05b",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "zod",
+          "specifiers": [
+            "z"
+          ]
+        }
+      ],
+      "exports": [
+        "TreeSitterConfigSchema",
+        "FilePatternConfigSchema",
+        "LanguageConfigSchema",
+        "StrictLanguageConfigSchema",
+        "FrameworkConfigSchema"
+      ],
+      "totalLines": 63,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/persistence/index.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "contentHash": "74a1615af01d7f68b4d833af94d5fccf9e05b7a69056e80ca8ce9dbbb20da783",
+      "functions": [
+        {
+          "name": "ensureDir",
+          "params": [
+            "projectRoot"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "sanitiseFilePaths",
+          "params": [
+            "graph",
+            "projectRoot"
+          ],
+          "returnType": "KnowledgeGraph",
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "saveGraph",
+          "params": [
+            "projectRoot",
+            "graph"
+          ],
+          "returnType": "void",
+          "exported": true,
+          "lineCount": 15
+        },
+        {
+          "name": "loadGraph",
+          "params": [
+            "projectRoot",
+            "options"
+          ],
+          "returnType": "KnowledgeGraph | null",
+          "exported": true,
+          "lineCount": 21
+        },
+        {
+          "name": "saveMeta",
+          "params": [
+            "projectRoot",
+            "meta"
+          ],
+          "returnType": "void",
+          "exported": true,
+          "lineCount": 4
+        },
+        {
+          "name": "loadMeta",
+          "params": [
+            "projectRoot"
+          ],
+          "returnType": "AnalysisMeta | null",
+          "exported": true,
+          "lineCount": 5
+        },
+        {
+          "name": "saveFingerprints",
+          "params": [
+            "projectRoot",
+            "store"
+          ],
+          "returnType": "void",
+          "exported": true,
+          "lineCount": 4
+        },
+        {
+          "name": "loadFingerprints",
+          "params": [
+            "projectRoot"
+          ],
+          "returnType": "FingerprintStore | null",
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "saveConfig",
+          "params": [
+            "projectRoot",
+            "config"
+          ],
+          "returnType": "void",
+          "exported": true,
+          "lineCount": 4
+        },
+        {
+          "name": "loadConfig",
+          "params": [
+            "projectRoot"
+          ],
+          "returnType": "ProjectConfig",
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "saveDomainGraph",
+          "params": [
+            "projectRoot",
+            "graph"
+          ],
+          "returnType": "void",
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "loadDomainGraph",
+          "params": [
+            "projectRoot",
+            "options"
+          ],
+          "returnType": "KnowledgeGraph | null",
+          "exported": true,
+          "lineCount": 21
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "readFileSync",
+            "writeFileSync",
+            "mkdirSync",
+            "existsSync"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join",
+            "isAbsolute",
+            "relative",
+            "basename"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph",
+            "AnalysisMeta",
+            "ProjectConfig"
+          ]
+        },
+        {
+          "source": "../fingerprint.js",
+          "specifiers": [
+            "FingerprintStore"
+          ]
+        },
+        {
+          "source": "../schema.js",
+          "specifiers": [
+            "validateGraph"
+          ]
+        }
+      ],
+      "exports": [
+        "saveGraph",
+        "loadGraph",
+        "saveMeta",
+        "loadMeta",
+        "saveFingerprints",
+        "loadFingerprints",
+        "saveConfig",
+        "loadConfig",
+        "saveDomainGraph",
+        "loadDomainGraph"
+      ],
+      "totalLines": 183,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/persistence/persistence.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/persistence/persistence.test.ts",
+      "contentHash": "f278b9bfd4a8233e85da01f7c8eb6dd6d63572043cc4c20d9b300c88bf1f489b",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeEach",
+            "afterEach"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "mkdtempSync",
+            "rmSync",
+            "existsSync"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join"
+          ]
+        },
+        {
+          "source": "node:os",
+          "specifiers": [
+            "tmpdir"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "writeFileSync"
+          ]
+        },
+        {
+          "source": "./index.js",
+          "specifiers": [
+            "saveGraph",
+            "loadGraph",
+            "saveMeta",
+            "loadMeta",
+            "saveFingerprints",
+            "loadFingerprints",
+            "saveConfig",
+            "loadConfig"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "KnowledgeGraph",
+            "AnalysisMeta"
+          ]
+        },
+        {
+          "source": "../fingerprint.js",
+          "specifiers": [
+            "FingerprintStore"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 205,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/discovery.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "contentHash": "b3c88c1fcc6009ad16a3b8270072dbb2e03a21aff4443e635d6d0626d07327c0",
+      "functions": [
+        {
+          "name": "parsePluginConfig",
+          "params": [
+            "jsonString"
+          ],
+          "returnType": "PluginConfig",
+          "exported": true,
+          "lineCount": 32
+        },
+        {
+          "name": "serializePluginConfig",
+          "params": [
+            "config"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 3
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../languages/configs/index.js",
+          "specifiers": [
+            "builtinLanguageConfigs"
+          ]
+        }
+      ],
+      "exports": [
+        "DEFAULT_PLUGIN_CONFIG",
+        "parsePluginConfig",
+        "serializePluginConfig"
+      ],
+      "totalLines": 69,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cpp-extractor.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cpp-extractor.test.ts",
+      "contentHash": "147eeb1e07f3d30fc1323047a71492ee0d526f08065a8916ac55a16d48bdb6da",
+      "functions": [
+        {
+          "name": "parse",
+          "params": [
+            "code"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "../cpp-extractor.js",
+          "specifiers": [
+            "CppExtractor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 697,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts",
+      "contentHash": "c163104ea9eb37afc48fd81242c65ede4141dedbc341c9f25248306616c94f75",
+      "functions": [
+        {
+          "name": "parse",
+          "params": [
+            "code"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "../csharp-extractor.js",
+          "specifiers": [
+            "CSharpExtractor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 666,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/dart-extractor.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/dart-extractor.test.ts",
+      "contentHash": "7f0dea1e9c0f6e53a8393b256cdfb5a11ec11a558f7cf7c840b6e4ffca799bd3",
+      "functions": [
+        {
+          "name": "parse",
+          "params": [
+            "code"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "../dart-extractor.js",
+          "specifiers": [
+            "DartExtractor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 676,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts",
+      "contentHash": "4bbe6a0f0f7fa6b311fc8f3a95b74aaff39f7c7b4e91c3f8d8219f212ee88203",
+      "functions": [
+        {
+          "name": "parse",
+          "params": [
+            "code"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "../go-extractor.js",
+          "specifiers": [
+            "GoExtractor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 600,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/java-extractor.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/java-extractor.test.ts",
+      "contentHash": "18d0fd5375175729e424461742f66776eab6a5cbb2219c96bee01b6efb1cf0dd",
+      "functions": [
+        {
+          "name": "parse",
+          "params": [
+            "code"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "../java-extractor.js",
+          "specifiers": [
+            "JavaExtractor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 569,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/kotlin-extractor.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/kotlin-extractor.test.ts",
+      "contentHash": "3e5c19226783a3a89f4b437ea4af0a89e6b1e4dec98d723feab199b6f8baf5f3",
+      "functions": [
+        {
+          "name": "parse",
+          "params": [
+            "code"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "../kotlin-extractor.js",
+          "specifiers": [
+            "KotlinExtractor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 365,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts",
+      "contentHash": "10184b66e2cc34d27b712a83439b4f46d8f592606c34d58ff03f256a38008919",
+      "functions": [
+        {
+          "name": "parse",
+          "params": [
+            "code"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "../php-extractor.js",
+          "specifiers": [
+            "PhpExtractor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 677,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts",
+      "contentHash": "ec0d013e15b17a905d2348a76597d297c8793a715ab749ba51d94bf66f96363b",
+      "functions": [
+        {
+          "name": "parse",
+          "params": [
+            "code"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "../python-extractor.js",
+          "specifiers": [
+            "PythonExtractor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 660,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts",
+      "contentHash": "2c950847b766b01b6a6e9806fefbd8eb2a2db4a8898e1a623d0caa695b189794",
+      "functions": [
+        {
+          "name": "parse",
+          "params": [
+            "code"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "../ruby-extractor.js",
+          "specifiers": [
+            "RubyExtractor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 689,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/rust-extractor.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/rust-extractor.test.ts",
+      "contentHash": "464ff733ab38c0f472a8c1eef13bbc58784388ab1477f1214bf0c54d2ebef58e",
+      "functions": [
+        {
+          "name": "parse",
+          "params": [
+            "code"
+          ],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "../rust-extractor.js",
+          "specifiers": [
+            "RustExtractor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 756,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "contentHash": "8eafac3b46058365ef317b7427f09befc570ed420fc3629f0ae6bdba7725d689",
+      "functions": [
+        {
+          "name": "traverse",
+          "params": [
+            "node",
+            "visitor"
+          ],
+          "returnType": "void",
+          "exported": true,
+          "lineCount": 10
+        },
+        {
+          "name": "getStringValue",
+          "params": [
+            "node"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "findChild",
+          "params": [
+            "node",
+            "type"
+          ],
+          "returnType": "TreeSitterNode | null",
+          "exported": true,
+          "lineCount": 7
+        },
+        {
+          "name": "findChildren",
+          "params": [
+            "node",
+            "type"
+          ],
+          "returnType": "TreeSitterNode[]",
+          "exported": true,
+          "lineCount": 8
+        },
+        {
+          "name": "hasChildOfType",
+          "params": [
+            "node",
+            "type"
+          ],
+          "returnType": "boolean",
+          "exported": true,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "TreeSitterNode"
+          ]
+        }
+      ],
+      "exports": [
+        "traverse",
+        "getStringValue",
+        "findChild",
+        "findChildren",
+        "hasChildOfType"
+      ],
+      "totalLines": 53,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "contentHash": "02d01bf5713a8b6e494346cd220efc0ac80b25550605cc412810bc9e7b0b9e15",
+      "functions": [
+        {
+          "name": "unwrapDeclaratorName",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "extractFuncDeclName",
+          "params": [
+            "funcDecl"
+          ],
+          "returnType": "{ name: string; qualifier: string | null } | null",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "extractParams",
+          "params": [
+            "paramsNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "extractReturnType",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "isStatic",
+          "params": [
+            "node"
+          ],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "CppExtractor",
+          "methods": [
+            "extractStructure",
+            "extractCallGraph",
+            "walkTopLevel",
+            "extractFunctionName",
+            "extractInclude",
+            "extractClassOrStruct",
+            "extractFunctionDef",
+            "extractCalleeName"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 378
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "findChild",
+            "findChildren"
+          ]
+        }
+      ],
+      "exports": [
+        "CppExtractor"
+      ],
+      "totalLines": 502,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "contentHash": "356a3e24aef8b4d16da2fe6bae1d3715d22c14360b843f5b984e8f54b420ea80",
+      "functions": [
+        {
+          "name": "extractParams",
+          "params": [
+            "paramsNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "extractReturnType",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "hasModifier",
+          "params": [
+            "node",
+            "modifier"
+          ],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "extractUsingSource",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "lastComponent",
+          "params": [
+            "path"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "extractInvocationName",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "CSharpExtractor",
+          "methods": [
+            "extractStructure",
+            "extractCallGraph",
+            "walkTopLevel",
+            "walkNamespaceBody",
+            "extractUsing",
+            "extractClass",
+            "extractInterface",
+            "extractClassBodyMembers",
+            "extractMethod",
+            "extractConstructor",
+            "extractProperty",
+            "extractField"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 399
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "findChild",
+            "findChildren"
+          ]
+        }
+      ],
+      "exports": [
+        "CSharpExtractor"
+      ],
+      "totalLines": 525,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "contentHash": "661d56f616e45a1fbb2b9c74fffe7233c8f21a7f9190f03ba6eb4d1f2a0295e4",
+      "functions": [
+        {
+          "name": "isExported",
+          "params": [
+            "name"
+          ],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "extractFunctionName",
+          "params": [
+            "sig"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "extractParamName",
+          "params": [
+            "paramNode"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "extractParams",
+          "params": [
+            "sig"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "extractReturnType",
+          "params": [
+            "sig"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "pushMethod",
+          "params": [
+            "declNode",
+            "sig",
+            "name",
+            "methods",
+            "functions",
+            "exports"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "uriText",
+          "params": [
+            "uriNode"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "constructorName",
+          "params": [
+            "sig"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "collectClassBody",
+          "params": [
+            "body",
+            "methods",
+            "properties",
+            "functions",
+            "exports"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 90
+        }
+      ],
+      "classes": [
+        {
+          "name": "DartExtractor",
+          "methods": [
+            "extractStructure",
+            "extractTopLevelFunction",
+            "extractClassLikeDeclaration",
+            "extractExtensionDeclaration",
+            "extractEnumDeclaration",
+            "extractImportOrExport",
+            "extractLibraryImport",
+            "extractLibraryExport",
+            "extractCallGraph",
+            "extractCalleeName"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 433
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "findChild",
+            "findChildren",
+            "getStringValue"
+          ]
+        }
+      ],
+      "exports": [
+        "DartExtractor"
+      ],
+      "totalLines": 737,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "contentHash": "71da081b3c434a7a783c3422205f5eb1146725ec423608f52d51b5a2ee93bc42",
+      "functions": [
+        {
+          "name": "extractParams",
+          "params": [
+            "paramsNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "extractResultType",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "extractReceiverType",
+          "params": [
+            "receiverNode"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "isExported",
+          "params": [
+            "name"
+          ],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "GoExtractor",
+          "methods": [
+            "extractStructure",
+            "extractCallGraph",
+            "extractFunction",
+            "extractMethod",
+            "extractTypeDeclaration",
+            "extractStruct",
+            "extractInterface",
+            "extractImportDeclaration",
+            "extractImportSpec"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 314
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "findChild",
+            "findChildren"
+          ]
+        }
+      ],
+      "exports": [
+        "GoExtractor"
+      ],
+      "totalLines": 403,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/index.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "contentHash": "7ea63fc45af9c431fc704f28edf29e56b32b173b7ac23353cdd63bcb5b138df7",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor"
+          ]
+        },
+        {
+          "source": "./typescript-extractor.js",
+          "specifiers": [
+            "TypeScriptExtractor"
+          ]
+        },
+        {
+          "source": "./python-extractor.js",
+          "specifiers": [
+            "PythonExtractor"
+          ]
+        },
+        {
+          "source": "./go-extractor.js",
+          "specifiers": [
+            "GoExtractor"
+          ]
+        },
+        {
+          "source": "./rust-extractor.js",
+          "specifiers": [
+            "RustExtractor"
+          ]
+        },
+        {
+          "source": "./java-extractor.js",
+          "specifiers": [
+            "JavaExtractor"
+          ]
+        },
+        {
+          "source": "./ruby-extractor.js",
+          "specifiers": [
+            "RubyExtractor"
+          ]
+        },
+        {
+          "source": "./php-extractor.js",
+          "specifiers": [
+            "PhpExtractor"
+          ]
+        },
+        {
+          "source": "./cpp-extractor.js",
+          "specifiers": [
+            "CppExtractor"
+          ]
+        },
+        {
+          "source": "./csharp-extractor.js",
+          "specifiers": [
+            "CSharpExtractor"
+          ]
+        },
+        {
+          "source": "./dart-extractor.js",
+          "specifiers": [
+            "DartExtractor"
+          ]
+        },
+        {
+          "source": "./kotlin-extractor.js",
+          "specifiers": [
+            "KotlinExtractor"
+          ]
+        }
+      ],
+      "exports": [
+        "LanguageExtractor",
+        "TreeSitterNode",
+        "traverse",
+        "getStringValue",
+        "findChild",
+        "findChildren",
+        "hasChildOfType",
+        "TypeScriptExtractor",
+        "PythonExtractor",
+        "GoExtractor",
+        "RustExtractor",
+        "JavaExtractor",
+        "RubyExtractor",
+        "PhpExtractor",
+        "CppExtractor",
+        "CSharpExtractor",
+        "DartExtractor",
+        "KotlinExtractor",
+        "builtinExtractors"
+      ],
+      "totalLines": 41,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "contentHash": "5b37d416d3e086d3394596711b192ad9cfa5ecdc491abcea7fa03cd44370325a",
+      "functions": [
+        {
+          "name": "extractParams",
+          "params": [
+            "paramsNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "extractReturnType",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "hasModifier",
+          "params": [
+            "node",
+            "modifier"
+          ],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "extractScopedIdentifierPath",
+          "params": [
+            "node"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "lastComponent",
+          "params": [
+            "path"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "JavaExtractor",
+          "methods": [
+            "extractStructure",
+            "extractCallGraph",
+            "extractMethodInvocationName",
+            "extractImport",
+            "extractClass",
+            "extractInterface",
+            "extractClassBodyMembers",
+            "extractMethod",
+            "extractConstructor",
+            "extractField"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 354
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "findChild",
+            "findChildren"
+          ]
+        }
+      ],
+      "exports": [
+        "JavaExtractor"
+      ],
+      "totalLines": 450,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "contentHash": "719805f7f60afc178580cab3e6e4f549ff4bb74cbd1c71a29789faa80a12ce24",
+      "functions": [
+        {
+          "name": "extractVisibility",
+          "params": [
+            "declNode"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "isExported",
+          "params": [
+            "declNode"
+          ],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "extractDeclarationName",
+          "params": [
+            "declNode"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "extractParams",
+          "params": [
+            "declNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "extractReturnType",
+          "params": [
+            "declNode"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "collectClassBody",
+          "params": [
+            "body",
+            "methods",
+            "properties",
+            "functions",
+            "exports"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 39
+        },
+        {
+          "name": "extractPropertyName",
+          "params": [
+            "propNode"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "collectPrimaryConstructorProperties",
+          "params": [
+            "declNode",
+            "properties"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 23
+        }
+      ],
+      "classes": [
+        {
+          "name": "KotlinExtractor",
+          "methods": [
+            "extractStructure",
+            "extractCallGraph",
+            "extractTopLevelFunction",
+            "extractClassDeclaration",
+            "extractObjectDeclaration",
+            "extractImport",
+            "extractCalleeName"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 243
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "findChild",
+            "findChildren"
+          ]
+        }
+      ],
+      "exports": [
+        "KotlinExtractor"
+      ],
+      "totalLines": 426,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "contentHash": "822b4832fbe17216e3792c055cf9b146ab68b1a9f177674805484d685e600057",
+      "functions": [
+        {
+          "name": "extractParams",
+          "params": [
+            "paramsNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "extractReturnType",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "extractUseName",
+          "params": [
+            "clause",
+            "prefix"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "lastSegment",
+          "params": [
+            "fqn"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "PhpExtractor",
+          "methods": [
+            "extractStructure",
+            "walkStatements",
+            "extractCallGraph",
+            "getFunctionName",
+            "getClassName",
+            "getInterfaceName",
+            "extractFunction",
+            "extractClass",
+            "extractInterface",
+            "extractDeclarationList",
+            "extractUseDeclaration"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 347
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "findChild",
+            "findChildren"
+          ]
+        }
+      ],
+      "exports": [
+        "PhpExtractor"
+      ],
+      "totalLines": 462,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "contentHash": "22509ab258465bc1b2b54a9dec9f6a928586710ad1d285fc86416028215d5a6a",
+      "functions": [
+        {
+          "name": "extractParams",
+          "params": [
+            "paramsNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 56
+        },
+        {
+          "name": "extractReturnType",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "unwrapDecorated",
+          "params": [
+            "node"
+          ],
+          "returnType": "TreeSitterNode",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "PythonExtractor",
+          "methods": [
+            "extractStructure",
+            "extractCallGraph",
+            "extractFunction",
+            "extractClass",
+            "extractImport",
+            "extractFromImport",
+            "addExport"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 252
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "findChild",
+            "findChildren"
+          ]
+        }
+      ],
+      "exports": [
+        "PythonExtractor"
+      ],
+      "totalLines": 354,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "contentHash": "9ca10f3dabc58c259f2011337c5404bd83433d500185c91ffda2088aa3457d9d",
+      "functions": [
+        {
+          "name": "extractParams",
+          "params": [
+            "paramsNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 41
+        },
+        {
+          "name": "extractAttrProperties",
+          "params": [
+            "callNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "getStringContent",
+          "params": [
+            "node"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 6
+        }
+      ],
+      "classes": [
+        {
+          "name": "RubyExtractor",
+          "methods": [
+            "extractStructure",
+            "extractCallGraph",
+            "getMethodName",
+            "getSingletonMethodName",
+            "getClassName",
+            "getModuleName",
+            "extractMethod",
+            "extractSingletonMethod",
+            "extractClass",
+            "extractModule",
+            "extractClassBody",
+            "extractTopLevelCall"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 310
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "findChild"
+          ]
+        }
+      ],
+      "exports": [
+        "RubyExtractor"
+      ],
+      "totalLines": 421,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "contentHash": "0480a8803b5ec396d6f2025fe1869d26145588043064fa45aeb55637675d070a",
+      "functions": [
+        {
+          "name": "extractParams",
+          "params": [
+            "paramsNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "extractReturnType",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "isPublic",
+          "params": [
+            "node"
+          ],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "extractScopedPath",
+          "params": [
+            "node"
+          ],
+          "returnType": "{ path: string; name: string }",
+          "exported": false,
+          "lineCount": 11
+        }
+      ],
+      "classes": [
+        {
+          "name": "RustExtractor",
+          "methods": [
+            "extractStructure",
+            "extractCallGraph",
+            "extractCalleeName",
+            "extractFunction",
+            "extractStruct",
+            "extractEnum",
+            "extractTrait",
+            "extractImpl",
+            "extractUseDeclaration"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 418
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "findChild",
+            "findChildren"
+          ]
+        }
+      ],
+      "exports": [
+        "RustExtractor"
+      ],
+      "totalLines": 510,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/types.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "contentHash": "9af707a4643eaec7f8986184033df852130dbf8cf632cfd415c00d1cce3f29a7",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 20,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "contentHash": "1c89405f3db6a1cf1f679144e886542405d3a7f8b99ba1d9593043888339457a",
+      "functions": [
+        {
+          "name": "extractParams",
+          "params": [
+            "paramsNode"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 40
+        },
+        {
+          "name": "extractReturnType",
+          "params": [
+            "node"
+          ],
+          "returnType": "string | undefined",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "extractImportSpecifiers",
+          "params": [
+            "importClause"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 33
+        }
+      ],
+      "classes": [
+        {
+          "name": "TypeScriptExtractor",
+          "methods": [
+            "extractStructure",
+            "extractCallGraph",
+            "processTopLevelNode",
+            "extractFunction",
+            "extractClass",
+            "extractVariableDeclarations",
+            "extractImport",
+            "processExportStatement"
+          ],
+          "properties": [
+            "languageIds"
+          ],
+          "exported": true,
+          "lineCount": 389
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "StructuralAnalysis",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "LanguageExtractor",
+            "TreeSitterNode"
+          ]
+        },
+        {
+          "source": "./base-extractor.js",
+          "specifiers": [
+            "getStringValue"
+          ]
+        }
+      ],
+      "exports": [
+        "TypeScriptExtractor"
+      ],
+      "totalLines": 495,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts",
+      "contentHash": "94e7e7f81504eb483e3a3b82bf80e1feff543c00f2cc90331748958c872f9f2b",
+      "functions": [],
+      "classes": [
+        {
+          "name": "DockerfileParser",
+          "methods": [
+            "analyzeFile",
+            "extractStages",
+            "extractSteps"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 79
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "ServiceInfo",
+            "StepInfo"
+          ]
+        }
+      ],
+      "exports": [
+        "DockerfileParser"
+      ],
+      "totalLines": 87,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts",
+      "contentHash": "de9167776cc01bfa553564dc23f4f3db778b0316ad08cd8afb3dee4ea0b6b19c",
+      "functions": [],
+      "classes": [
+        {
+          "name": "EnvParser",
+          "methods": [
+            "analyzeFile",
+            "extractVariables"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 34
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "DefinitionInfo"
+          ]
+        }
+      ],
+      "exports": [
+        "EnvParser"
+      ],
+      "totalLines": 42,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts",
+      "contentHash": "548542e064326e22d2c15f4267951bc95213c6d38d1a673953301353f29a9855",
+      "functions": [],
+      "classes": [
+        {
+          "name": "GraphQLParser",
+          "methods": [
+            "analyzeFile",
+            "extractDefinitions",
+            "extractEndpoints",
+            "extractFields"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 115
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "DefinitionInfo",
+            "EndpointInfo"
+          ]
+        }
+      ],
+      "exports": [
+        "GraphQLParser"
+      ],
+      "totalLines": 123,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/index.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "contentHash": "0482fcb938491100e513300040a462cd24fc314a113f2790f0d79fe64759669d",
+      "functions": [
+        {
+          "name": "registerAllParsers",
+          "params": [
+            "registry"
+          ],
+          "returnType": "void",
+          "exported": true,
+          "lineCount": 14
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../registry.js",
+          "specifiers": [
+            "PluginRegistry"
+          ]
+        },
+        {
+          "source": "./markdown-parser.js",
+          "specifiers": [
+            "MarkdownParser"
+          ]
+        },
+        {
+          "source": "./yaml-parser.js",
+          "specifiers": [
+            "YAMLConfigParser"
+          ]
+        },
+        {
+          "source": "./json-parser.js",
+          "specifiers": [
+            "JSONConfigParser"
+          ]
+        },
+        {
+          "source": "./toml-parser.js",
+          "specifiers": [
+            "TOMLParser"
+          ]
+        },
+        {
+          "source": "./env-parser.js",
+          "specifiers": [
+            "EnvParser"
+          ]
+        },
+        {
+          "source": "./dockerfile-parser.js",
+          "specifiers": [
+            "DockerfileParser"
+          ]
+        },
+        {
+          "source": "./sql-parser.js",
+          "specifiers": [
+            "SQLParser"
+          ]
+        },
+        {
+          "source": "./graphql-parser.js",
+          "specifiers": [
+            "GraphQLParser"
+          ]
+        },
+        {
+          "source": "./protobuf-parser.js",
+          "specifiers": [
+            "ProtobufParser"
+          ]
+        },
+        {
+          "source": "./terraform-parser.js",
+          "specifiers": [
+            "TerraformParser"
+          ]
+        },
+        {
+          "source": "./makefile-parser.js",
+          "specifiers": [
+            "MakefileParser"
+          ]
+        },
+        {
+          "source": "./shell-parser.js",
+          "specifiers": [
+            "ShellParser"
+          ]
+        }
+      ],
+      "exports": [
+        "MarkdownParser",
+        "YAMLConfigParser",
+        "JSONConfigParser",
+        "TOMLParser",
+        "EnvParser",
+        "DockerfileParser",
+        "SQLParser",
+        "GraphQLParser",
+        "ProtobufParser",
+        "TerraformParser",
+        "MakefileParser",
+        "ShellParser",
+        "registerAllParsers"
+      ],
+      "totalLines": 45,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "contentHash": "7fad80e12b8869bd2eae585f3ceef5686c75fb3e697c35bd045c686c3bebcbc8",
+      "functions": [
+        {
+          "name": "stripJsoncSyntax",
+          "params": [
+            "content"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 49
+        }
+      ],
+      "classes": [
+        {
+          "name": "JSONConfigParser",
+          "methods": [
+            "analyzeFile",
+            "extractReferences",
+            "extractSections"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 68
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "SectionInfo",
+            "ReferenceResolution"
+          ]
+        }
+      ],
+      "exports": [
+        "stripJsoncSyntax",
+        "JSONConfigParser"
+      ],
+      "totalLines": 137,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts",
+      "contentHash": "c8343dbfc6f7fa73619195927e531aae35630a95f49f92d64053f59ac0bb0cd2",
+      "functions": [],
+      "classes": [
+        {
+          "name": "MakefileParser",
+          "methods": [
+            "analyzeFile",
+            "extractTargets"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 44
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "StepInfo"
+          ]
+        }
+      ],
+      "exports": [
+        "MakefileParser"
+      ],
+      "totalLines": 52,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts",
+      "contentHash": "7042fb277894f3d02decd25ef7d1dbce02b47318ac935312c9835022ec94d836",
+      "functions": [],
+      "classes": [
+        {
+          "name": "MarkdownParser",
+          "methods": [
+            "analyzeFile",
+            "extractReferences",
+            "extractSections"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 71
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "ReferenceResolution",
+            "SectionInfo"
+          ]
+        }
+      ],
+      "exports": [
+        "MarkdownParser"
+      ],
+      "totalLines": 79,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts",
+      "contentHash": "5c55a55cbf284134c10d016570eed28dcca0929b477f4bae68bfbcae9b859b66",
+      "functions": [],
+      "classes": [
+        {
+          "name": "ProtobufParser",
+          "methods": [
+            "analyzeFile",
+            "extractDefinitions",
+            "extractServiceMethods",
+            "extractMessageFields",
+            "extractEnumValues",
+            "findClosingBrace"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 134
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "DefinitionInfo",
+            "EndpointInfo"
+          ]
+        }
+      ],
+      "exports": [
+        "ProtobufParser"
+      ],
+      "totalLines": 142,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts",
+      "contentHash": "adee0b999e96d8d0f44985ab35b645a9746f5210b3f58037e294edc5b43a6b6a",
+      "functions": [],
+      "classes": [
+        {
+          "name": "ShellParser",
+          "methods": [
+            "analyzeFile",
+            "extractReferences",
+            "extractFunctions"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 79
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "ReferenceResolution"
+          ]
+        }
+      ],
+      "exports": [
+        "ShellParser"
+      ],
+      "totalLines": 87,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts",
+      "contentHash": "52b24eb14aa42684cb50f48d8e3172f11a0f298f4a3603c539da33f4bfd95cf0",
+      "functions": [],
+      "classes": [
+        {
+          "name": "SQLParser",
+          "methods": [
+            "analyzeFile",
+            "extractDefinitions",
+            "extractColumns"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 95
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "DefinitionInfo"
+          ]
+        }
+      ],
+      "exports": [
+        "SQLParser"
+      ],
+      "totalLines": 103,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts",
+      "contentHash": "d6f2811b50dd49b147e53a173f67d1bb3aebbce0604a243029797afb549a6896",
+      "functions": [],
+      "classes": [
+        {
+          "name": "TerraformParser",
+          "methods": [
+            "analyzeFile",
+            "extractResources",
+            "extractVariablesAndOutputs",
+            "findClosingBrace"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 123
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "ResourceInfo",
+            "DefinitionInfo"
+          ]
+        }
+      ],
+      "exports": [
+        "TerraformParser"
+      ],
+      "totalLines": 131,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts",
+      "contentHash": "0ac3fc6fdf41dc61a5715118a70dd2bed818721f395c20bb47228682995adce0",
+      "functions": [],
+      "classes": [
+        {
+          "name": "TOMLParser",
+          "methods": [
+            "analyzeFile",
+            "extractSections"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 39
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "SectionInfo"
+          ]
+        }
+      ],
+      "exports": [
+        "TOMLParser"
+      ],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts",
+      "contentHash": "ac4defd986696ca6d1ac0e8e714e815b2edcb37b7a43591a391fd1322eda6b2a",
+      "functions": [],
+      "classes": [
+        {
+          "name": "YAMLConfigParser",
+          "methods": [
+            "analyzeFile",
+            "extractSections",
+            "escapeRegex"
+          ],
+          "properties": [
+            "name",
+            "languages"
+          ],
+          "exported": true,
+          "lineCount": 93
+        }
+      ],
+      "imports": [
+        {
+          "source": "../../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "SectionInfo"
+          ]
+        },
+        {
+          "source": "yaml",
+          "specifiers": [
+            "parseYAML"
+          ]
+        }
+      ],
+      "exports": [
+        "YAMLConfigParser"
+      ],
+      "totalLines": 107,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/registry.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "contentHash": "10f4da908d8c2eec75bfee85ae3cab0ef808d6cec394e35c530613107d5abe19",
+      "functions": [],
+      "classes": [
+        {
+          "name": "PluginRegistry",
+          "methods": [
+            "constructor",
+            "register",
+            "unregister",
+            "getPluginForLanguage",
+            "getPluginForFile",
+            "getLanguageForFile",
+            "analyzeFile",
+            "resolveImports",
+            "extractCallGraph",
+            "getPlugins",
+            "getSupportedLanguages"
+          ],
+          "properties": [
+            "plugins",
+            "languageMap",
+            "languageRegistry"
+          ],
+          "exported": true,
+          "lineCount": 71
+        }
+      ],
+      "imports": [
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "ImportResolution",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "../languages/language-registry.js",
+          "specifiers": [
+            "LanguageRegistry"
+          ]
+        }
+      ],
+      "exports": [
+        "PluginRegistry"
+      ],
+      "totalLines": 82,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.test.ts",
+      "contentHash": "0ad8fa79ac2858dd55c718b4389e55923e4e0efdc88fd611b1a4721ecb66468f",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll"
+          ]
+        },
+        {
+          "source": "./tree-sitter-plugin.js",
+          "specifiers": [
+            "TreeSitterPlugin"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 308,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "contentHash": "9fe43b31ac2d7afcbc586ebc26dca251f777605452c7d3829f4489e5916a0495",
+      "functions": [],
+      "classes": [
+        {
+          "name": "TreeSitterPlugin",
+          "methods": [
+            "constructor",
+            "registerExtractor",
+            "getExtractor",
+            "languageKeyFromPath",
+            "init",
+            "getParser",
+            "analyzeFile",
+            "resolveImports",
+            "extractCallGraph"
+          ],
+          "properties": [
+            "name",
+            "languages",
+            "configs",
+            "_ParserClass",
+            "_languages",
+            "_extensionToLang",
+            "_initialized",
+            "extractors"
+          ],
+          "exported": true,
+          "lineCount": 269
+        }
+      ],
+      "imports": [
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname",
+            "resolve",
+            "extname"
+          ]
+        },
+        {
+          "source": "../types.js",
+          "specifiers": [
+            "AnalyzerPlugin",
+            "StructuralAnalysis",
+            "ImportResolution",
+            "CallGraphEntry"
+          ]
+        },
+        {
+          "source": "../languages/types.js",
+          "specifiers": [
+            "LanguageConfig"
+          ]
+        },
+        {
+          "source": "./extractors/types.js",
+          "specifiers": [
+            "LanguageExtractor"
+          ]
+        },
+        {
+          "source": "./extractors/index.js",
+          "specifiers": [
+            "builtinExtractors"
+          ]
+        }
+      ],
+      "exports": [
+        "TreeSitterPlugin"
+      ],
+      "totalLines": 300,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/schema.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/schema.ts",
+      "contentHash": "9c146c848edd77cb4494fd8dcffb85276c11a83ccbbb04f487ef1656b963c5cb",
+      "functions": [
+        {
+          "name": "sanitizeGraph",
+          "params": [
+            "data"
+          ],
+          "returnType": "Record<string, unknown>",
+          "exported": true,
+          "lineCount": 47
+        },
+        {
+          "name": "autoFixGraph",
+          "params": [
+            "data"
+          ],
+          "returnType": "{\n  data: Record<string, unknown>;\n  issues: GraphIssue[];\n}",
+          "exported": true,
+          "lineCount": 156
+        },
+        {
+          "name": "buildInvalidCollectionIssue",
+          "params": [
+            "name"
+          ],
+          "returnType": "GraphIssue",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "buildErrors",
+          "params": [
+            "issues",
+            "fatal"
+          ],
+          "returnType": "string[] | undefined",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "normalizeGraph",
+          "params": [
+            "data"
+          ],
+          "returnType": "unknown",
+          "exported": true,
+          "lineCount": 36
+        },
+        {
+          "name": "validateGraph",
+          "params": [
+            "data"
+          ],
+          "returnType": "ValidationResult",
+          "exported": true,
+          "lineCount": 165
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "zod",
+          "specifiers": [
+            "z"
+          ]
+        }
+      ],
+      "exports": [
+        "EdgeTypeSchema",
+        "NODE_TYPE_ALIASES",
+        "EDGE_TYPE_ALIASES",
+        "COMPLEXITY_ALIASES",
+        "DIRECTION_ALIASES",
+        "sanitizeGraph",
+        "autoFixGraph",
+        "GraphNodeSchema",
+        "GraphEdgeSchema",
+        "LayerSchema",
+        "TourStepSchema",
+        "ProjectMetaSchema",
+        "KnowledgeGraphSchema",
+        "normalizeGraph",
+        "validateGraph"
+      ],
+      "totalLines": 664,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/search.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/search.ts",
+      "contentHash": "62a9313587879a2ca396eb1c749b8f963cc9dd7bc29663b18b015526fe1774ef",
+      "functions": [],
+      "classes": [
+        {
+          "name": "SearchEngine",
+          "methods": [
+            "constructor",
+            "search",
+            "updateNodes"
+          ],
+          "properties": [
+            "fuse",
+            "nodes"
+          ],
+          "exported": true,
+          "lineCount": 39
+        }
+      ],
+      "imports": [
+        {
+          "source": "fuse.js",
+          "specifiers": [
+            "Fuse",
+            "IFuseOptions"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "GraphNode"
+          ]
+        }
+      ],
+      "exports": [
+        "SearchEngine"
+      ],
+      "totalLines": 66,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/staleness.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/staleness.ts",
+      "contentHash": "c08121229374396333aa8212b7f732b29fb3c9ca51f820ac587c131131ed47f3",
+      "functions": [
+        {
+          "name": "getChangedFiles",
+          "params": [
+            "projectDir",
+            "lastCommitHash"
+          ],
+          "returnType": "string[]",
+          "exported": true,
+          "lineCount": 17
+        },
+        {
+          "name": "isStale",
+          "params": [
+            "projectDir",
+            "lastCommitHash"
+          ],
+          "returnType": "StalenessResult",
+          "exported": true,
+          "lineCount": 10
+        },
+        {
+          "name": "mergeGraphUpdate",
+          "params": [
+            "existingGraph",
+            "changedFilePaths",
+            "newNodes",
+            "newEdges",
+            "newCommitHash"
+          ],
+          "returnType": "KnowledgeGraph",
+          "exported": true,
+          "lineCount": 37
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "child_process",
+          "specifiers": [
+            "execFileSync"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "KnowledgeGraph",
+            "GraphNode",
+            "GraphEdge"
+          ]
+        }
+      ],
+      "exports": [
+        "getChangedFiles",
+        "isStale",
+        "mergeGraphUpdate"
+      ],
+      "totalLines": 91,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/types.test.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/types.test.ts",
+      "contentHash": "115a2c521250c631b3a0277210bbbd03847273800d0e592f94b3da7e69a7d24f",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "./types.js",
+          "specifiers": [
+            "KnowledgeGraph",
+            "GraphNode",
+            "GraphEdge",
+            "EdgeType",
+            "NodeType",
+            "StructuralAnalysis",
+            "AnalyzerPlugin",
+            "ReferenceResolution"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 204,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/src/types.ts": {
+      "filePath": "understand-anything-plugin/packages/core/src/types.ts",
+      "contentHash": "dd9e12879b2a40382bda11795457b77d981dc1a5aa5de1c30a11fa926e812ea5",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 203,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/tsconfig.json": {
+      "filePath": "understand-anything-plugin/packages/core/tsconfig.json",
+      "contentHash": "e883e3117f39afcf9e2cf7d612094ac51421a3bc0c29bd6a4c1a543147a6144b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 20,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/core/vitest.config.ts": {
+      "filePath": "understand-anything-plugin/packages/core/vitest.config.ts",
+      "contentHash": "991fbc1dac3e595024391b3055fd169171cabf59c10c69b55d18ddcf5dc8b093",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest/config",
+          "specifiers": [
+            "defineConfig"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 8,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/index.html": {
+      "filePath": "understand-anything-plugin/packages/dashboard/index.html",
+      "contentHash": "9f9269c942d7e1cfa3fabc7759f0658d4ce93b2701a2f0c3005212b60e11fe3b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 20,
+      "hasStructuralAnalysis": false
+    },
+    "understand-anything-plugin/packages/dashboard/package.json": {
+      "filePath": "understand-anything-plugin/packages/dashboard/package.json",
+      "contentHash": "969a8ad9c6e602fb78775953cdd3ed29515053b2bd92695bc2eae1b6e534fb08",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 44,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/public/knowledge-graph.json": {
+      "filePath": "understand-anything-plugin/packages/dashboard/public/knowledge-graph.json",
+      "contentHash": "f4fd122a57c2da9a428eb7b9cdd93fff1fb5e7eac175bc3660ae81bcd93d99a8",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 3088,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs": {
+      "filePath": "understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "contentHash": "c4c13b6e139b29d9563e627c7e0615b9e5a8e3b98ec5f51d22bd586b60c883fe",
+      "functions": [
+        {
+          "name": "makeGraph",
+          "params": [
+            "layerCount",
+            "nodesPerLayer"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "aggregateBefore",
+          "params": [
+            "graph"
+          ],
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "aggregateAfter",
+          "params": [
+            "graph",
+            "nodesById"
+          ],
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "bench",
+          "params": [
+            "label",
+            "layerCount",
+            "nodesPerLayer"
+          ],
+          "exported": false,
+          "lineCount": 20
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:perf_hooks",
+          "specifiers": [
+            "performance"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 100,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs": {
+      "filePath": "understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs",
+      "contentHash": "6aa754ba1f236c55bb6962c3fcc2a887e1bb6b06ab9c531bd12523d91026a3cc",
+      "functions": [
+        {
+          "name": "fillDims",
+          "params": [
+            "children"
+          ],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "applyElkLayout",
+          "params": [
+            "input"
+          ],
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "makeGraph",
+          "params": [
+            "nodeCount"
+          ],
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "bench",
+          "params": [
+            "label",
+            "n"
+          ],
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:perf_hooks",
+          "specifiers": [
+            "performance"
+          ]
+        },
+        {
+          "source": "elkjs/lib/elk.bundled.js",
+          "specifiers": [
+            "ELK"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 81,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/App.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "contentHash": "7431631100e9a728d322fb7dd6c8ebbf39e15c22c6ce5927b20d9f74da4e2898",
+      "functions": [
+        {
+          "name": "shouldShowOnboarding",
+          "params": [],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "dataUrl",
+          "params": [
+            "fileName",
+            "token"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "resolveInitialToken",
+          "params": [],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "App",
+          "params": [],
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "Dashboard",
+          "params": [
+            "{ accessToken }"
+          ],
+          "exported": false,
+          "lineCount": 111
+        },
+        {
+          "name": "DashboardContent",
+          "params": [
+            "{\n  accessToken,\n  loadError,\n  graphIssues,\n}"
+          ],
+          "exported": false,
+          "lineCount": 492
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect",
+            "useState",
+            "useMemo",
+            "useCallback",
+            "lazy",
+            "Suspense"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/schema",
+          "specifiers": [
+            "validateGraph"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/schema",
+          "specifiers": [
+            "GraphIssue"
+          ]
+        },
+        {
+          "source": "./store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "./components/GraphView",
+          "specifiers": [
+            "GraphView"
+          ]
+        },
+        {
+          "source": "./components/DomainGraphView",
+          "specifiers": [
+            "DomainGraphView"
+          ]
+        },
+        {
+          "source": "./components/KnowledgeGraphView",
+          "specifiers": [
+            "KnowledgeGraphView"
+          ]
+        },
+        {
+          "source": "./components/SearchBar",
+          "specifiers": [
+            "SearchBar"
+          ]
+        },
+        {
+          "source": "./components/NodeInfo",
+          "specifiers": [
+            "NodeInfo"
+          ]
+        },
+        {
+          "source": "./components/LayerLegend",
+          "specifiers": [
+            "LayerLegend"
+          ]
+        },
+        {
+          "source": "./components/DiffToggle",
+          "specifiers": [
+            "DiffToggle"
+          ]
+        },
+        {
+          "source": "./components/FilterPanel",
+          "specifiers": [
+            "FilterPanel"
+          ]
+        },
+        {
+          "source": "./components/ExportMenu",
+          "specifiers": [
+            "ExportMenu"
+          ]
+        },
+        {
+          "source": "./components/PersonaSelector",
+          "specifiers": [
+            "PersonaSelector"
+          ]
+        },
+        {
+          "source": "./components/ProjectOverview",
+          "specifiers": [
+            "ProjectOverview"
+          ]
+        },
+        {
+          "source": "./components/FileExplorer",
+          "specifiers": [
+            "FileExplorer"
+          ]
+        },
+        {
+          "source": "./components/WarningBanner",
+          "specifiers": [
+            "WarningBanner"
+          ]
+        },
+        {
+          "source": "./components/TokenGate",
+          "specifiers": [
+            "TokenGate"
+          ]
+        },
+        {
+          "source": "./components/MobileLayout",
+          "specifiers": [
+            "MobileLayout"
+          ]
+        },
+        {
+          "source": "./hooks/useIsMobile",
+          "specifiers": [
+            "useIsMobile"
+          ]
+        },
+        {
+          "source": "./hooks/useKeyboardShortcuts",
+          "specifiers": [
+            "useKeyboardShortcuts"
+          ]
+        },
+        {
+          "source": "./hooks/useKeyboardShortcuts",
+          "specifiers": [
+            "KeyboardShortcut"
+          ]
+        },
+        {
+          "source": "./themes/index.ts",
+          "specifiers": [
+            "ThemeProvider"
+          ]
+        },
+        {
+          "source": "./components/ThemePicker.tsx",
+          "specifiers": [
+            "ThemePicker"
+          ]
+        },
+        {
+          "source": "./themes/index.ts",
+          "specifiers": [
+            "ThemeConfig"
+          ]
+        },
+        {
+          "source": "./contexts/I18nContext.tsx",
+          "specifiers": [
+            "I18nProvider",
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 716,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx",
+      "contentHash": "8dbb96e8a52f9fa0608f9ae5b71e413f35e81c7ec62dda815237bb7249ac1d76",
+      "functions": [
+        {
+          "name": "Breadcrumb",
+          "params": [],
+          "exported": true,
+          "lineCount": 37
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "Breadcrumb"
+      ],
+      "totalLines": 41,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+      "contentHash": "4165a23fa5b7cc87bbc0eff0e5710bc0aa16c0472e9fc844dbb31fc64b45d810",
+      "functions": [
+        {
+          "name": "fileContentUrl",
+          "params": [
+            "filePath",
+            "token"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "fallbackLanguage",
+          "params": [
+            "filePath"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "formatBytes",
+          "params": [
+            "bytes"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "CodeViewer",
+          "params": [
+            "{\n  accessToken,\n  presentation = \"sidebar\",\n  onClose,\n  onExpand,\n}"
+          ],
+          "exported": true,
+          "lineCount": 201
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect",
+            "useMemo",
+            "useState"
+          ]
+        },
+        {
+          "source": "prism-react-renderer",
+          "specifiers": [
+            "Highlight",
+            "themes"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "CodeViewer"
+      ],
+      "totalLines": 260,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx",
+      "contentHash": "7d435864362d09e26e5a8c4a451a4cac0c8f502545f5e32bc30191bde587d7d2",
+      "functions": [
+        {
+          "name": "ContainerNodeComponent",
+          "params": [
+            "{ data, width, height }"
+          ],
+          "exported": false,
+          "lineCount": 76
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "memo"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "NodeProps",
+            "Node"
+          ]
+        },
+        {
+          "source": "./LayerLegend",
+          "specifiers": [
+            "getLayerColor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 102,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx",
+      "contentHash": "a3287169fda6cfb9af88043c31a1cadc12b4b1e443dea41d7f03c4eff9579d8e",
+      "functions": [
+        {
+          "name": "CustomNodeComponent",
+          "params": [
+            "{\n  id,\n  data,\n}"
+          ],
+          "exported": false,
+          "lineCount": 104
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "memo"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Handle",
+            "Position"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "NodeProps",
+            "Node"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "NodeType"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 191,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+      "contentHash": "8fdebc9c42062806385e17a23a978ffdafc3ed2fe06590dbd55b0f2e0d593713",
+      "functions": [
+        {
+          "name": "DiffToggle",
+          "params": [],
+          "exported": true,
+          "lineCount": 63
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "DiffToggle"
+      ],
+      "totalLines": 67,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx",
+      "contentHash": "f5b146c7a1c3372900ffe4aeec878b198a1acbb96f614fd7e34722662eea9426",
+      "functions": [
+        {
+          "name": "DomainClusterNode",
+          "params": [
+            "{ data }"
+          ],
+          "exported": false,
+          "lineCount": 48
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "memo"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Handle",
+            "Position"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Node",
+            "NodeProps"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 67,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "contentHash": "e149c9786826182a60601e1b95fe1f2402c15297d55db4217c7675b555c9dc6d",
+      "functions": [
+        {
+          "name": "getDomainMeta",
+          "params": [
+            "node"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "buildDomainOverview",
+          "params": [
+            "graph"
+          ],
+          "returnType": "BuiltGraph",
+          "exported": false,
+          "lineCount": 48
+        },
+        {
+          "name": "buildDomainDetail",
+          "params": [
+            "graph",
+            "domainId"
+          ],
+          "returnType": "BuiltGraph",
+          "exported": false,
+          "lineCount": 76
+        },
+        {
+          "name": "DomainGraphViewInner",
+          "params": [],
+          "exported": false,
+          "lineCount": 105
+        },
+        {
+          "name": "DomainGraphView",
+          "params": [],
+          "exported": true,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect",
+            "useMemo",
+            "useState"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "ReactFlow",
+            "ReactFlowProvider",
+            "Background",
+            "BackgroundVariant",
+            "Controls",
+            "MiniMap"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Edge",
+            "Node"
+          ]
+        },
+        {
+          "source": "@xyflow/react/dist/style.css",
+          "specifiers": []
+        },
+        {
+          "source": "./DomainClusterNode",
+          "specifiers": [
+            "DomainClusterNode"
+          ]
+        },
+        {
+          "source": "./DomainClusterNode",
+          "specifiers": [
+            "DomainClusterFlowNode"
+          ]
+        },
+        {
+          "source": "./FlowNode",
+          "specifiers": [
+            "FlowNode"
+          ]
+        },
+        {
+          "source": "./FlowNode",
+          "specifiers": [
+            "FlowFlowNode"
+          ]
+        },
+        {
+          "source": "./StepNode",
+          "specifiers": [
+            "StepNode"
+          ]
+        },
+        {
+          "source": "./StepNode",
+          "specifiers": [
+            "StepFlowNode"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        },
+        {
+          "source": "../utils/layout",
+          "specifiers": [
+            "mergeElkPositions",
+            "nodesToElkInput"
+          ]
+        },
+        {
+          "source": "../utils/elk-layout",
+          "specifiers": [
+            "applyElkLayout"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "KnowledgeGraph",
+            "GraphNode"
+          ]
+        }
+      ],
+      "exports": [
+        "DomainGraphView"
+      ],
+      "totalLines": 280,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "contentHash": "fa10362f4c01210f1a47d10801aed1c872cac65d2d7ff69da493f2e972038ad1",
+      "functions": [
+        {
+          "name": "escapeXml",
+          "params": [
+            "s"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "downloadBlob",
+          "params": [
+            "blob",
+            "filename"
+          ],
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "ExportMenu",
+          "params": [],
+          "exported": true,
+          "lineCount": 258
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect",
+            "useRef"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        },
+        {
+          "source": "../utils/filters",
+          "specifiers": [
+            "filterNodes",
+            "filterEdges"
+          ]
+        }
+      ],
+      "exports": [
+        "ExportMenu"
+      ],
+      "totalLines": 280,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "contentHash": "c076fe5c2286a351837195c7fe17f545f4bdbb31322568b3822292a7376f85c5",
+      "functions": [
+        {
+          "name": "normalizeFilePath",
+          "params": [
+            "filePath"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "bestFileNode",
+          "params": [
+            "existing",
+            "candidate"
+          ],
+          "returnType": "GraphNode",
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "buildFileTree",
+          "params": [
+            "nodes"
+          ],
+          "returnType": "FileEntry[]",
+          "exported": false,
+          "lineCount": 56
+        },
+        {
+          "name": "FileTreeRow",
+          "params": [
+            "{\n  entry,\n  depth,\n  expanded,\n  toggleFolder,\n  openFile,\n}"
+          ],
+          "exported": false,
+          "lineCount": 57
+        },
+        {
+          "name": "FileExplorer",
+          "params": [],
+          "exported": true,
+          "lineCount": 73
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useMemo",
+            "useState"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphNode"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "FileExplorer"
+      ],
+      "totalLines": 215,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+      "contentHash": "870ee140f5cfa42218f0f926a31d4a3a0697a81b3a5738db0b79b71c2e3a20b7",
+      "functions": [
+        {
+          "name": "FilterPanel",
+          "params": [],
+          "exported": true,
+          "lineCount": 214
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect",
+            "useRef"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore",
+            "ALL_NODE_TYPES",
+            "ALL_COMPLEXITIES",
+            "ALL_EDGE_CATEGORIES"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "NodeType",
+            "Complexity",
+            "EdgeCategory"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "FilterPanel"
+      ],
+      "totalLines": 220,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx",
+      "contentHash": "e566649a65e19b109ea034cf8c8914210899af00ba8cb7da75a27f9471a3f885",
+      "functions": [
+        {
+          "name": "FlowNode",
+          "params": [
+            "{ data }"
+          ],
+          "exported": false,
+          "lineCount": 34
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "memo"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Handle",
+            "Position"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Node",
+            "NodeProps"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 53,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "contentHash": "bd51f448455dce4a24edc7e1edcf3379fc5c7d34725259112edc8fd4c8df9ff1",
+      "functions": [
+        {
+          "name": "TourFitView",
+          "params": [],
+          "exported": false,
+          "lineCount": 85
+        },
+        {
+          "name": "SelectedNodeFitView",
+          "params": [],
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "useOverviewGraph",
+          "params": [],
+          "exported": false,
+          "lineCount": 119
+        },
+        {
+          "name": "useLayerDetailTopology",
+          "params": [],
+          "returnType": "LayerDetailTopology & {\n  layoutStatus: \"computing\" | \"ready\";\n}",
+          "exported": false,
+          "lineCount": 538
+        },
+        {
+          "name": "buildCustomFlowNode",
+          "params": [
+            "node",
+            "opts"
+          ],
+          "returnType": "CustomFlowNode",
+          "exported": false,
+          "lineCount": 35
+        },
+        {
+          "name": "useLayerDetailGraph",
+          "params": [],
+          "exported": false,
+          "lineCount": 336
+        },
+        {
+          "name": "GraphViewInner",
+          "params": [],
+          "exported": false,
+          "lineCount": 275
+        },
+        {
+          "name": "GraphView",
+          "params": [],
+          "exported": true,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useCallback",
+            "useEffect",
+            "useMemo",
+            "useRef",
+            "useState"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "ReactFlow",
+            "ReactFlowProvider",
+            "useNodes",
+            "useNodesState",
+            "useEdgesState",
+            "useReactFlow",
+            "Background",
+            "BackgroundVariant",
+            "Controls",
+            "MiniMap"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Edge",
+            "Node"
+          ]
+        },
+        {
+          "source": "@xyflow/react/dist/style.css",
+          "specifiers": []
+        },
+        {
+          "source": "./CustomNode",
+          "specifiers": [
+            "CustomNode"
+          ]
+        },
+        {
+          "source": "./CustomNode",
+          "specifiers": [
+            "CustomFlowNode"
+          ]
+        },
+        {
+          "source": "./LayerClusterNode",
+          "specifiers": [
+            "LayerClusterNode"
+          ]
+        },
+        {
+          "source": "./LayerClusterNode",
+          "specifiers": [
+            "LayerClusterFlowNode"
+          ]
+        },
+        {
+          "source": "./PortalNode",
+          "specifiers": [
+            "PortalNode"
+          ]
+        },
+        {
+          "source": "./PortalNode",
+          "specifiers": [
+            "PortalFlowNode"
+          ]
+        },
+        {
+          "source": "./ContainerNode",
+          "specifiers": [
+            "ContainerNode"
+          ]
+        },
+        {
+          "source": "./ContainerNode",
+          "specifiers": [
+            "ContainerFlowNode",
+            "ContainerNodeData"
+          ]
+        },
+        {
+          "source": "./Breadcrumb",
+          "specifiers": [
+            "Breadcrumb"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphEdge",
+            "GraphNode",
+            "KnowledgeGraph",
+            "NodeType"
+          ]
+        },
+        {
+          "source": "../themes/index.ts",
+          "specifiers": [
+            "useTheme"
+          ]
+        },
+        {
+          "source": "../utils/layout",
+          "specifiers": [
+            "NODE_WIDTH",
+            "NODE_HEIGHT",
+            "LAYER_CLUSTER_WIDTH",
+            "LAYER_CLUSTER_HEIGHT",
+            "PORTAL_NODE_WIDTH",
+            "PORTAL_NODE_HEIGHT",
+            "ELK_DEFAULT_LAYOUT_OPTIONS",
+            "nodesToElkInput",
+            "mergeElkPositions"
+          ]
+        },
+        {
+          "source": "../utils/elk-layout",
+          "specifiers": [
+            "applyElkLayout"
+          ]
+        },
+        {
+          "source": "../utils/elk-layout",
+          "specifiers": [
+            "ElkChild",
+            "ElkEdge",
+            "ElkInput"
+          ]
+        },
+        {
+          "source": "../utils/edgeAggregation",
+          "specifiers": [
+            "aggregateContainerEdges",
+            "aggregateLayerEdges",
+            "computePortals",
+            "findCrossLayerFileNodes"
+          ]
+        },
+        {
+          "source": "../utils/containers",
+          "specifiers": [
+            "deriveContainers"
+          ]
+        },
+        {
+          "source": "../utils/containers",
+          "specifiers": [
+            "DerivedContainer"
+          ]
+        },
+        {
+          "source": "../utils/layerStats",
+          "specifiers": [
+            "computeLayerStats"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "NodeCategory"
+          ]
+        }
+      ],
+      "exports": [
+        "GraphView"
+      ],
+      "totalLines": 1582,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx",
+      "contentHash": "f98ef14aa6796b1c5332c3f4d40ae8172f1b335814de8ceee2a95e4d2e37ce54",
+      "functions": [
+        {
+          "name": "KeyboardShortcutsHelp",
+          "params": [
+            "{\n  shortcuts,\n  onClose,\n}"
+          ],
+          "exported": true,
+          "lineCount": 96
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../hooks/useKeyboardShortcuts",
+          "specifiers": [
+            "KeyboardShortcut"
+          ]
+        },
+        {
+          "source": "../hooks/useKeyboardShortcuts",
+          "specifiers": [
+            "formatShortcutKey"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "KeyboardShortcutsHelp"
+      ],
+      "totalLines": 106,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "contentHash": "4fff8dbda0b51c8744e411a89f8415d59ccb5eea1099161c1266c2977b07ece9",
+      "functions": [
+        {
+          "name": "getNodeDimensions",
+          "params": [
+            "edgeCount"
+          ],
+          "returnType": "{ width: number; height: number }",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "computeLayout",
+          "params": [
+            "graph"
+          ],
+          "returnType": "{ positionMap: Map<string, { x: number; y: number }>; edgeCounts: Map<string, number>; communityMap: Map<string, number> }",
+          "exported": false,
+          "lineCount": 44
+        },
+        {
+          "name": "KnowledgeGraphViewInner",
+          "params": [],
+          "exported": false,
+          "lineCount": 189
+        },
+        {
+          "name": "KnowledgeGraphView",
+          "params": [],
+          "exported": true,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useMemo",
+            "useCallback"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "ReactFlow",
+            "ReactFlowProvider",
+            "Background",
+            "BackgroundVariant",
+            "Controls",
+            "MiniMap"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Edge",
+            "Node"
+          ]
+        },
+        {
+          "source": "@xyflow/react/dist/style.css",
+          "specifiers": []
+        },
+        {
+          "source": "./CustomNode",
+          "specifiers": [
+            "CustomNode"
+          ]
+        },
+        {
+          "source": "./CustomNode",
+          "specifiers": [
+            "CustomNodeData"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../utils/layout",
+          "specifiers": [
+            "applyForceLayout",
+            "NODE_WIDTH",
+            "NODE_HEIGHT"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        }
+      ],
+      "exports": [
+        "KnowledgeGraphView"
+      ],
+      "totalLines": 293,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx",
+      "contentHash": "c941812b38c9b961667cc89bf433a9ecd7f2abdda9f8e01f4d685c5e73d292b6",
+      "functions": [
+        {
+          "name": "LayerClusterNode",
+          "params": [
+            "{\n  data,\n}"
+          ],
+          "exported": false,
+          "lineCount": 78
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "memo"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Handle",
+            "Position"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "NodeProps",
+            "Node"
+          ]
+        },
+        {
+          "source": "./LayerLegend",
+          "specifiers": [
+            "getLayerColor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 105,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "contentHash": "763bdd68a9e8c39faea5f55d661554f081d0fead7026a0f3d8d98fa5ab8d64ea",
+      "functions": [
+        {
+          "name": "getLayerColor",
+          "params": [
+            "index"
+          ],
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "LayerLegend",
+          "params": [],
+          "exported": true,
+          "lineCount": 54
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "LAYER_PALETTE",
+        "getLayerColor",
+        "LayerLegend"
+      ],
+      "totalLines": 73,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx",
+      "contentHash": "918406c775f23796112566017dd466bd18f53b959c89f48b7bf68d54a7296dd6",
+      "functions": [
+        {
+          "name": "LearnPanel",
+          "params": [],
+          "exported": true,
+          "lineCount": 225
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useMemo"
+          ]
+        },
+        {
+          "source": "react-markdown",
+          "specifiers": [
+            "ReactMarkdown"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "LearnPanel"
+      ],
+      "totalLines": 231,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx",
+      "contentHash": "1c4ba1556b5ea7365fb49f1848bc2558335f9fd6843d7d4776588870f3fd9d4d",
+      "functions": [
+        {
+          "name": "MobileBottomNav",
+          "params": [
+            "{ activeTab, onTabChange }"
+          ],
+          "exported": true,
+          "lineCount": 33
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "ReactNode"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "MobileBottomNav"
+      ],
+      "totalLines": 72,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "contentHash": "9f7e88dc3cc6a9884cf7958f82f34a6534e96905bd23319719249f81133d48e7",
+      "functions": [
+        {
+          "name": "SectionLabel",
+          "params": [
+            "{ children }"
+          ],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "MobileDrawer",
+          "params": [
+            "{\n  open,\n  onClose,\n  onTogglePathFinder,\n  onShowKeyboardHelp,\n}"
+          ],
+          "exported": true,
+          "lineCount": 233
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        },
+        {
+          "source": "./PersonaSelector",
+          "specifiers": [
+            "PersonaSelector"
+          ]
+        },
+        {
+          "source": "./DiffToggle",
+          "specifiers": [
+            "DiffToggle"
+          ]
+        },
+        {
+          "source": "./LayerLegend",
+          "specifiers": [
+            "LayerLegend"
+          ]
+        },
+        {
+          "source": "./FilterPanel",
+          "specifiers": [
+            "FilterPanel"
+          ]
+        },
+        {
+          "source": "./ExportMenu",
+          "specifiers": [
+            "ExportMenu"
+          ]
+        },
+        {
+          "source": "./ThemePicker",
+          "specifiers": [
+            "ThemePicker"
+          ]
+        }
+      ],
+      "exports": [
+        "MobileDrawer"
+      ],
+      "totalLines": 267,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "contentHash": "f35169557f1855c2bf512ac02b7e012c2f85e7494141bcff78d345f637bd2f6a",
+      "functions": [
+        {
+          "name": "MobileLayout",
+          "params": [
+            "{\n  accessToken,\n  showKeyboardHelp,\n  setShowKeyboardHelp,\n  loadError,\n  allIssues,\n  shortcuts,\n}"
+          ],
+          "exported": true,
+          "lineCount": 203
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "lazy",
+            "Suspense",
+            "useEffect",
+            "useState"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/schema",
+          "specifiers": [
+            "GraphIssue"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        },
+        {
+          "source": "./GraphView",
+          "specifiers": [
+            "GraphView"
+          ]
+        },
+        {
+          "source": "./DomainGraphView",
+          "specifiers": [
+            "DomainGraphView"
+          ]
+        },
+        {
+          "source": "./KnowledgeGraphView",
+          "specifiers": [
+            "KnowledgeGraphView"
+          ]
+        },
+        {
+          "source": "./SearchBar",
+          "specifiers": [
+            "SearchBar"
+          ]
+        },
+        {
+          "source": "./NodeInfo",
+          "specifiers": [
+            "NodeInfo"
+          ]
+        },
+        {
+          "source": "./ProjectOverview",
+          "specifiers": [
+            "ProjectOverview"
+          ]
+        },
+        {
+          "source": "./FileExplorer",
+          "specifiers": [
+            "FileExplorer"
+          ]
+        },
+        {
+          "source": "./WarningBanner",
+          "specifiers": [
+            "WarningBanner"
+          ]
+        },
+        {
+          "source": "./MobileBottomNav",
+          "specifiers": [
+            "MobileBottomNav"
+          ]
+        },
+        {
+          "source": "./MobileBottomNav",
+          "specifiers": [
+            "MobileTab"
+          ]
+        },
+        {
+          "source": "./MobileDrawer",
+          "specifiers": [
+            "MobileDrawer"
+          ]
+        }
+      ],
+      "exports": [
+        "MobileLayout"
+      ],
+      "totalLines": 234,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "contentHash": "d0a0b674e8ae5f319407b6f71553afef19788267514160ae9eda046c4d357921",
+      "functions": [
+        {
+          "name": "getDirectionalLabel",
+          "params": [
+            "edgeType",
+            "isSource",
+            "t"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "KnowledgeNodeDetails",
+          "params": [
+            "{ node, graph }"
+          ],
+          "exported": false,
+          "lineCount": 91
+        },
+        {
+          "name": "DomainNodeDetails",
+          "params": [
+            "{ node, graph }"
+          ],
+          "exported": false,
+          "lineCount": 120
+        },
+        {
+          "name": "NodeInfo",
+          "params": [],
+          "exported": true,
+          "lineCount": 281
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useState"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "NodeType",
+            "EdgeType",
+            "KnowledgeGraph",
+            "GraphNode"
+          ]
+        }
+      ],
+      "exports": [
+        "NodeInfo"
+      ],
+      "totalLines": 540,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx",
+      "contentHash": "cfce2561f7736cb742ce22848195d2c1168d5d5c73e5798768c92b5722549bce",
+      "functions": [
+        {
+          "name": "NodeTooltip",
+          "params": [
+            "{\n  data,\n  nodeId,\n  incomingCount,\n  outgoingCount,\n  tags = [],\n}"
+          ],
+          "exported": true,
+          "lineCount": 113
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect",
+            "useState"
+          ]
+        },
+        {
+          "source": "./CustomNode",
+          "specifiers": [
+            "CustomNodeData"
+          ]
+        }
+      ],
+      "exports": [
+        "NodeTooltip"
+      ],
+      "totalLines": 125,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx",
+      "contentHash": "ceb426ec0650ecdf7e5e50181bf2c099938113cb5e019adc2ac584def78cd330",
+      "functions": [
+        {
+          "name": "OnboardingOverlay",
+          "params": [
+            "{ onDismiss }"
+          ],
+          "exported": true,
+          "lineCount": 110
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect",
+            "useState"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "OnboardingOverlay"
+      ],
+      "totalLines": 257,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx",
+      "contentHash": "589d720104b658a6562bc81f0cf7761f0097e0a9d173f0c12069c9399ef6ce9a",
+      "functions": [
+        {
+          "name": "PathFinderModal",
+          "params": [
+            "{ isOpen, onClose }"
+          ],
+          "exported": true,
+          "lineCount": 303
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect",
+            "useRef",
+            "useState"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        }
+      ],
+      "exports": [
+        "PathFinderModal"
+      ],
+      "totalLines": 312,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "contentHash": "98ef303e558c6839c1914f2222d26a044486252375c0d10b7ad919f19e5eed6a",
+      "functions": [
+        {
+          "name": "PersonaSelector",
+          "params": [],
+          "exported": true,
+          "lineCount": 42
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "Persona"
+          ]
+        }
+      ],
+      "exports": [
+        "PersonaSelector"
+      ],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx",
+      "contentHash": "5e0626d58fbdb2baefa4c1e9ea1e7db4acbd1a17a053064a1b10468b32259cbc",
+      "functions": [
+        {
+          "name": "PortalNode",
+          "params": [
+            "{\n  data,\n}"
+          ],
+          "exported": false,
+          "lineCount": 47
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "memo"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Handle",
+            "Position"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "NodeProps",
+            "Node"
+          ]
+        },
+        {
+          "source": "./LayerLegend",
+          "specifiers": [
+            "getLayerColor"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 65,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "contentHash": "b371e43a64dd45d4348f04de88ff7e140609240fac41ddeed9713986b856d7fc",
+      "functions": [
+        {
+          "name": "ProjectOverview",
+          "params": [],
+          "exported": true,
+          "lineCount": 219
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "ProjectOverview"
+      ],
+      "totalLines": 223,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "contentHash": "789502614ffe09c4b22983239f3fefbc710d87829196433c5f4a9d615abe1a14",
+      "functions": [
+        {
+          "name": "SearchBar",
+          "params": [],
+          "exported": true,
+          "lineCount": 168
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useCallback",
+            "useEffect",
+            "useMemo",
+            "useRef",
+            "useState"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "SearchBar"
+      ],
+      "totalLines": 192,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx",
+      "contentHash": "9bae7c6a43f45ce45cf334a90e3d66ba45e1fffaa58b19714ae584fc1f79ceae",
+      "functions": [
+        {
+          "name": "StepNode",
+          "params": [
+            "{ data }"
+          ],
+          "exported": false,
+          "lineCount": 36
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "memo"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Handle",
+            "Position"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Node",
+            "NodeProps"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "useDashboardStore"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 54,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "contentHash": "8da4b99fd9ce1d72515b0ac57a88bb479274935edacb4d4ea750887ff4763f74",
+      "functions": [
+        {
+          "name": "ThemePicker",
+          "params": [],
+          "exported": true,
+          "lineCount": 175
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useCallback",
+            "useEffect",
+            "useRef",
+            "useState"
+          ]
+        },
+        {
+          "source": "../themes/index.ts",
+          "specifiers": [
+            "useTheme",
+            "PRESETS"
+          ]
+        },
+        {
+          "source": "../themes/index.ts",
+          "specifiers": [
+            "HeadingFont"
+          ]
+        },
+        {
+          "source": "../contexts/I18nContext",
+          "specifiers": [
+            "useI18n"
+          ]
+        }
+      ],
+      "exports": [
+        "ThemePicker"
+      ],
+      "totalLines": 181,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx",
+      "contentHash": "270089a53b0b98f38fdf652f8630146b65bbede65ce149677f0ea3aa5fe5a938",
+      "functions": [
+        {
+          "name": "TokenGate",
+          "params": [
+            "{ onTokenValid }"
+          ],
+          "exported": true,
+          "lineCount": 73
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useState"
+          ]
+        }
+      ],
+      "exports": [
+        "TokenGate"
+      ],
+      "totalLines": 80,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+      "contentHash": "6eb397256755ab6565215cb9c573b37480084c3d616298687db2613d9ff2cbf8",
+      "functions": [
+        {
+          "name": "buildCopyText",
+          "params": [
+            "issues"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 36
+        },
+        {
+          "name": "WarningBanner",
+          "params": [
+            "{ issues }"
+          ],
+          "exported": true,
+          "lineCount": 209
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useState",
+            "useCallback"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/schema",
+          "specifiers": [
+            "GraphIssue"
+          ]
+        }
+      ],
+      "exports": [
+        "WarningBanner"
+      ],
+      "totalLines": 254,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "contentHash": "08153e94d4ae7580a9763574601a85b9813a76fe06ef97a305c71cbf65872983",
+      "functions": [
+        {
+          "name": "useI18n",
+          "params": [],
+          "returnType": "I18nContextValue",
+          "exported": true,
+          "lineCount": 7
+        },
+        {
+          "name": "I18nProvider",
+          "params": [
+            "{\n  language,\n  children,\n}"
+          ],
+          "exported": true,
+          "lineCount": 25
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "createContext",
+            "useContext",
+            "useMemo",
+            "ReactNode"
+          ]
+        },
+        {
+          "source": "../locales",
+          "specifiers": [
+            "getLocale",
+            "resolveLocaleKey",
+            "Locale",
+            "LocaleKey"
+          ]
+        }
+      ],
+      "exports": [
+        "useI18n",
+        "I18nProvider"
+      ],
+      "totalLines": 44,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts",
+      "contentHash": "5875cba166ee95d078651a14b67799f4799b4275fc8dc33104b120523b252976",
+      "functions": [
+        {
+          "name": "useIsMobile",
+          "params": [
+            "breakpoint"
+          ],
+          "returnType": "boolean",
+          "exported": true,
+          "lineCount": 17
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect",
+            "useState"
+          ]
+        }
+      ],
+      "exports": [
+        "useIsMobile"
+      ],
+      "totalLines": 22,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "contentHash": "d18b7eecc05f37d140f2d589ec08ee50a380f77ae76d12bfc2037495405abc6b",
+      "functions": [
+        {
+          "name": "useKeyboardShortcuts",
+          "params": [
+            "shortcuts",
+            "enabled"
+          ],
+          "exported": true,
+          "lineCount": 37
+        },
+        {
+          "name": "formatShortcutKey",
+          "params": [
+            "shortcut"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 20
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "useEffect"
+          ]
+        }
+      ],
+      "exports": [
+        "useKeyboardShortcuts",
+        "formatShortcutKey"
+      ],
+      "totalLines": 72,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/index.css": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/index.css",
+      "contentHash": "744a73a949df21e547a908af475bb9c1c7cc06662f46814ec1261817beb48bf7",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 266,
+      "hasStructuralAnalysis": false
+    },
+    "understand-anything-plugin/packages/dashboard/src/locales/en.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/en.ts",
+      "contentHash": "0aaded774c62e156a590b4dc1919d56056c04c7dcb0ce09a9031c06e8ee7cd1a",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "en"
+      ],
+      "totalLines": 306,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/locales/index.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "contentHash": "73e4b44f1bc89e00c8683b760d6b096beec8c8a7168bac6605b8a5bd870f538a",
+      "functions": [
+        {
+          "name": "getLocale",
+          "params": [
+            "key"
+          ],
+          "returnType": "Locale",
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "resolveLocaleKey",
+          "params": [
+            "lang"
+          ],
+          "returnType": "LocaleKey",
+          "exported": true,
+          "lineCount": 10
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "./en",
+          "specifiers": [
+            "en"
+          ]
+        },
+        {
+          "source": "./zh",
+          "specifiers": [
+            "zh"
+          ]
+        },
+        {
+          "source": "./zh-TW",
+          "specifiers": [
+            "zhTW"
+          ]
+        },
+        {
+          "source": "./ja",
+          "specifiers": [
+            "ja"
+          ]
+        },
+        {
+          "source": "./ko",
+          "specifiers": [
+            "ko"
+          ]
+        },
+        {
+          "source": "./ru",
+          "specifiers": [
+            "ru"
+          ]
+        }
+      ],
+      "exports": [
+        "locales",
+        "getLocale",
+        "resolveLocaleKey",
+        "en",
+        "zh",
+        "\"zh-TW\"",
+        "ja",
+        "ko",
+        "ru"
+      ],
+      "totalLines": 36,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/locales/ja.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/ja.ts",
+      "contentHash": "dc61e379c91d2288e4f56057b69132e793c1aa66862a46b60ec705711ac8a32e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "ja"
+      ],
+      "totalLines": 306,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/locales/ko.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/ko.ts",
+      "contentHash": "29bc1ccee560b3bec6d660c3e8a261f0350a7d5880f6d16ada7b1fa088fd35b8",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "ko"
+      ],
+      "totalLines": 306,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/locales/ru.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/ru.ts",
+      "contentHash": "6fd8664061f4cd950cf77a41341632cfd3679a207eb1835a81432b46f8872b15",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "ru"
+      ],
+      "totalLines": 307,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts",
+      "contentHash": "d328826aa1cf69a42fd05053d3a7c1399ae75b25239e81ef88457cb8edbc4ca6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "zhTW"
+      ],
+      "totalLines": 306,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/locales/zh.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/zh.ts",
+      "contentHash": "4aa99e2904046d97619e8dd7ee5aba98f1d93bf90ce4988d1f3daddb33d8ad05",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "zh"
+      ],
+      "totalLines": 306,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/main.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/main.tsx",
+      "contentHash": "3d31aed4164d4d47b45b8b7c824ab154420846b146875de51577e8b8d8e4a181",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "StrictMode"
+          ]
+        },
+        {
+          "source": "react-dom/client",
+          "specifiers": [
+            "createRoot"
+          ]
+        },
+        {
+          "source": "./index.css",
+          "specifiers": []
+        },
+        {
+          "source": "./App",
+          "specifiers": [
+            "App"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 11,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/store.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/store.ts",
+      "contentHash": "77e6ae7c1d52d68fda382dcdd3f48d7ac6a92add140577e17968022dec4d7ed9",
+      "functions": [
+        {
+          "name": "buildGraphIndexes",
+          "params": [
+            "graph"
+          ],
+          "returnType": "{\n  nodesById: Map<string, GraphNode>;\n  nodeIdToLayerId: Map<string, string>;\n  nodeIdToLayerIds: Map<string, Set<string>>;\n}",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "getSortedTour",
+          "params": [
+            "graph"
+          ],
+          "returnType": "TourStep[]",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "navigateTourToLayer",
+          "params": [
+            "nodeIdToLayerId",
+            "nodeIds"
+          ],
+          "returnType": "Partial<DashboardStore>",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "layerResetIfChanged",
+          "params": [
+            "layerNav",
+            "prevLayerId"
+          ],
+          "returnType": "Partial<DashboardStore>",
+          "exported": false,
+          "lineCount": 16
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "zustand",
+          "specifiers": [
+            "create"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/search",
+          "specifiers": [
+            "SearchEngine"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/search",
+          "specifiers": [
+            "SearchResult"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/schema",
+          "specifiers": [
+            "GraphIssue"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphNode",
+            "KnowledgeGraph",
+            "TourStep"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "ReactFlowInstance"
+          ]
+        }
+      ],
+      "exports": [
+        "ALL_NODE_TYPES",
+        "ALL_COMPLEXITIES",
+        "ALL_EDGE_CATEGORIES",
+        "EDGE_CATEGORY_MAP",
+        "DOMAIN_EDGE_TYPES",
+        "useDashboardStore"
+      ],
+      "totalLines": 785,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/themes/index.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/index.ts",
+      "contentHash": "8b31b7d8b41e002e85e498f46bfa900ba49e7e11aa493750a1cbe2904cc4e5da",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "ThemeProvider",
+        "useTheme",
+        "PRESETS",
+        "getPreset",
+        "getAccent",
+        "applyTheme",
+        "HeadingFont",
+        "PresetId",
+        "ThemeConfig",
+        "ThemePreset",
+        "AccentSwatch",
+        "DEFAULT_THEME_CONFIG"
+      ],
+      "totalLines": 6,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/themes/presets.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "contentHash": "d82700fa737c17e88c57858323151e06e00da46bd2843f174acb5c648fb2a47e",
+      "functions": [
+        {
+          "name": "getPreset",
+          "params": [
+            "id"
+          ],
+          "returnType": "ThemePreset",
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "getAccent",
+          "params": [
+            "preset",
+            "accentId"
+          ],
+          "returnType": "AccentSwatch",
+          "exported": true,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "./types.ts",
+          "specifiers": [
+            "AccentSwatch",
+            "ThemePreset"
+          ]
+        }
+      ],
+      "exports": [
+        "PRESETS",
+        "getPreset",
+        "getAccent"
+      ],
+      "totalLines": 184,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "contentHash": "b32bc45bbbf77311aa4d06ef0d6db0666e51ff95d16510206f24c84be1fe2218",
+      "functions": [
+        {
+          "name": "hexToRgb",
+          "params": [
+            "hex"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 5
+        },
+        {
+          "name": "deriveFromAccent",
+          "params": [
+            "accentHex",
+            "isDark"
+          ],
+          "returnType": "Record<string, string>",
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "applyTheme",
+          "params": [
+            "config"
+          ],
+          "returnType": "void",
+          "exported": true,
+          "lineCount": 33
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "./types.ts",
+          "specifiers": [
+            "ThemeConfig"
+          ]
+        },
+        {
+          "source": "./presets.ts",
+          "specifiers": [
+            "getAccent",
+            "getPreset"
+          ]
+        }
+      ],
+      "exports": [
+        "hexToRgb",
+        "applyTheme"
+      ],
+      "totalLines": 66,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "contentHash": "38979fa20ea8b03ecf16e7c93cfb4876c6e4aec062ded4072f6f65ff79ad921a",
+      "functions": [
+        {
+          "name": "loadFromLocalStorage",
+          "params": [],
+          "returnType": "ThemeConfig | null",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "saveToLocalStorage",
+          "params": [
+            "config"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "resolveInitialTheme",
+          "params": [
+            "metaTheme"
+          ],
+          "returnType": "ThemeConfig",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "ThemeProvider",
+          "params": [
+            "{ metaTheme, children }"
+          ],
+          "exported": true,
+          "lineCount": 43
+        },
+        {
+          "name": "useTheme",
+          "params": [],
+          "returnType": "ThemeContextValue",
+          "exported": true,
+          "lineCount": 5
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "react",
+          "specifiers": [
+            "createContext",
+            "useCallback",
+            "useContext",
+            "useEffect",
+            "useRef",
+            "useState",
+            "ReactNode"
+          ]
+        },
+        {
+          "source": "./types.ts",
+          "specifiers": [
+            "HeadingFont",
+            "PresetId",
+            "ThemeConfig",
+            "ThemePreset"
+          ]
+        },
+        {
+          "source": "./types.ts",
+          "specifiers": [
+            "DEFAULT_THEME_CONFIG"
+          ]
+        },
+        {
+          "source": "./presets.ts",
+          "specifiers": [
+            "getPreset"
+          ]
+        },
+        {
+          "source": "./theme-engine.ts",
+          "specifiers": [
+            "applyTheme"
+          ]
+        }
+      ],
+      "exports": [
+        "ThemeProvider",
+        "useTheme"
+      ],
+      "totalLines": 107,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/themes/types.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/types.ts",
+      "contentHash": "c4953c103643737fddfa2b4ff58f3e95a1ade34aacefd5032c878c2ef1c2259b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "DEFAULT_THEME_CONFIG"
+      ],
+      "totalLines": 37,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/__tests__/containers.test.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/containers.test.ts",
+      "contentHash": "c712642ae3a0cee4b03fb22b805e00cd266ff9d6e27ee9332730bf1b6ea8c690",
+      "functions": [
+        {
+          "name": "node",
+          "params": [
+            "id",
+            "filePath"
+          ],
+          "returnType": "GraphNode",
+          "exported": false,
+          "lineCount": 11
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../containers",
+          "specifiers": [
+            "deriveContainers"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphNode",
+            "GraphEdge"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 132,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/__tests__/edgeAggregation.test.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/edgeAggregation.test.ts",
+      "contentHash": "5f9ae8f87549417e15c748d9bf4d9af9c5b4b60c23609c58eb70b6b9bd12cee7",
+      "functions": [
+        {
+          "name": "ce",
+          "params": [
+            "source",
+            "target",
+            "type"
+          ],
+          "returnType": "GraphEdge",
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../edgeAggregation",
+          "specifiers": [
+            "aggregateContainerEdges"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphEdge",
+            "EdgeType"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 80,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/__tests__/elk-layout.test.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/elk-layout.test.ts",
+      "contentHash": "05071140a1423570c7fe689e163db2e420dc830e481d5d64cb06ae1732e0ff04",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../elk-layout",
+          "specifiers": [
+            "applyElkLayout",
+            "repairElkInput",
+            "ElkInput"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 107,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/__tests__/filters.test.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/filters.test.ts",
+      "contentHash": "4108294c0814aa7ed8b4c7ba04f58585e67dd05739f314f2c1cfbc4e27a66b82",
+      "functions": [
+        {
+          "name": "node",
+          "params": [
+            "id",
+            "type",
+            "complexity"
+          ],
+          "returnType": "GraphNode",
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "edge",
+          "params": [
+            "source",
+            "target",
+            "type"
+          ],
+          "returnType": "GraphEdge",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "defaultFilters",
+          "params": [
+            "overrides"
+          ],
+          "returnType": "FilterState",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "indexLayers",
+          "params": [
+            "layers"
+          ],
+          "returnType": "Map<string, Set<string>>",
+          "exported": false,
+          "lineCount": 14
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../filters",
+          "specifiers": [
+            "filterNodes",
+            "filterEdges"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphNode",
+            "GraphEdge",
+            "Layer"
+          ]
+        },
+        {
+          "source": "../../store",
+          "specifiers": [
+            "FilterState",
+            "NodeType",
+            "Complexity",
+            "EdgeCategory"
+          ]
+        },
+        {
+          "source": "../../store",
+          "specifiers": [
+            "ALL_NODE_TYPES",
+            "ALL_COMPLEXITIES",
+            "ALL_EDGE_CATEGORIES"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 197,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/__tests__/layerStats.test.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/layerStats.test.ts",
+      "contentHash": "ebab136ff5c0bbf27ba9594601caf51503e9a1a0f8b3b42636a297bf75838467",
+      "functions": [
+        {
+          "name": "node",
+          "params": [
+            "id",
+            "complexity"
+          ],
+          "returnType": "GraphNode",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "layer",
+          "params": [
+            "id",
+            "nodeIds"
+          ],
+          "returnType": "Layer",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "indexById",
+          "params": [
+            "nodes"
+          ],
+          "returnType": "Map<string, GraphNode>",
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../layerStats",
+          "specifiers": [
+            "computeLayerStats"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphNode",
+            "Layer"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 119,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/__tests__/smoke.test.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/smoke.test.ts",
+      "contentHash": "005b94329b0d12f68a970e618bccd84b0d6dbfef0ffdeb496fa760f93309db00",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "elkjs/lib/elk.bundled.js",
+          "specifiers": [
+            "ELK"
+          ]
+        },
+        {
+          "source": "graphology",
+          "specifiers": [
+            "Graph"
+          ]
+        },
+        {
+          "source": "graphology-communities-louvain",
+          "specifiers": [
+            "louvain"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 21,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/containers.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "contentHash": "d742a6055e0fddd357ede07dd3ba20dd646a576b60e5fc545153c92ffc11c530",
+      "functions": [
+        {
+          "name": "commonPrefix",
+          "params": [
+            "paths"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "firstSegment",
+          "params": [
+            "path"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "groupByFolder",
+          "params": [
+            "nodes"
+          ],
+          "returnType": "{ groups: Map<string, string[]>; rooted: string[] }",
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "shouldFallbackToCommunity",
+          "params": [
+            "groups",
+            "rooted",
+            "totalNodes"
+          ],
+          "returnType": "boolean",
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "deriveContainers",
+          "params": [
+            "nodes",
+            "edges"
+          ],
+          "returnType": "DeriveResult",
+          "exported": true,
+          "lineCount": 66
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphNode",
+            "GraphEdge"
+          ]
+        },
+        {
+          "source": "./louvain",
+          "specifiers": [
+            "detectCommunities"
+          ]
+        }
+      ],
+      "exports": [
+        "deriveContainers"
+      ],
+      "totalLines": 157,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "contentHash": "d82b2122ea7e015206512ebc011392c691b60d295fbbf093413d9f4e1cd9d8b6",
+      "functions": [
+        {
+          "name": "aggregateLayerEdges",
+          "params": [
+            "graph"
+          ],
+          "returnType": "LayerEdgeAggregation[]",
+          "exported": true,
+          "lineCount": 50
+        },
+        {
+          "name": "computePortals",
+          "params": [
+            "graph",
+            "activeLayerId",
+            "precomputed"
+          ],
+          "returnType": "PortalInfo[]",
+          "exported": true,
+          "lineCount": 30
+        },
+        {
+          "name": "findCrossLayerFileNodes",
+          "params": [
+            "graph",
+            "activeLayerId",
+            "targetLayerId"
+          ],
+          "returnType": "Set<string>",
+          "exported": true,
+          "lineCount": 23
+        },
+        {
+          "name": "aggregateContainerEdges",
+          "params": [
+            "edges",
+            "nodeToContainer"
+          ],
+          "returnType": "ContainerEdgeBuckets",
+          "exported": true,
+          "lineCount": 51
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphEdge",
+            "KnowledgeGraph"
+          ]
+        }
+      ],
+      "exports": [
+        "aggregateLayerEdges",
+        "computePortals",
+        "findCrossLayerFileNodes",
+        "aggregateContainerEdges"
+      ],
+      "totalLines": 209,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "contentHash": "3963eb9d033a5872d543b628745c76858406fcea1a2bb164ee9b2a1a91071780",
+      "functions": [
+        {
+          "name": "makeIssue",
+          "params": [
+            "level",
+            "category",
+            "message"
+          ],
+          "returnType": "GraphIssue",
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "maybeThrow",
+          "params": [
+            "strict",
+            "issue"
+          ],
+          "returnType": "void",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "repairElkInput",
+          "params": [
+            "input",
+            "opts"
+          ],
+          "returnType": "RepairResult",
+          "exported": true,
+          "lineCount": 157
+        },
+        {
+          "name": "applyElkLayout",
+          "params": [
+            "input",
+            "opts"
+          ],
+          "returnType": "Promise<ElkLayoutResult>",
+          "exported": true,
+          "lineCount": 20
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "elkjs/lib/elk.bundled.js",
+          "specifiers": [
+            "ELK"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/schema",
+          "specifiers": [
+            "GraphIssue"
+          ]
+        },
+        {
+          "source": "./layout",
+          "specifiers": [
+            "NODE_WIDTH",
+            "NODE_HEIGHT"
+          ]
+        }
+      ],
+      "exports": [
+        "repairElkInput",
+        "applyElkLayout"
+      ],
+      "totalLines": 245,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/filters.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "contentHash": "82930de100c25417ac184df6e58c0f52d8560c1acae4158b3f7a907ee511a8b4",
+      "functions": [
+        {
+          "name": "filterNodes",
+          "params": [
+            "nodes",
+            "nodeIdToLayerIds",
+            "filters"
+          ],
+          "returnType": "GraphNode[]",
+          "exported": true,
+          "lineCount": 34
+        },
+        {
+          "name": "filterEdges",
+          "params": [
+            "edges",
+            "visibleNodeIds",
+            "filters"
+          ],
+          "returnType": "GraphEdge[]",
+          "exported": true,
+          "lineCount": 20
+        },
+        {
+          "name": "getEdgeCategory",
+          "params": [
+            "edgeType"
+          ],
+          "returnType": "EdgeCategory | null",
+          "exported": false,
+          "lineCount": 8
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphNode",
+            "GraphEdge"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "FilterState",
+            "NodeType",
+            "Complexity",
+            "EdgeCategory"
+          ]
+        },
+        {
+          "source": "../store",
+          "specifiers": [
+            "EDGE_CATEGORY_MAP"
+          ]
+        }
+      ],
+      "exports": [
+        "filterNodes",
+        "filterEdges"
+      ],
+      "totalLines": 89,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts",
+      "contentHash": "ab695940ab619978d3b925516c9fde2eef962affea4e2f4c9270447ab59a1158",
+      "functions": [
+        {
+          "name": "computeLayerStats",
+          "params": [
+            "layer",
+            "nodesById"
+          ],
+          "returnType": "LayerStats",
+          "exported": true,
+          "lineCount": 20
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphNode",
+            "Layer"
+          ]
+        }
+      ],
+      "exports": [
+        "computeLayerStats"
+      ],
+      "totalLines": 40,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/layout.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "contentHash": "af6eeae466f8402feb4fa5087432b75a939f6eb7e6fb9077c2bc2804f357c239",
+      "functions": [
+        {
+          "name": "applyDagreLayout",
+          "params": [
+            "nodes",
+            "edges",
+            "direction",
+            "nodeDimensions",
+            "spacingOverrides"
+          ],
+          "returnType": "{ nodes: Node[]; edges: Edge[] }",
+          "exported": true,
+          "lineCount": 50
+        },
+        {
+          "name": "applyForceLayout",
+          "params": [
+            "nodes",
+            "edges",
+            "nodeDimensions",
+            "communityMap"
+          ],
+          "returnType": "{ nodes: Node[]; edges: Edge[] }",
+          "exported": true,
+          "lineCount": 96
+        },
+        {
+          "name": "nodesToElkInput",
+          "params": [
+            "nodes",
+            "edges",
+            "dims",
+            "layoutOptionsOverride"
+          ],
+          "returnType": "ElkInput",
+          "exported": true,
+          "lineCount": 24
+        },
+        {
+          "name": "mergeElkPositions",
+          "params": [
+            "nodes",
+            "positioned"
+          ],
+          "returnType": "T[]",
+          "exported": true,
+          "lineCount": 36
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@dagrejs/dagre",
+          "specifiers": [
+            "dagre"
+          ]
+        },
+        {
+          "source": "d3-force",
+          "specifiers": [
+            "forceSimulation",
+            "forceLink",
+            "forceManyBody",
+            "forceCenter",
+            "forceCollide",
+            "forceX",
+            "forceY"
+          ]
+        },
+        {
+          "source": "d3-force",
+          "specifiers": [
+            "SimulationNodeDatum",
+            "SimulationLinkDatum"
+          ]
+        },
+        {
+          "source": "@xyflow/react",
+          "specifiers": [
+            "Node",
+            "Edge"
+          ]
+        },
+        {
+          "source": "./elk-layout",
+          "specifiers": [
+            "ElkInput"
+          ]
+        }
+      ],
+      "exports": [
+        "NODE_WIDTH",
+        "NODE_HEIGHT",
+        "LAYER_CLUSTER_WIDTH",
+        "LAYER_CLUSTER_HEIGHT",
+        "PORTAL_NODE_WIDTH",
+        "PORTAL_NODE_HEIGHT",
+        "applyDagreLayout",
+        "applyForceLayout",
+        "ELK_DEFAULT_LAYOUT_OPTIONS",
+        "nodesToElkInput",
+        "mergeElkPositions"
+      ],
+      "totalLines": 267,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/layout.worker.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layout.worker.ts",
+      "contentHash": "3debd7874842bac959c2f2109635bf3f7869671789333bfa4a0f61878058fa30",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@dagrejs/dagre",
+          "specifiers": [
+            "dagre"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 48,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/utils/louvain.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/louvain.ts",
+      "contentHash": "83e7b8a1a628d722a608d0961eb2ea939309738d016f26e91a51aadc200ee1d6",
+      "functions": [
+        {
+          "name": "detectCommunities",
+          "params": [
+            "nodeIds",
+            "edges"
+          ],
+          "returnType": "Map<string, number>",
+          "exported": true,
+          "lineCount": 31
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "graphology",
+          "specifiers": [
+            "Graph"
+          ]
+        },
+        {
+          "source": "graphology-communities-louvain",
+          "specifiers": [
+            "louvain"
+          ]
+        },
+        {
+          "source": "@understand-anything/core/types",
+          "specifiers": [
+            "GraphEdge"
+          ]
+        }
+      ],
+      "exports": [
+        "detectCommunities"
+      ],
+      "totalLines": 48,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/src/vite-env.d.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/src/vite-env.d.ts",
+      "contentHash": "65996936fbb042915f7b74a200fcdde7e410f32a669b1ab9597cfaa4b0faddb5",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/tsconfig.app.json": {
+      "filePath": "understand-anything-plugin/packages/dashboard/tsconfig.app.json",
+      "contentHash": "3eb2f3bbc8b70ade2c5bac9c3721ae2f54cee344de0752f9b27ca63683025301",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 25,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/tsconfig.json": {
+      "filePath": "understand-anything-plugin/packages/dashboard/tsconfig.json",
+      "contentHash": "b6d51d37a8d51b993bd758b7043fa9233eea24d34a4041198ff73c063d9ed66c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 5,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/vite.config.demo.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/vite.config.demo.ts",
+      "contentHash": "5efa9bcb69224aada1fb16cd378f01a8ff7c851b8b9d06a7ab2bd517311ae306",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vite",
+          "specifiers": [
+            "defineConfig"
+          ]
+        },
+        {
+          "source": "@vitejs/plugin-react",
+          "specifiers": [
+            "react"
+          ]
+        },
+        {
+          "source": "@tailwindcss/vite",
+          "specifiers": [
+            "tailwindcss"
+          ]
+        },
+        {
+          "source": "path",
+          "specifiers": [
+            "path"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 50,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/dashboard/vite.config.ts": {
+      "filePath": "understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "contentHash": "1930f8694b41bc3727c04fd94708253fe5d3473195720a5843f09c4f3d9b69d6",
+      "functions": [
+        {
+          "name": "graphFileCandidates",
+          "params": [
+            "fileName"
+          ],
+          "returnType": "string[]",
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "findGraphFile",
+          "params": [
+            "fileName"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "projectRootFromGraphFile",
+          "params": [
+            "candidate"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "normalizeGraphPath",
+          "params": [
+            "filePath",
+            "projectRoot"
+          ],
+          "returnType": "string | null",
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "graphFilePathSet",
+          "params": [
+            "graphFile",
+            "projectRoot"
+          ],
+          "returnType": "Set<string>",
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "detectLanguage",
+          "params": [
+            "filePath"
+          ],
+          "returnType": "string",
+          "exported": false,
+          "lineCount": 31
+        },
+        {
+          "name": "sendJson",
+          "params": [
+            "res",
+            "statusCode",
+            "payload"
+          ],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "rejectFileRequest",
+          "params": [
+            "message",
+            "statusCode"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "readSourceFile",
+          "params": [
+            "url"
+          ],
+          "exported": false,
+          "lineCount": 64
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vite",
+          "specifiers": [
+            "defineConfig"
+          ]
+        },
+        {
+          "source": "@vitejs/plugin-react",
+          "specifiers": [
+            "react"
+          ]
+        },
+        {
+          "source": "@tailwindcss/vite",
+          "specifiers": [
+            "tailwindcss"
+          ]
+        },
+        {
+          "source": "path",
+          "specifiers": [
+            "path"
+          ]
+        },
+        {
+          "source": "fs",
+          "specifiers": [
+            "fs"
+          ]
+        },
+        {
+          "source": "crypto",
+          "specifiers": [
+            "crypto"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 363,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/tree-sitter-dart-wasm/BUILD.md": {
+      "filePath": "understand-anything-plugin/packages/tree-sitter-dart-wasm/BUILD.md",
+      "contentHash": "d124dac9e36dee5a7439aec4045a08114cb195b95d7c062938b435d3129590c0",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 48,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/tree-sitter-dart-wasm/package.json": {
+      "filePath": "understand-anything-plugin/packages/tree-sitter-dart-wasm/package.json",
+      "contentHash": "fae52ec2a947c41e80c554ca4268713961d04ffa744c826c844d7cbbc403c921",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 10,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/packages/tree-sitter-dart-wasm/tree-sitter-dart.wasm": {
+      "filePath": "understand-anything-plugin/packages/tree-sitter-dart-wasm/tree-sitter-dart.wasm",
+      "contentHash": "03122e87987cacc9ab19a07ae7055c19d636d8c73564fb67a583f5bc9f73779c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2680,
+      "hasStructuralAnalysis": false
+    },
+    "understand-anything-plugin/pnpm-workspace.yaml": {
+      "filePath": "understand-anything-plugin/pnpm-workspace.yaml",
+      "contentHash": "0fb360452b0231d114d0b0ad6cc76bb48fe528382f55827cf93739bf64ec79e1",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 3,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand-chat/SKILL.md": {
+      "filePath": "understand-anything-plugin/skills/understand-chat/SKILL.md",
+      "contentHash": "d8234baaabcee97c2e4be8204a58123de592164e8d7502398caeddf1223b2e17",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 56,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand-dashboard/SKILL.md": {
+      "filePath": "understand-anything-plugin/skills/understand-dashboard/SKILL.md",
+      "contentHash": "5c2155ab1dcdf54e0b7e3e508d666a5c8faaf7c89ad1f7e1753d115eb371a691",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 106,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand-diff/SKILL.md": {
+      "filePath": "understand-anything-plugin/skills/understand-diff/SKILL.md",
+      "contentHash": "747a84b1a25f9b65f2b0dea3ed37bb701e70b31d8e5d03d04c4b10805c56a3fd",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 73,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand-domain/extract-domain-context.py": {
+      "filePath": "understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "contentHash": "13e889cf3daaccbd3db8cc548f20ff4ac1525476bd57b088799eb0e61492a5c8",
+      "functions": [
+        {
+          "name": "parse_gitignore",
+          "params": [
+            "project_root"
+          ],
+          "returnType": "list[re.Pattern[str]]",
+          "exported": true,
+          "lineCount": 20
+        },
+        {
+          "name": "is_ignored",
+          "params": [
+            "rel_path",
+            "gitignore_patterns"
+          ],
+          "returnType": "bool",
+          "exported": true,
+          "lineCount": 6
+        },
+        {
+          "name": "scan_file_tree",
+          "params": [
+            "root",
+            "gitignore_patterns",
+            "max_depth"
+          ],
+          "returnType": "list[str]",
+          "exported": true,
+          "lineCount": 42
+        },
+        {
+          "name": "detect_entry_points",
+          "params": [
+            "root",
+            "file_paths"
+          ],
+          "returnType": "list[dict[str, Any]]",
+          "exported": true,
+          "lineCount": 43
+        },
+        {
+          "name": "extract_file_signatures",
+          "params": [
+            "root",
+            "file_paths"
+          ],
+          "returnType": "list[dict[str, Any]]",
+          "exported": true,
+          "lineCount": 58
+        },
+        {
+          "name": "extract_metadata",
+          "params": [
+            "root"
+          ],
+          "returnType": "dict[str, Any]",
+          "exported": true,
+          "lineCount": 33
+        },
+        {
+          "name": "_truncate_to_fit",
+          "params": [
+            "context"
+          ],
+          "returnType": "dict[str, Any]",
+          "exported": true,
+          "lineCount": 31
+        },
+        {
+          "name": "main",
+          "params": [],
+          "returnType": "None",
+          "exported": true,
+          "lineCount": 49
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "json",
+          "specifiers": [
+            "json"
+          ]
+        },
+        {
+          "source": "os",
+          "specifiers": [
+            "os"
+          ]
+        },
+        {
+          "source": "re",
+          "specifiers": [
+            "re"
+          ]
+        },
+        {
+          "source": "sys",
+          "specifiers": [
+            "sys"
+          ]
+        },
+        {
+          "source": "pathlib",
+          "specifiers": [
+            "Path"
+          ]
+        },
+        {
+          "source": "typing",
+          "specifiers": [
+            "Any"
+          ]
+        }
+      ],
+      "exports": [
+        "parse_gitignore",
+        "is_ignored",
+        "scan_file_tree",
+        "detect_entry_points",
+        "extract_file_signatures",
+        "extract_metadata",
+        "_truncate_to_fit",
+        "main"
+      ],
+      "totalLines": 429,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand-domain/SKILL.md": {
+      "filePath": "understand-anything-plugin/skills/understand-domain/SKILL.md",
+      "contentHash": "8c3c3bb810bcd11752f66be7c88347ceb4435e47cdfaf1bf39663fa5f37d0cb4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 141,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand-explain/SKILL.md": {
+      "filePath": "understand-anything-plugin/skills/understand-explain/SKILL.md",
+      "contentHash": "5a057cf9ce6717eb2d3ecbb8dd6a68647a41b901ebc1fc0b9439ca186f1b0739",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 59,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py": {
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py",
+      "contentHash": "f5690aacc4fe90102923ba72e07f79e50ba7d0cebf53cdcad679b7a3534470de",
+      "functions": [
+        {
+          "name": "normalize_node_type",
+          "params": [
+            "t"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "normalize_edge_type",
+          "params": [
+            "t"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "normalize_entity_name",
+          "params": [
+            "name"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "merge",
+          "params": [
+            "root"
+          ],
+          "returnType": "dict",
+          "exported": true,
+          "lineCount": 289
+        },
+        {
+          "name": "main",
+          "params": [],
+          "exported": true,
+          "lineCount": 11
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "json",
+          "specifiers": [
+            "json"
+          ]
+        },
+        {
+          "source": "os",
+          "specifiers": [
+            "os"
+          ]
+        },
+        {
+          "source": "re",
+          "specifiers": [
+            "re"
+          ]
+        },
+        {
+          "source": "sys",
+          "specifiers": [
+            "sys"
+          ]
+        },
+        {
+          "source": "datetime",
+          "specifiers": [
+            "datetime",
+            "timezone"
+          ]
+        },
+        {
+          "source": "pathlib",
+          "specifiers": [
+            "Path"
+          ]
+        }
+      ],
+      "exports": [
+        "normalize_node_type",
+        "normalize_edge_type",
+        "normalize_entity_name",
+        "merge",
+        "main"
+      ],
+      "totalLines": 398,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py": {
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "contentHash": "2db13c356bbcae9b976b311fcd3fcec5dbfd2408bc584a1d2f525b0f1e66d51c",
+      "functions": [
+        {
+          "name": "detect_format",
+          "params": [
+            "root"
+          ],
+          "returnType": "dict",
+          "exported": true,
+          "lineCount": 32
+        },
+        {
+          "name": "extract_frontmatter",
+          "params": [
+            "text"
+          ],
+          "returnType": "dict",
+          "exported": true,
+          "lineCount": 11
+        },
+        {
+          "name": "extract_wikilinks",
+          "params": [
+            "text"
+          ],
+          "returnType": "list[dict]",
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "extract_headings",
+          "params": [
+            "text"
+          ],
+          "returnType": "list[dict]",
+          "exported": true,
+          "lineCount": 6
+        },
+        {
+          "name": "extract_code_blocks",
+          "params": [
+            "text"
+          ],
+          "returnType": "list[str]",
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "extract_first_paragraph",
+          "params": [
+            "text"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 42
+        },
+        {
+          "name": "extract_h1",
+          "params": [
+            "text"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 7
+        },
+        {
+          "name": "parse_index",
+          "params": [
+            "index_path"
+          ],
+          "returnType": "list[dict]",
+          "exported": true,
+          "lineCount": 25
+        },
+        {
+          "name": "parse_log",
+          "params": [
+            "log_path"
+          ],
+          "returnType": "list[dict]",
+          "exported": true,
+          "lineCount": 16
+        },
+        {
+          "name": "build_name_to_stem_map",
+          "params": [
+            "wiki_root"
+          ],
+          "returnType": "dict[str, str]",
+          "exported": true,
+          "lineCount": 27
+        },
+        {
+          "name": "resolve_wikilink",
+          "params": [
+            "target",
+            "name_map",
+            "node_ids"
+          ],
+          "returnType": "str | None",
+          "exported": true,
+          "lineCount": 24
+        },
+        {
+          "name": "parse_wiki",
+          "params": [
+            "root"
+          ],
+          "returnType": "dict",
+          "exported": true,
+          "lineCount": 202
+        },
+        {
+          "name": "main",
+          "params": [],
+          "exported": true,
+          "lineCount": 24
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "json",
+          "specifiers": [
+            "json"
+          ]
+        },
+        {
+          "source": "os",
+          "specifiers": [
+            "os"
+          ]
+        },
+        {
+          "source": "re",
+          "specifiers": [
+            "re"
+          ]
+        },
+        {
+          "source": "sys",
+          "specifiers": [
+            "sys"
+          ]
+        },
+        {
+          "source": "pathlib",
+          "specifiers": [
+            "Path"
+          ]
+        }
+      ],
+      "exports": [
+        "detect_format",
+        "extract_frontmatter",
+        "extract_wikilinks",
+        "extract_headings",
+        "extract_code_blocks",
+        "extract_first_paragraph",
+        "extract_h1",
+        "parse_index",
+        "parse_log",
+        "build_name_to_stem_map",
+        "resolve_wikilink",
+        "parse_wiki",
+        "main"
+      ],
+      "totalLines": 510,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand-knowledge/SKILL.md": {
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/SKILL.md",
+      "contentHash": "9664aabd22f87072c4d3653450a8934dc5df6dc991ffbbc44b6704b23b8439c5",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 133,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand-onboard/SKILL.md": {
+      "filePath": "understand-anything-plugin/skills/understand-onboard/SKILL.md",
+      "contentHash": "fad391a6526aeeb90ae8686e071ebe2d29700ebb4ea975e47a1c6da8b66171c3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 56,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/build-fingerprints.mjs": {
+      "filePath": "understand-anything-plugin/skills/understand/build-fingerprints.mjs",
+      "contentHash": "2ed228677bbf1bda3fba00d4662c8e542caa3d69c5fed911c4878e6382767881",
+      "functions": [
+        {
+          "name": "main",
+          "params": [],
+          "exported": false,
+          "lineCount": 34
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname",
+            "resolve"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath",
+            "pathToFileURL"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "readFileSync"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 91,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/compute-batches.mjs": {
+      "filePath": "understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "contentHash": "2c35a73fbeec6bba90fe07e51dc60f35f4899be53c660c4fa4ae7e4209a39554",
+      "functions": [
+        {
+          "name": "extractExports",
+          "params": [
+            "projectRoot",
+            "codeFiles"
+          ],
+          "exported": false,
+          "lineCount": 71
+        },
+        {
+          "name": "buildNonCodeBatches",
+          "params": [
+            "nonCodeFiles"
+          ],
+          "exported": false,
+          "lineCount": 85
+        },
+        {
+          "name": "buildBatchOfMap",
+          "params": [
+            "allBatches"
+          ],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "runLouvain",
+          "params": [
+            "codeFiles",
+            "importMap"
+          ],
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "countBasedAssignment",
+          "params": [
+            "codeFiles"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "mergeSmallBatches",
+          "params": [
+            "bareBatches"
+          ],
+          "exported": false,
+          "lineCount": 55
+        },
+        {
+          "name": "main",
+          "params": [],
+          "exported": false,
+          "lineCount": 224
+        },
+        {
+          "name": "isCliEntry",
+          "params": [],
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "readFileSync",
+            "writeFileSync",
+            "existsSync",
+            "realpathSync"
+          ]
+        },
+        {
+          "source": "node:fs/promises",
+          "specifiers": [
+            "readFile"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname",
+            "join",
+            "resolve"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath",
+            "pathToFileURL"
+          ]
+        },
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "graphology",
+          "specifiers": [
+            "Graph"
+          ]
+        },
+        {
+          "source": "graphology-communities-louvain",
+          "specifiers": [
+            "louvain"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 589,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/extract-import-map.mjs": {
+      "filePath": "understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "contentHash": "ec0dff3313ce192d7e90eabca5b905ad73c997ef5152c562a852af9c0268e526",
+      "functions": [
+        {
+          "name": "readFilesParallel",
+          "params": [
+            "paths"
+          ],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "toPosix",
+          "params": [
+            "p"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "resolveRelative",
+          "params": [
+            "dir",
+            "rel"
+          ],
+          "exported": false,
+          "lineCount": 16
+        },
+        {
+          "name": "dirOf",
+          "params": [
+            "p"
+          ],
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "parseTsConfigText",
+          "params": [
+            "raw"
+          ],
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "loadTsConfigs",
+          "params": [
+            "projectRoot",
+            "files"
+          ],
+          "exported": false,
+          "lineCount": 38
+        },
+        {
+          "name": "loadGoModules",
+          "params": [
+            "projectRoot",
+            "files"
+          ],
+          "exported": false,
+          "lineCount": 32
+        },
+        {
+          "name": "findNearestConfigDir",
+          "params": [
+            "startDir",
+            "configMap"
+          ],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "buildResolutionContext",
+          "params": [
+            "projectRoot",
+            "files"
+          ],
+          "exported": false,
+          "lineCount": 63
+        },
+        {
+          "name": "probeWithExtensions",
+          "params": [
+            "basePath",
+            "fileSet"
+          ],
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "resolveTsJsImport",
+          "params": [
+            "rawImport",
+            "file",
+            "ctx"
+          ],
+          "exported": true,
+          "lineCount": 58
+        },
+        {
+          "name": "matchTsAlias",
+          "params": [
+            "alias",
+            "src"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "applyTsAlias",
+          "params": [
+            "target",
+            "wildcard"
+          ],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "stripJsLikeComments",
+          "params": [
+            "content"
+          ],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "extractRequireSources",
+          "params": [
+            "content"
+          ],
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "extractKotlinSources",
+          "params": [
+            "content"
+          ],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "resolvePythonImport",
+          "params": [
+            "rawImport",
+            "specifiers",
+            "file",
+            "ctx"
+          ],
+          "exported": true,
+          "lineCount": 77
+        },
+        {
+          "name": "resolvePythonProbe",
+          "params": [
+            "moduleParts",
+            "specifiers",
+            "ctx"
+          ],
+          "exported": false,
+          "lineCount": 36
+        },
+        {
+          "name": "resolveGoImport",
+          "params": [
+            "rawImport",
+            "file",
+            "ctx"
+          ],
+          "exported": true,
+          "lineCount": 49
+        },
+        {
+          "name": "buildSuffixIndex",
+          "params": [
+            "files",
+            "extPredicate"
+          ],
+          "exported": false,
+          "lineCount": 19
+        },
+        {
+          "name": "resolveDottedFqn",
+          "params": [
+            "fqn",
+            "ext",
+            "suffixIndex"
+          ],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "resolveJavaImport",
+          "params": [
+            "rawImport",
+            "_file",
+            "ctx"
+          ],
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "resolveKotlinImport",
+          "params": [
+            "rawImport",
+            "_file",
+            "ctx"
+          ],
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "resolveCSharpImport",
+          "params": [
+            "rawImport",
+            "_file",
+            "ctx"
+          ],
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "stripRubyComments",
+          "params": [
+            "content"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "parseRubyImports",
+          "params": [
+            "content"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "resolveRubyImport",
+          "params": [
+            "file",
+            "ctx"
+          ],
+          "exported": true,
+          "lineCount": 17
+        },
+        {
+          "name": "parseComposerAutoloadText",
+          "params": [
+            "raw"
+          ],
+          "exported": false,
+          "lineCount": 27
+        },
+        {
+          "name": "loadPhpAutoloads",
+          "params": [
+            "projectRoot",
+            "files"
+          ],
+          "exported": false,
+          "lineCount": 36
+        },
+        {
+          "name": "resolvePhpImport",
+          "params": [
+            "rawImport",
+            "file",
+            "ctx"
+          ],
+          "exported": true,
+          "lineCount": 45
+        },
+        {
+          "name": "probeRustModule",
+          "params": [
+            "base",
+            "fileSet"
+          ],
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "findRustCrateSrc",
+          "params": [
+            "importerDir",
+            "fileSet"
+          ],
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "resolveRustImport",
+          "params": [
+            "rawImport",
+            "file",
+            "ctx"
+          ],
+          "exported": true,
+          "lineCount": 58
+        },
+        {
+          "name": "extractRustModSources",
+          "params": [
+            "content"
+          ],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "resolveCppImport",
+          "params": [
+            "rawImport",
+            "file",
+            "ctx"
+          ],
+          "exported": true,
+          "lineCount": 17
+        },
+        {
+          "name": "resolveImport",
+          "params": [
+            "imp",
+            "file",
+            "ctx"
+          ],
+          "exported": false,
+          "lineCount": 36
+        },
+        {
+          "name": "extractExtraImportSources",
+          "params": [
+            "file",
+            "content"
+          ],
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "main",
+          "params": [],
+          "exported": false,
+          "lineCount": 158
+        },
+        {
+          "name": "isCliEntry",
+          "params": [],
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname",
+            "resolve",
+            "join",
+            "posix"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath",
+            "pathToFileURL"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "existsSync",
+            "readFileSync",
+            "realpathSync",
+            "writeFileSync"
+          ]
+        },
+        {
+          "source": "node:fs/promises",
+          "specifiers": [
+            "readFile"
+          ]
+        }
+      ],
+      "exports": [
+        "resolveTsJsImport",
+        "resolvePythonImport",
+        "resolveGoImport",
+        "resolveJavaImport",
+        "resolveKotlinImport",
+        "resolveCSharpImport",
+        "resolveRubyImport",
+        "resolvePhpImport",
+        "resolveRustImport",
+        "resolveCppImport"
+      ],
+      "totalLines": 1668,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/extract-structure.mjs": {
+      "filePath": "understand-anything-plugin/skills/understand/extract-structure.mjs",
+      "contentHash": "ecf8e19203ee4328be8ef03d6cc00ac2db4dcf29e012a84f117c168772256d28",
+      "functions": [
+        {
+          "name": "main",
+          "params": [],
+          "exported": false,
+          "lineCount": 92
+        },
+        {
+          "name": "buildResult",
+          "params": [
+            "file",
+            "totalLines",
+            "nonEmptyLines",
+            "analysis",
+            "callGraph",
+            "batchImportData"
+          ],
+          "exported": true,
+          "lineCount": 159
+        },
+        {
+          "name": "isCliEntry",
+          "params": [],
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname",
+            "resolve",
+            "join"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath",
+            "pathToFileURL"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "existsSync",
+            "readFileSync",
+            "realpathSync",
+            "writeFileSync"
+          ]
+        }
+      ],
+      "exports": [
+        "buildResult"
+      ],
+      "totalLines": 335,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/frameworks/django.md": {
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/django.md",
+      "contentHash": "a2257a849cf64d09cf2869a3106991264d7f50acd03c93e76284ed288cba7051",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 68,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/frameworks/express.md": {
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/express.md",
+      "contentHash": "0a7b0d4ddc72fca3d1cbf5d7c63739f4cbbb924b86625907df03656b6734898c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 58,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/frameworks/fastapi.md": {
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/fastapi.md",
+      "contentHash": "54f971f48dd74a6138d9cd03a3c4e7f4b06ab803403a663ebcc4a6422c0671b1",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 59,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/frameworks/flask.md": {
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/flask.md",
+      "contentHash": "645844e41c9a09ab47233c4ed68febfb7e15d8cc6bb354bb029b4218b0d6141c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 54,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/frameworks/gin.md": {
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/gin.md",
+      "contentHash": "6621187a9fe0023d7d36ffe51680571ee58a7a77ebe915db4d35b6fb26eadb77",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 60,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/frameworks/nextjs.md": {
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/nextjs.md",
+      "contentHash": "99ae673ecaf27381e18483b12a6dc66ce7bbc37f3bf8f2f66344a160a882f2ea",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 60,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/frameworks/rails.md": {
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/rails.md",
+      "contentHash": "f5fb1fb05a32c9e71ba44e93d205252fd4e58b71a6cce9d62cd4ee20d14adc36",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 66,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/frameworks/react.md": {
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/react.md",
+      "contentHash": "eaaf30363244b89a6bad91971f3d476ec809a8892f387a8bf33c04638a04af20",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 56,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/frameworks/spring.md": {
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/spring.md",
+      "contentHash": "296c10395b794c8c0741cd2faaa61f9e171933003f39cbe45f462237ed1066c6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 60,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/frameworks/vue.md": {
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/vue.md",
+      "contentHash": "49a432fe59c8b0759632bd1745b4acc7ddcaef4343a270d97698d9bede69e5db",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 60,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/generate-ignore.mjs": {
+      "filePath": "understand-anything-plugin/skills/understand/generate-ignore.mjs",
+      "contentHash": "38227d8e3175c16f0c18e2d232ee642958132a0756b53224ef66cec3c47ff421",
+      "functions": [
+        {
+          "name": "resolvePluginRoot",
+          "params": [],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname",
+            "join",
+            "resolve"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath",
+            "pathToFileURL"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "existsSync",
+            "mkdirSync",
+            "writeFileSync"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 67,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/cpp.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/cpp.md",
+      "contentHash": "2a658bb677944fa58e6a244430d120cb0657d09e4e50fe28a9cdfbdd554f46f9",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 48,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/csharp.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/csharp.md",
+      "contentHash": "507cb86fb5c494d9d5e8ab947015ac6f4e7a2c280c0509ffdbab812a0472c467",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/css.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/css.md",
+      "contentHash": "ed3a8dcd96e9921d8d85cfcf0ea07d7a15838cd076180017a80162b1b7166131",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 38,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/dockerfile.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/dockerfile.md",
+      "contentHash": "bb548a778970cb234ea805ee35dde488274eb077d2b671aa4b55297985f88bb6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 35,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/go.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/go.md",
+      "contentHash": "359f808ba97c79726598fe92478ee5680c1bd22a6065db9d374e403f5e19f0e1",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 48,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/graphql.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/graphql.md",
+      "contentHash": "735b28063ee40ad7b07fc76a4268f96fa59f9fd5d38f185f4914275a1fa430e3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 36,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/html.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/html.md",
+      "contentHash": "059b74d8ca82efa09c273afc00aa96796202f637f147242990ebe2c90897ce3f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 35,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/java.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/java.md",
+      "contentHash": "fd8584d68da5d11e2b8b4e1c8a3d737175bfe77abe55ba49ca5750359571f55d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 46,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/javascript.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/javascript.md",
+      "contentHash": "4e2bc5e4c4139c86baf2a0e48587a4130d337d06929a323d8b2ab302c3355352",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/json.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/json.md",
+      "contentHash": "6a420be6610ed2c5f2950f72b1e3f9c6c15a2377f23d70e066a9bd4ae860cf4a",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 35,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/kotlin.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/kotlin.md",
+      "contentHash": "fe3d5eff0f190027ce6e9686bc80e7dce4313aced194a014febb3e93cd091977",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 46,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/markdown.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/markdown.md",
+      "contentHash": "32203c73af64c9f38768199887a25f5e58c166957b82b8b8934fb926d614f944",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 35,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/php.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/php.md",
+      "contentHash": "043635d64c89b6293936085f2cd341f055d61b71132b0d09ed599e608023c772",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/protobuf.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/protobuf.md",
+      "contentHash": "7db34b5f2085ab14ac888c4c817caa6f1045a7405e14f7c30000bec93139b3dd",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 35,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/python.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/python.md",
+      "contentHash": "bb6553846c7ddb63ab4c156caf183fa64f59c63a56c3b0aaa42f764f9332ba94",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 49,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/ruby.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/ruby.md",
+      "contentHash": "f5942f0e7136e48723c7d70ef49358cc9d12d4e3b3144e65607c947137382788",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/rust.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/rust.md",
+      "contentHash": "32cb3c3fcd1a560821ed09dd9a0da184dfa5c79c85f1e03034945ef4d14208d4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 48,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/shell.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/shell.md",
+      "contentHash": "f9992d17799065cef318c6906ad6cdad646cb3bbbe9ff1d07234a0634f587bd9",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 36,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/sql.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/sql.md",
+      "contentHash": "d0345797e637e91ae8e98f1f9fc37b62b881a6691e2801a60139fc422341c4a4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 37,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/swift.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/swift.md",
+      "contentHash": "4c866204fffe114a4e27f11b162829257cd687020cb69b30bce88dbfff334775",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/terraform.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/terraform.md",
+      "contentHash": "862d02b31ebc9de6d03d2112cf17084fcc15b4952bed08fa39e69260d642748e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 39,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/typescript.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/typescript.md",
+      "contentHash": "20d6d1ae757d806b8a4aeb0aa6e9fb5c3307ad4e3c83715d2e8532924e8afda6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/languages/yaml.md": {
+      "filePath": "understand-anything-plugin/skills/understand/languages/yaml.md",
+      "contentHash": "0cda6694a866ca53715a23cafcc00d5e8995437916a49e40eb77a50114e55d7f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 36,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/locales/en.md": {
+      "filePath": "understand-anything-plugin/skills/understand/locales/en.md",
+      "contentHash": "bfbecb6e2e902bf92ee0476a35ea8c267fd7040ba8ffa2621da183fe767dc3b2",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 44,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/locales/ja.md": {
+      "filePath": "understand-anything-plugin/skills/understand/locales/ja.md",
+      "contentHash": "97c8462f64dd6fd8400861eb49871b27640b144d532e4be7f866689eefc7b7c6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 49,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/locales/ko.md": {
+      "filePath": "understand-anything-plugin/skills/understand/locales/ko.md",
+      "contentHash": "2a7cbed153d563221516858160b073e33b1080881b13a652f60667e98f0a3e6f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 49,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/locales/ru.md": {
+      "filePath": "understand-anything-plugin/skills/understand/locales/ru.md",
+      "contentHash": "02a9cfb7894ffd6e68a24d1dfd050ccc06bd66cac10b0b35d75acf72cedf12de",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 50,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/locales/zh-TW.md": {
+      "filePath": "understand-anything-plugin/skills/understand/locales/zh-TW.md",
+      "contentHash": "727f14f80a4edb73dfe53025686d5d3afe865eaa554ec1c6c787f3a9a070621f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 49,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/locales/zh.md": {
+      "filePath": "understand-anything-plugin/skills/understand/locales/zh.md",
+      "contentHash": "06cbd26979a3383f6177b3d37995bef44f104ebe2de43704b8b1d1b5031ad98b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 49,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/merge-batch-graphs.py": {
+      "filePath": "understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "contentHash": "aec850cb49b091d54045f660733e2e5b644b73c012ba9fd15a8c1caae56dbd9f",
+      "functions": [
+        {
+          "name": "normalize_direction",
+          "params": [
+            "value"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 7
+        },
+        {
+          "name": "_num",
+          "params": [
+            "v"
+          ],
+          "returnType": "float",
+          "exported": true,
+          "lineCount": 6
+        },
+        {
+          "name": "load_batch",
+          "params": [
+            "path"
+          ],
+          "returnType": "dict[str, Any] | None",
+          "exported": true,
+          "lineCount": 16
+        },
+        {
+          "name": "classify_id_fix",
+          "params": [
+            "original",
+            "corrected"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 22
+        },
+        {
+          "name": "normalize_node_id",
+          "params": [
+            "node_id",
+            "node"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 44
+        },
+        {
+          "name": "normalize_complexity",
+          "params": [
+            "value"
+          ],
+          "returnType": "tuple[str, str]",
+          "exported": true,
+          "lineCount": 26
+        },
+        {
+          "name": "_path_segments",
+          "params": [
+            "path"
+          ],
+          "returnType": "list[str]",
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "_basename",
+          "params": [
+            "path"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 2
+        },
+        {
+          "name": "is_test_path",
+          "params": [
+            "path"
+          ],
+          "returnType": "bool",
+          "exported": true,
+          "lineCount": 21
+        },
+        {
+          "name": "_strip_test_infix",
+          "params": [
+            "stem"
+          ],
+          "returnType": "str | None",
+          "exported": true,
+          "lineCount": 7
+        },
+        {
+          "name": "_join",
+          "params": [
+            "dir_path",
+            "name"
+          ],
+          "returnType": "str",
+          "exported": true,
+          "lineCount": 4
+        },
+        {
+          "name": "_add_unique",
+          "params": [
+            "out",
+            "path"
+          ],
+          "returnType": "None",
+          "exported": true,
+          "lineCount": 4
+        },
+        {
+          "name": "_js_ts_sibling_candidates",
+          "params": [
+            "dir_path",
+            "base_stem"
+          ],
+          "returnType": "list[str]",
+          "exported": true,
+          "lineCount": 7
+        },
+        {
+          "name": "production_candidates",
+          "params": [
+            "test_path"
+          ],
+          "returnType": "list[str]",
+          "exported": true,
+          "lineCount": 167
+        },
+        {
+          "name": "_file_node_path",
+          "params": [
+            "node"
+          ],
+          "returnType": "str | None",
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "_swap_tested_by_in_place",
+          "params": [
+            "edge",
+            "original_src",
+            "original_tgt"
+          ],
+          "returnType": "None",
+          "exported": true,
+          "lineCount": 16
+        },
+        {
+          "name": "_ensure_tested_tag",
+          "params": [
+            "node"
+          ],
+          "returnType": "bool",
+          "exported": true,
+          "lineCount": 16
+        },
+        {
+          "name": "link_tests",
+          "params": [
+            "nodes_by_id",
+            "edges"
+          ],
+          "returnType": "tuple[int, int, int, int]",
+          "exported": true,
+          "lineCount": 164
+        },
+        {
+          "name": "merge_and_normalize",
+          "params": [
+            "batches"
+          ],
+          "returnType": "tuple[dict[str, Any], list[str]]",
+          "exported": true,
+          "lineCount": 185
+        },
+        {
+          "name": "recover_imports_from_scan",
+          "params": [
+            "assembled",
+            "scan_result_path"
+          ],
+          "returnType": "tuple[int, list[str]]",
+          "exported": true,
+          "lineCount": 86
+        },
+        {
+          "name": "main",
+          "params": [],
+          "returnType": "None",
+          "exported": true,
+          "lineCount": 158
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "json",
+          "specifiers": [
+            "json"
+          ]
+        },
+        {
+          "source": "os",
+          "specifiers": [
+            "os"
+          ]
+        },
+        {
+          "source": "re",
+          "specifiers": [
+            "re"
+          ]
+        },
+        {
+          "source": "sys",
+          "specifiers": [
+            "sys"
+          ]
+        },
+        {
+          "source": "collections",
+          "specifiers": [
+            "Counter"
+          ]
+        },
+        {
+          "source": "pathlib",
+          "specifiers": [
+            "Path"
+          ]
+        },
+        {
+          "source": "typing",
+          "specifiers": [
+            "Any"
+          ]
+        }
+      ],
+      "exports": [
+        "normalize_direction",
+        "_num",
+        "load_batch",
+        "classify_id_fix",
+        "normalize_node_id",
+        "normalize_complexity",
+        "_path_segments",
+        "_basename",
+        "is_test_path",
+        "_strip_test_infix",
+        "_join",
+        "_add_unique",
+        "_js_ts_sibling_candidates",
+        "production_candidates",
+        "_file_node_path",
+        "_swap_tested_by_in_place",
+        "_ensure_tested_tag",
+        "link_tests",
+        "merge_and_normalize",
+        "recover_imports_from_scan",
+        "main"
+      ],
+      "totalLines": 1165,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/merge-subdomain-graphs.py": {
+      "filePath": "understand-anything-plugin/skills/understand/merge-subdomain-graphs.py",
+      "contentHash": "75aa0967ea8f93ba2538b1f2fcc0a48e6b38f7bcf12de3b42f9733d5dddf0d28",
+      "functions": [
+        {
+          "name": "_num",
+          "params": [
+            "v"
+          ],
+          "returnType": "float",
+          "exported": true,
+          "lineCount": 6
+        },
+        {
+          "name": "load_graph",
+          "params": [
+            "path"
+          ],
+          "returnType": "dict[str, Any] | None",
+          "exported": true,
+          "lineCount": 14
+        },
+        {
+          "name": "merge_graphs",
+          "params": [
+            "graphs"
+          ],
+          "returnType": "tuple[dict[str, Any], list[str]]",
+          "exported": true,
+          "lineCount": 181
+        },
+        {
+          "name": "main",
+          "params": [],
+          "returnType": "None",
+          "exported": true,
+          "lineCount": 70
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "json",
+          "specifiers": [
+            "json"
+          ]
+        },
+        {
+          "source": "sys",
+          "specifiers": [
+            "sys"
+          ]
+        },
+        {
+          "source": "collections",
+          "specifiers": [
+            "Counter"
+          ]
+        },
+        {
+          "source": "pathlib",
+          "specifiers": [
+            "Path"
+          ]
+        },
+        {
+          "source": "typing",
+          "specifiers": [
+            "Any"
+          ]
+        }
+      ],
+      "exports": [
+        "_num",
+        "load_graph",
+        "merge_graphs",
+        "main"
+      ],
+      "totalLines": 309,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/scan-project.mjs": {
+      "filePath": "understand-anything-plugin/skills/understand/scan-project.mjs",
+      "contentHash": "d9673ab2b37eaad4df7d5e419d04b95077045d0b09cf4e5d4e330951df62de9b",
+      "functions": [
+        {
+          "name": "detectLanguage",
+          "params": [
+            "filePath"
+          ],
+          "exported": true,
+          "lineCount": 28
+        },
+        {
+          "name": "dotfileKey",
+          "params": [
+            "base"
+          ],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "detectCategory",
+          "params": [
+            "filePath"
+          ],
+          "exported": true,
+          "lineCount": 45
+        },
+        {
+          "name": "estimateComplexity",
+          "params": [
+            "totalFiles"
+          ],
+          "exported": true,
+          "lineCount": 6
+        },
+        {
+          "name": "toPosix",
+          "params": [
+            "p"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "enumerateViaGit",
+          "params": [
+            "projectRoot"
+          ],
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "enumerateViaWalk",
+          "params": [
+            "projectRoot"
+          ],
+          "exported": false,
+          "lineCount": 46
+        },
+        {
+          "name": "enumerateFiles",
+          "params": [
+            "projectRoot"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "buildDefaultsOnlyFilter",
+          "params": [],
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "hasUserIgnoreFile",
+          "params": [
+            "projectRoot"
+          ],
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "countLines",
+          "params": [
+            "absPath",
+            "posixPath"
+          ],
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "main",
+          "params": [],
+          "exported": false,
+          "lineCount": 121
+        },
+        {
+          "name": "isCliEntry",
+          "params": [],
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:module",
+          "specifiers": [
+            "createRequire"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname",
+            "resolve",
+            "join",
+            "basename",
+            "extname",
+            "relative",
+            "sep"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath",
+            "pathToFileURL"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "existsSync",
+            "readFileSync",
+            "readdirSync",
+            "realpathSync",
+            "statSync",
+            "writeFileSync"
+          ]
+        },
+        {
+          "source": "node:child_process",
+          "specifiers": [
+            "spawnSync"
+          ]
+        }
+      ],
+      "exports": [
+        "detectLanguage",
+        "detectCategory",
+        "estimateComplexity"
+      ],
+      "totalLines": 803,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/skills/understand/SKILL.md": {
+      "filePath": "understand-anything-plugin/skills/understand/SKILL.md",
+      "contentHash": "88ecde51339428a705816481163f68eb300795820cd22e0f036c04220298cf62",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 839,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/__tests__/context-builder.test.ts": {
+      "filePath": "understand-anything-plugin/src/__tests__/context-builder.test.ts",
+      "contentHash": "e8db3b59b38daab45dab929bbfa74f0a7d80a83ef9628cd5e7f49ab99297d6a8",
+      "functions": [
+        {
+          "name": "makeNode",
+          "params": [
+            "overrides"
+          ],
+          "returnType": "GraphNode",
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../context-builder.js",
+          "specifiers": [
+            "buildChatContext",
+            "formatContextForPrompt"
+          ]
+        },
+        {
+          "source": "@understand-anything/core",
+          "specifiers": [
+            "KnowledgeGraph",
+            "GraphNode",
+            "GraphEdge",
+            "Layer"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 235,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/__tests__/diff-analyzer.test.ts": {
+      "filePath": "understand-anything-plugin/src/__tests__/diff-analyzer.test.ts",
+      "contentHash": "0a23258f4b08fb64086b0ca101b7e22a67f49f057498be02db7677726ebd897e",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../diff-analyzer.js",
+          "specifiers": [
+            "buildDiffContext",
+            "formatDiffAnalysis"
+          ]
+        },
+        {
+          "source": "@understand-anything/core",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 107,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/__tests__/explain-builder.test.ts": {
+      "filePath": "understand-anything-plugin/src/__tests__/explain-builder.test.ts",
+      "contentHash": "eeec0e4198d69816516fdbf39dea0d6c7e421913ad3d532e496c88c4d382aef0",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../explain-builder.js",
+          "specifiers": [
+            "buildExplainContext",
+            "formatExplainPrompt"
+          ]
+        },
+        {
+          "source": "@understand-anything/core",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 83,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/__tests__/extract-structure.test.mjs": {
+      "filePath": "understand-anything-plugin/src/__tests__/extract-structure.test.mjs",
+      "contentHash": "7c5ee007ce6d6b9748c97d69f011d51d5d113640bffb1668b1d2e66dbfb46de0",
+      "functions": [
+        {
+          "name": "file",
+          "params": [],
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "analysis",
+          "params": [],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../../skills/understand/extract-structure.mjs",
+          "specifiers": [
+            "buildResult"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 113,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs": {
+      "filePath": "understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs",
+      "contentHash": "00582255853b87095027fe44ab3f61024f8ea0c6dab731f4471140119af8be5c",
+      "functions": [
+        {
+          "name": "runMerge",
+          "params": [],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "fileNode",
+          "params": [
+            "path"
+          ],
+          "exported": false,
+          "lineCount": 11
+        },
+        {
+          "name": "importsEdge",
+          "params": [
+            "src",
+            "tgt"
+          ],
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeEach",
+            "afterEach"
+          ]
+        },
+        {
+          "source": "node:child_process",
+          "specifiers": [
+            "spawnSync"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "mkdirSync",
+            "mkdtempSync",
+            "rmSync",
+            "writeFileSync",
+            "readFileSync"
+          ]
+        },
+        {
+          "source": "node:os",
+          "specifiers": [
+            "tmpdir"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname",
+            "resolve"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 188,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/__tests__/onboard-builder.test.ts": {
+      "filePath": "understand-anything-plugin/src/__tests__/onboard-builder.test.ts",
+      "contentHash": "f8259066a640f192d7f175c7901f2176f55e5f44a7cf0ae01f323c1f9fe8e459",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect"
+          ]
+        },
+        {
+          "source": "../onboard-builder.js",
+          "specifiers": [
+            "buildOnboardingGuide"
+          ]
+        },
+        {
+          "source": "@understand-anything/core",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 88,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs": {
+      "filePath": "understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs",
+      "contentHash": "ae1494efb68de26360be973ede5b10f1e3be9013b5bbdc50972ef895ca4de29c",
+      "functions": [
+        {
+          "name": "runResolve",
+          "params": [
+            "projectRoot"
+          ],
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest",
+          "specifiers": [
+            "describe",
+            "it",
+            "expect",
+            "beforeAll",
+            "afterAll"
+          ]
+        },
+        {
+          "source": "node:child_process",
+          "specifiers": [
+            "execFileSync"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "mkdtempSync",
+            "rmSync",
+            "mkdirSync",
+            "writeFileSync",
+            "realpathSync"
+          ]
+        },
+        {
+          "source": "node:os",
+          "specifiers": [
+            "tmpdir"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "join"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 90,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/context-builder.ts": {
+      "filePath": "understand-anything-plugin/src/context-builder.ts",
+      "contentHash": "1acad5d4617b83dd203345edfb62a0d5239e7b9e7baff23181ee9746de739575",
+      "functions": [
+        {
+          "name": "buildChatContext",
+          "params": [
+            "graph",
+            "query",
+            "maxNodes"
+          ],
+          "returnType": "ChatContext",
+          "exported": true,
+          "lineCount": 56
+        },
+        {
+          "name": "formatContextForPrompt",
+          "params": [
+            "context"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 63
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@understand-anything/core",
+          "specifiers": [
+            "SearchEngine"
+          ]
+        },
+        {
+          "source": "@understand-anything/core",
+          "specifiers": [
+            "KnowledgeGraph",
+            "GraphNode",
+            "GraphEdge",
+            "Layer"
+          ]
+        }
+      ],
+      "exports": [
+        "buildChatContext",
+        "formatContextForPrompt"
+      ],
+      "totalLines": 148,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/diff-analyzer.ts": {
+      "filePath": "understand-anything-plugin/src/diff-analyzer.ts",
+      "contentHash": "ce25679b46bf927cd4217db51125b67b2c7536a36deda48512ef9203c4963673",
+      "functions": [
+        {
+          "name": "buildDiffContext",
+          "params": [
+            "graph",
+            "changedFiles"
+          ],
+          "returnType": "DiffContext",
+          "exported": true,
+          "lineCount": 67
+        },
+        {
+          "name": "formatDiffAnalysis",
+          "params": [
+            "ctx"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 106
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@understand-anything/core",
+          "specifiers": [
+            "KnowledgeGraph",
+            "GraphNode",
+            "GraphEdge",
+            "Layer"
+          ]
+        }
+      ],
+      "exports": [
+        "buildDiffContext",
+        "formatDiffAnalysis"
+      ],
+      "totalLines": 199,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/explain-builder.ts": {
+      "filePath": "understand-anything-plugin/src/explain-builder.ts",
+      "contentHash": "d523dcfcb14c127b5630254d813051293416bae96022366eac8bfe6705c3723b",
+      "functions": [
+        {
+          "name": "buildExplainContext",
+          "params": [
+            "graph",
+            "path"
+          ],
+          "returnType": "ExplainContext",
+          "exported": true,
+          "lineCount": 82
+        },
+        {
+          "name": "formatExplainPrompt",
+          "params": [
+            "ctx"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 89
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@understand-anything/core",
+          "specifiers": [
+            "KnowledgeGraph",
+            "GraphNode",
+            "GraphEdge",
+            "Layer"
+          ]
+        }
+      ],
+      "exports": [
+        "buildExplainContext",
+        "formatExplainPrompt"
+      ],
+      "totalLines": 197,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/index.ts": {
+      "filePath": "understand-anything-plugin/src/index.ts",
+      "contentHash": "155134e1b07942cac1cd1566cda9d4aebe9652820e2ff046542fee10dd0f58dd",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [
+        "buildChatContext",
+        "formatContextForPrompt",
+        "ChatContext",
+        "buildChatPrompt",
+        "buildDiffContext",
+        "formatDiffAnalysis",
+        "DiffContext",
+        "buildExplainContext",
+        "formatExplainPrompt",
+        "ExplainContext",
+        "buildOnboardingGuide"
+      ],
+      "totalLines": 18,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/onboard-builder.ts": {
+      "filePath": "understand-anything-plugin/src/onboard-builder.ts",
+      "contentHash": "f11d220545d5138b79f1686f2b19f9a221027d685d6bcf7fcd298ea009af364f",
+      "functions": [
+        {
+          "name": "buildOnboardingGuide",
+          "params": [
+            "graph"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 118
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@understand-anything/core",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        }
+      ],
+      "exports": [
+        "buildOnboardingGuide"
+      ],
+      "totalLines": 125,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/src/understand-chat.ts": {
+      "filePath": "understand-anything-plugin/src/understand-chat.ts",
+      "contentHash": "9dda9e6f4182a3877dcba2c4d32fd078f35c3fabcbe92d0f510ad2f9d36db88c",
+      "functions": [
+        {
+          "name": "buildChatPrompt",
+          "params": [
+            "graph",
+            "query"
+          ],
+          "returnType": "string",
+          "exported": true,
+          "lineCount": 22
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@understand-anything/core",
+          "specifiers": [
+            "KnowledgeGraph"
+          ]
+        },
+        {
+          "source": "./context-builder.js",
+          "specifiers": [
+            "buildChatContext",
+            "formatContextForPrompt"
+          ]
+        }
+      ],
+      "exports": [
+        "buildChatPrompt"
+      ],
+      "totalLines": 30,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/tsconfig.json": {
+      "filePath": "understand-anything-plugin/tsconfig.json",
+      "contentHash": "e883e3117f39afcf9e2cf7d612094ac51421a3bc0c29bd6a4c1a543147a6144b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 20,
+      "hasStructuralAnalysis": true
+    },
+    "understand-anything-plugin/vitest.config.ts": {
+      "filePath": "understand-anything-plugin/vitest.config.ts",
+      "contentHash": "f4221ce7c260301c10ba7f5e26b1b4ead1dedd8933000ef29eed6d0970181505",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest/config",
+          "specifiers": [
+            "defineConfig"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "vitest.config.ts": {
+      "filePath": "vitest.config.ts",
+      "contentHash": "8cb606abab5fc7ac6c48f7d4a5b7fd0d291b47619625cc7570eb10f4016ab37d",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "vitest/config",
+          "specifiers": [
+            "defineConfig"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 26,
+      "hasStructuralAnalysis": true
+    },
+    "scripts/check-graph.mjs": {
+      "filePath": "scripts/check-graph.mjs",
+      "contentHash": "83b54d0b26fc9a19d3bddd8abe5b3fd797895ccc5797cfcfeb0862a54a143317",
+      "functions": [
+        {
+          "name": "ghError",
+          "params": [
+            "msg"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "ghWarning",
+          "params": [
+            "msg"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "loadCore",
+          "params": [],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "validateOne",
+          "params": [
+            "validateGraph",
+            "fileName"
+          ],
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "trackedSourceFiles",
+          "params": [
+            "filter"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "checkStaleness",
+          "params": [
+            "core"
+          ],
+          "exported": false,
+          "lineCount": 60
+        },
+        {
+          "name": "checkDomainSync",
+          "params": [],
+          "exported": false,
+          "lineCount": 41
+        },
+        {
+          "name": "main",
+          "params": [],
+          "exported": false,
+          "lineCount": 23
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "node:child_process",
+          "specifiers": [
+            "execFileSync"
+          ]
+        },
+        {
+          "source": "node:fs",
+          "specifiers": [
+            "existsSync",
+            "readFileSync"
+          ]
+        },
+        {
+          "source": "node:path",
+          "specifiers": [
+            "dirname",
+            "resolve",
+            "extname"
+          ]
+        },
+        {
+          "source": "node:url",
+          "specifiers": [
+            "fileURLToPath",
+            "pathToFileURL"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 245,
+      "hasStructuralAnalysis": true
+    }
+  }
+}

--- a/.understand-anything/knowledge-graph.json
+++ b/.understand-anything/knowledge-graph.json
@@ -1,0 +1,17635 @@
+{
+  "version": "1.0.0",
+  "project": {
+    "name": "understand-anything",
+    "languages": [
+      "typescript",
+      "javascript",
+      "python",
+      "markdown",
+      "json",
+      "yaml",
+      "css",
+      "html",
+      "shell",
+      "powershell",
+      "astro",
+      "wasm"
+    ],
+    "frameworks": [
+      "Astro",
+      "GitHub Actions",
+      "React",
+      "Tailwind CSS",
+      "Vite",
+      "Vitest",
+      "Zustand"
+    ],
+    "description": "An open-source tool combining LLM intelligence + static analysis to produce interactive dashboards for understanding codebases.",
+    "analyzedAt": "2026-06-24T15:31:15.051Z",
+    "gitCommitHash": "dee750facc588fc860744f8c6061a150e6852d9f"
+  },
+  "nodes": [
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts",
+      "type": "file",
+      "name": "framework-registry.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts",
+      "summary": "Unit tests validating the FrameworkRegistry's registration, lookup, and detection behavior using the Django and React framework configs.",
+      "tags": [
+        "test",
+        "framework",
+        "registry",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts",
+      "type": "file",
+      "name": "language-registry.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts",
+      "summary": "Unit tests covering the LanguageRegistry, exercising registration, schema validation, and extension-based language resolution with the Python and TypeScript configs.",
+      "tags": [
+        "test",
+        "language",
+        "registry",
+        "schema-validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/plugin-discovery.test.ts",
+      "type": "file",
+      "name": "plugin-discovery.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/plugin-discovery.test.ts",
+      "summary": "Unit tests for plugin discovery, verifying default config, parsing, and serialization of plugin configuration.",
+      "tags": [
+        "test",
+        "plugin",
+        "discovery",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/batch.ts",
+      "type": "file",
+      "name": "batch.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/batch.ts",
+      "summary": "Language configuration for Windows Batch scripts, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "batch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/c.ts",
+      "type": "file",
+      "name": "c.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/c.ts",
+      "summary": "Language configuration for C, declaring tree-sitter settings and file patterns for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/cpp.ts",
+      "type": "file",
+      "name": "cpp.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/cpp.ts",
+      "summary": "Language configuration for C++, declaring tree-sitter settings and file patterns for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/csharp.ts",
+      "type": "file",
+      "name": "csharp.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/csharp.ts",
+      "summary": "Language configuration for C#, declaring tree-sitter settings and file patterns for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/css.ts",
+      "type": "file",
+      "name": "css.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/css.ts",
+      "summary": "Language configuration for CSS, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "markup"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/csv.ts",
+      "type": "file",
+      "name": "csv.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/csv.ts",
+      "summary": "Language configuration for CSV data files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "data"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/dart.ts",
+      "type": "file",
+      "name": "dart.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/dart.ts",
+      "summary": "Language configuration for Dart, declaring tree-sitter settings and file patterns for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/dockerfile.ts",
+      "type": "file",
+      "name": "dockerfile.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/dockerfile.ts",
+      "summary": "Language configuration for Dockerfiles, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/env.ts",
+      "type": "file",
+      "name": "env.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/env.ts",
+      "summary": "Language configuration for dotenv (.env) files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/github-actions.ts",
+      "type": "file",
+      "name": "github-actions.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/github-actions.ts",
+      "summary": "Language configuration for GitHub Actions workflow files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "ci-cd"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/go.ts",
+      "type": "file",
+      "name": "go.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/go.ts",
+      "summary": "Language configuration for Go, declaring tree-sitter settings and file patterns for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/graphql.ts",
+      "type": "file",
+      "name": "graphql.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/graphql.ts",
+      "summary": "Language configuration for GraphQL schema files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "schema-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/html.ts",
+      "type": "file",
+      "name": "html.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/html.ts",
+      "summary": "Language configuration for HTML, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "markup"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "summary": "Barrel module aggregating every built-in language configuration into the builtinLanguageConfigs array and re-exporting each config for consumption by the language registry.",
+      "tags": [
+        "barrel",
+        "entry-point",
+        "language-config",
+        "aggregation"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "TypeScript barrel that both re-exports individual configs and assembles them into a single registration array."
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/java.ts",
+      "type": "file",
+      "name": "java.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/java.ts",
+      "summary": "Language configuration for Java, declaring tree-sitter settings and file patterns for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/javascript.ts",
+      "type": "file",
+      "name": "javascript.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/javascript.ts",
+      "summary": "Language configuration for JavaScript, declaring tree-sitter settings and file patterns for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/jenkinsfile.ts",
+      "type": "file",
+      "name": "jenkinsfile.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/jenkinsfile.ts",
+      "summary": "Language configuration for Jenkinsfiles, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "ci-cd"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/json-config.ts",
+      "type": "file",
+      "name": "json-config.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/json-config.ts",
+      "summary": "Language configuration for JSON files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/json-schema.ts",
+      "type": "file",
+      "name": "json-schema.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/json-schema.ts",
+      "summary": "Language configuration for JSON Schema files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "schema-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/kotlin.ts",
+      "type": "file",
+      "name": "kotlin.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/kotlin.ts",
+      "summary": "Language configuration for Kotlin, declaring tree-sitter settings and file patterns for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/kubernetes.ts",
+      "type": "file",
+      "name": "kubernetes.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/kubernetes.ts",
+      "summary": "Language configuration for Kubernetes manifest files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/lua.ts",
+      "type": "file",
+      "name": "lua.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/lua.ts",
+      "summary": "Language configuration for Lua, declaring tree-sitter settings and file patterns for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/makefile.ts",
+      "type": "file",
+      "name": "makefile.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/makefile.ts",
+      "summary": "Language configuration for Makefiles, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/markdown.ts",
+      "type": "file",
+      "name": "markdown.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/markdown.ts",
+      "summary": "Language configuration for Markdown files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "documentation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/openapi.ts",
+      "type": "file",
+      "name": "openapi.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/openapi.ts",
+      "summary": "Language configuration for OpenAPI/Swagger specification files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "api-schema"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/php.ts",
+      "type": "file",
+      "name": "php.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/php.ts",
+      "summary": "Language configuration for PHP, declaring tree-sitter settings and file patterns for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/plaintext.ts",
+      "type": "file",
+      "name": "plaintext.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/plaintext.ts",
+      "summary": "Language configuration for plain text files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "fallback"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/powershell.ts",
+      "type": "file",
+      "name": "powershell.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/powershell.ts",
+      "summary": "Declares the PowerShell language configuration (extensions, tree-sitter mapping, file patterns) consumed by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/protobuf.ts",
+      "type": "file",
+      "name": "protobuf.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/protobuf.ts",
+      "summary": "Declares the Protobuf language configuration used by the language registry for detecting and parsing .proto files.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/python.ts",
+      "type": "file",
+      "name": "python.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/python.ts",
+      "summary": "Declares the Python language configuration including extensions, tree-sitter node mappings, and import/definition patterns.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/restructuredtext.ts",
+      "type": "file",
+      "name": "restructuredtext.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/restructuredtext.ts",
+      "summary": "Declares the reStructuredText language configuration consumed by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/ruby.ts",
+      "type": "file",
+      "name": "ruby.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/ruby.ts",
+      "summary": "Declares the Ruby language configuration with extensions and tree-sitter parsing rules used by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/rust.ts",
+      "type": "file",
+      "name": "rust.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/rust.ts",
+      "summary": "Declares the Rust language configuration with extensions and tree-sitter parsing rules used by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/shell.ts",
+      "type": "file",
+      "name": "shell.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/shell.ts",
+      "summary": "Declares the shell scripting language configuration consumed by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/sql.ts",
+      "type": "file",
+      "name": "sql.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/sql.ts",
+      "summary": "Declares the SQL language configuration consumed by the language registry for detecting and parsing SQL files.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/swift.ts",
+      "type": "file",
+      "name": "swift.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/swift.ts",
+      "summary": "Declares the Swift language configuration with extensions and parsing rules used by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/terraform.ts",
+      "type": "file",
+      "name": "terraform.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/terraform.ts",
+      "summary": "Declares the Terraform/HCL language configuration consumed by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/toml.ts",
+      "type": "file",
+      "name": "toml.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/toml.ts",
+      "summary": "Declares the TOML language configuration consumed by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/typescript.ts",
+      "type": "file",
+      "name": "typescript.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/typescript.ts",
+      "summary": "Declares the TypeScript language configuration including extensions, tree-sitter node mappings, and import/definition patterns used by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/xml.ts",
+      "type": "file",
+      "name": "xml.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/xml.ts",
+      "summary": "Declares the XML language configuration consumed by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/yaml.ts",
+      "type": "file",
+      "name": "yaml.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/yaml.ts",
+      "summary": "Declares the YAML language configuration consumed by the language registry.",
+      "tags": [
+        "language-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+      "type": "file",
+      "name": "framework-registry.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+      "summary": "Defines the FrameworkRegistry that registers framework configs, indexes them by id and language, and detects frameworks from project manifests.",
+      "tags": [
+        "registry",
+        "service",
+        "framework-detection",
+        "factory",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/django.ts",
+      "type": "file",
+      "name": "django.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/django.ts",
+      "summary": "Declares the Django framework detection config (keywords, manifests, conventions) registered with the framework registry.",
+      "tags": [
+        "framework-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/express.ts",
+      "type": "file",
+      "name": "express.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/express.ts",
+      "summary": "Declares the Express framework detection config registered with the framework registry.",
+      "tags": [
+        "framework-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/fastapi.ts",
+      "type": "file",
+      "name": "fastapi.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/fastapi.ts",
+      "summary": "Declares the FastAPI framework detection config registered with the framework registry.",
+      "tags": [
+        "framework-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/flask.ts",
+      "type": "file",
+      "name": "flask.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/flask.ts",
+      "summary": "Declares the Flask framework detection config registered with the framework registry.",
+      "tags": [
+        "framework-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/gin.ts",
+      "type": "file",
+      "name": "gin.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/gin.ts",
+      "summary": "Declares the Gin (Go) framework detection config registered with the framework registry.",
+      "tags": [
+        "framework-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "summary": "Barrel module that aggregates all built-in framework configs into builtinFrameworkConfigs and re-exports each individual config.",
+      "tags": [
+        "barrel",
+        "entry-point",
+        "framework-config"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/nextjs.ts",
+      "type": "file",
+      "name": "nextjs.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/nextjs.ts",
+      "summary": "Declares the Next.js framework detection config registered with the framework registry.",
+      "tags": [
+        "framework-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/rails.ts",
+      "type": "file",
+      "name": "rails.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/rails.ts",
+      "summary": "Declares the Ruby on Rails framework detection config registered with the framework registry.",
+      "tags": [
+        "framework-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/react.ts",
+      "type": "file",
+      "name": "react.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/react.ts",
+      "summary": "Declares the React framework detection config registered with the framework registry.",
+      "tags": [
+        "framework-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/spring.ts",
+      "type": "file",
+      "name": "spring.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/spring.ts",
+      "summary": "Declares the Spring (Java) framework detection config registered with the framework registry.",
+      "tags": [
+        "framework-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/frameworks/vue.ts",
+      "type": "file",
+      "name": "vue.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/frameworks/vue.ts",
+      "summary": "Declares the Vue framework detection config registered with the framework registry.",
+      "tags": [
+        "framework-config",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "type": "file",
+      "name": "language-registry.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "summary": "Defines the LanguageRegistry that registers language configs and resolves a language by id, file extension, or filename.",
+      "tags": [
+        "registry",
+        "service",
+        "language-detection",
+        "factory",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "file",
+      "name": "types.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/types.ts",
+      "summary": "Defines Zod schemas and derived types for language and framework configurations (tree-sitter, file patterns, strict configs).",
+      "tags": [
+        "type-definition",
+        "validation",
+        "schema-definition"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses Zod schemas as the single source of truth, deriving TypeScript types via z.infer."
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "type": "file",
+      "name": "discovery.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "summary": "Parses and serializes plugin configuration JSON, validating plugin entries and providing the default plugin config.",
+      "tags": [
+        "plugin",
+        "serialization",
+        "validation",
+        "configuration",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/languages/framework-registry.ts:FrameworkRegistry",
+      "type": "class",
+      "name": "FrameworkRegistry",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+      "lineRange": [
+        9,
+        86
+      ],
+      "summary": "Registry that stores framework configs indexed by id and language, validates them on registration, and detects frameworks by scanning manifest contents for keywords.",
+      "tags": [
+        "registry",
+        "framework-detection",
+        "factory"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/languages/language-registry.ts:LanguageRegistry",
+      "type": "class",
+      "name": "LanguageRegistry",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "lineRange": [
+        9,
+        64
+      ],
+      "summary": "Registry that stores language configs indexed by id, extension, and filename, and resolves the appropriate language for a given file path.",
+      "tags": [
+        "registry",
+        "language-detection",
+        "factory"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/plugins/discovery.ts:parsePluginConfig",
+      "type": "function",
+      "name": "parsePluginConfig",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "lineRange": [
+        30,
+        61
+      ],
+      "summary": "Parses a plugin config JSON string, validating each plugin entry has a name and a non-empty languages array, falling back to defaults when invalid.",
+      "tags": [
+        "parsing",
+        "validation",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/plugins/discovery.ts:serializePluginConfig",
+      "type": "function",
+      "name": "serializePluginConfig",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "lineRange": [
+        66,
+        68
+      ],
+      "summary": "Serializes a plugin config object to a formatted JSON string.",
+      "tags": [
+        "serialization",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cpp-extractor.test.ts",
+      "type": "file",
+      "name": "cpp-extractor.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cpp-extractor.test.ts",
+      "summary": "Vitest suite exercising the CppExtractor against parsed C++ source, asserting extracted functions, classes/structs, includes, and call graph.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "extractor",
+        "cpp"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts",
+      "type": "file",
+      "name": "csharp-extractor.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts",
+      "summary": "Vitest suite validating CSharpExtractor structural extraction (classes, interfaces, methods, properties, usings) and call graph from parsed C# code.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "extractor",
+        "csharp"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/dart-extractor.test.ts",
+      "type": "file",
+      "name": "dart-extractor.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/dart-extractor.test.ts",
+      "summary": "Vitest suite covering DartExtractor extraction of top-level functions, classes, extensions, enums, imports/exports, and call graph.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "extractor",
+        "dart"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts",
+      "type": "file",
+      "name": "go-extractor.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts",
+      "summary": "Vitest suite validating GoExtractor extraction of functions, methods with receivers, structs, interfaces, imports, and call graph.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "extractor",
+        "golang"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/java-extractor.test.ts",
+      "type": "file",
+      "name": "java-extractor.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/java-extractor.test.ts",
+      "summary": "Vitest suite validating JavaExtractor extraction of classes, interfaces, methods, fields, and imports from parsed Java source.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "extractor",
+        "java"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/kotlin-extractor.test.ts",
+      "type": "file",
+      "name": "kotlin-extractor.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/kotlin-extractor.test.ts",
+      "summary": "Vitest suite covering KotlinExtractor extraction of functions, classes, visibility-based exports, properties, and primary constructor parameters.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "extractor",
+        "kotlin"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts",
+      "type": "file",
+      "name": "php-extractor.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts",
+      "summary": "Vitest suite validating PhpExtractor extraction of functions, classes, methods, properties, and use statements from parsed PHP source.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "extractor",
+        "php"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts",
+      "type": "file",
+      "name": "python-extractor.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts",
+      "summary": "Vitest suite validating PythonExtractor extraction of functions, classes, decorated definitions, parameters, and imports.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "extractor",
+        "python"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts",
+      "type": "file",
+      "name": "ruby-extractor.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts",
+      "summary": "Vitest suite validating RubyExtractor extraction of methods, classes, modules, attr accessors, and require statements.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "extractor",
+        "ruby"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/rust-extractor.test.ts",
+      "type": "file",
+      "name": "rust-extractor.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/rust-extractor.test.ts",
+      "summary": "Vitest suite validating RustExtractor extraction of functions, structs, enums, traits, impl blocks, and use declarations.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "extractor",
+        "rust"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "file",
+      "name": "base-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "summary": "Shared tree-sitter AST traversal helpers (traverse, getStringValue, findChild, findChildren, hasChildOfType) used by every language extractor.",
+      "tags": [
+        "utility",
+        "tree-sitter",
+        "ast",
+        "extractor"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "type": "file",
+      "name": "cpp-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "summary": "Language extractor that walks a C++ tree-sitter AST to extract functions, classes/structs, includes, and a call graph.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "cpp",
+        "ast",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "type": "file",
+      "name": "csharp-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "summary": "Language extractor that walks a C# tree-sitter AST to extract namespaces, classes, interfaces, methods, properties, fields, and a call graph.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "csharp",
+        "ast",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "type": "file",
+      "name": "dart-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "summary": "Language extractor that walks a Dart tree-sitter AST to extract top-level functions, classes, extensions, enums, imports/exports, and a call graph.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "dart",
+        "ast",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "type": "file",
+      "name": "go-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "summary": "Language extractor that walks a Go tree-sitter AST to extract functions, receiver methods, structs, interfaces, imports, and a call graph.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "golang",
+        "ast",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "summary": "Barrel module re-exporting all language extractors, base helpers, and types, plus the builtinExtractors registry consumed by the tree-sitter plugin.",
+      "tags": [
+        "barrel",
+        "entry-point",
+        "extractor",
+        "registry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "type": "file",
+      "name": "java-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "summary": "Language extractor that walks a Java tree-sitter AST to extract classes, interfaces, methods, fields, and imports.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "java",
+        "ast",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "type": "file",
+      "name": "kotlin-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "summary": "Language extractor that walks a Kotlin tree-sitter AST to extract functions, classes, visibility-aware exports, properties, and constructor parameters.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "kotlin",
+        "ast",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "type": "file",
+      "name": "php-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "summary": "Language extractor that walks a PHP tree-sitter AST to extract functions, classes, methods, properties, and use statements.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "php",
+        "ast",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "type": "file",
+      "name": "python-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "summary": "Language extractor that walks a Python tree-sitter AST to extract functions, classes, decorated definitions, parameters, and imports.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "python",
+        "ast",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "type": "file",
+      "name": "ruby-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "summary": "Language extractor that walks a Ruby tree-sitter AST to extract methods, classes, modules, attr accessors, and require statements.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "ruby",
+        "ast",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "type": "file",
+      "name": "rust-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "summary": "Language extractor that walks a Rust tree-sitter AST to extract functions, structs, enums, traits, impl blocks, and use declarations.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "rust",
+        "ast",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "file",
+      "name": "types.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "summary": "Type definitions shared by the extractor layer, including the LanguageExtractor interface and tree-sitter node aliases.",
+      "tags": [
+        "type-definition",
+        "extractor",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "type": "file",
+      "name": "typescript-extractor.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "summary": "Language extractor that walks a TypeScript/JavaScript tree-sitter AST to extract functions, classes, import specifiers, and a call graph.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "typescript",
+        "ast"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.test.ts",
+      "type": "file",
+      "name": "tree-sitter-plugin.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.test.ts",
+      "summary": "Vitest suite validating the TreeSitterPlugin's language detection, extractor dispatch, and structural/call-graph aggregation.",
+      "tags": [
+        "test",
+        "tree-sitter",
+        "plugin",
+        "integration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "type": "file",
+      "name": "tree-sitter-plugin.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "summary": "Orchestrating plugin that loads tree-sitter grammars and dispatches parsed files to the appropriate language extractor from the builtin registry.",
+      "tags": [
+        "plugin",
+        "tree-sitter",
+        "orchestration",
+        "extractor",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts:traverse",
+      "type": "function",
+      "name": "traverse",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "lineRange": [
+        4,
+        13
+      ],
+      "summary": "Recursively walks a tree-sitter node and its children, invoking a visitor callback on each node.",
+      "tags": [
+        "utility",
+        "tree-sitter",
+        "ast",
+        "traversal"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts:findChildren",
+      "type": "function",
+      "name": "findChildren",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "lineRange": [
+        36,
+        43
+      ],
+      "summary": "Returns all immediate child nodes of a given tree-sitter node type.",
+      "tags": [
+        "utility",
+        "tree-sitter",
+        "ast"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts:CppExtractor",
+      "type": "class",
+      "name": "CppExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "lineRange": [
+        124,
+        501
+      ],
+      "summary": "LanguageExtractor implementation for C++ that extracts structure (functions, classes/structs, includes) and call graph from a tree-sitter AST.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "cpp",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts:CSharpExtractor",
+      "type": "class",
+      "name": "CSharpExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "lineRange": [
+        126,
+        524
+      ],
+      "summary": "LanguageExtractor implementation for C# extracting namespaces, classes, interfaces, methods, properties, fields, and a call graph.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "csharp",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts:DartExtractor",
+      "type": "class",
+      "name": "DartExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "lineRange": [
+        304,
+        736
+      ],
+      "summary": "LanguageExtractor implementation for Dart extracting top-level functions, classes, extensions, enums, imports/exports, and a call graph.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "dart",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts:GoExtractor",
+      "type": "class",
+      "name": "GoExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "lineRange": [
+        89,
+        402
+      ],
+      "summary": "LanguageExtractor implementation for Go extracting functions, receiver methods, structs, interfaces, imports, and a call graph.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "golang",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts:JavaExtractor",
+      "type": "class",
+      "name": "JavaExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "lineRange": [
+        96,
+        449
+      ],
+      "summary": "LanguageExtractor implementation for Java extracting classes, interfaces, methods, fields, and imports.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "java",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts:KotlinExtractor",
+      "type": "class",
+      "name": "KotlinExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "lineRange": [
+        183,
+        425
+      ],
+      "summary": "LanguageExtractor implementation for Kotlin extracting functions, classes, visibility-aware exports, properties, and primary constructor parameters.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "kotlin",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts:PhpExtractor",
+      "type": "class",
+      "name": "PhpExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "lineRange": [
+        115,
+        461
+      ],
+      "summary": "LanguageExtractor implementation for PHP extracting functions, classes, methods, properties, and use statements.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "php",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts:PythonExtractor",
+      "type": "class",
+      "name": "PythonExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "lineRange": [
+        102,
+        353
+      ],
+      "summary": "LanguageExtractor implementation for Python extracting functions, classes, decorated definitions, parameters, and imports.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "python",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts:RubyExtractor",
+      "type": "class",
+      "name": "RubyExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "lineRange": [
+        111,
+        420
+      ],
+      "summary": "LanguageExtractor implementation for Ruby extracting methods, classes, modules, attr accessors, and require statements.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "ruby",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts:RustExtractor",
+      "type": "class",
+      "name": "RustExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "lineRange": [
+        92,
+        509
+      ],
+      "summary": "LanguageExtractor implementation for Rust extracting functions, structs, enums, traits, impl blocks, and use declarations.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "rust",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts:TypeScriptExtractor",
+      "type": "class",
+      "name": "TypeScriptExtractor",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "lineRange": [
+        106,
+        494
+      ],
+      "summary": "LanguageExtractor implementation for TypeScript/JavaScript extracting functions, classes, import specifiers, and a call graph.",
+      "tags": [
+        "extractor",
+        "tree-sitter",
+        "typescript",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts:TreeSitterPlugin",
+      "type": "class",
+      "name": "TreeSitterPlugin",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "lineRange": [
+        31,
+        299
+      ],
+      "summary": "Plugin that loads tree-sitter grammars, detects the language for each file, and dispatches parsing to the matching extractor from the builtin registry.",
+      "tags": [
+        "plugin",
+        "tree-sitter",
+        "orchestration",
+        "class"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "type": "file",
+      "name": "GraphView.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "summary": "Core structural graph view that builds overview and per-layer detail topologies with containers and portals, applies ELK/dagre/force layouts, and orchestrates React Flow rendering, fit-view, and tour interactions.",
+      "tags": [
+        "component",
+        "graph-view",
+        "layout",
+        "react-flow",
+        "core"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Largest dashboard module (~1.5k lines) composing many custom hooks for layout topology generation and view fitting."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx:useOverviewGraph",
+      "type": "function",
+      "name": "useOverviewGraph",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "lineRange": [
+        211,
+        329
+      ],
+      "summary": "Hook that derives the layer-cluster overview topology (nodes and aggregated edges) from the graph and layer stats.",
+      "tags": [
+        "hook",
+        "graph-construction",
+        "layout"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx:useLayerDetailTopology",
+      "type": "function",
+      "name": "useLayerDetailTopology",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "lineRange": [
+        365,
+        902
+      ],
+      "summary": "Hook that computes the detailed in-layer topology with containers, portals, and cross-layer edge aggregation for the drilled-in view.",
+      "tags": [
+        "hook",
+        "graph-construction",
+        "layout",
+        "core"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx:useLayerDetailGraph",
+      "type": "function",
+      "name": "useLayerDetailGraph",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "lineRange": [
+        960,
+        1295
+      ],
+      "summary": "Hook that turns the layer detail topology into positioned React Flow nodes/edges by applying the active layout engine.",
+      "tags": [
+        "hook",
+        "layout",
+        "react-flow"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx:GraphViewInner",
+      "type": "function",
+      "name": "GraphViewInner",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "lineRange": [
+        1299,
+        1573
+      ],
+      "summary": "Inner component rendering the React Flow canvas with the selected overview/detail graph, controls, minimap, and fit-view behaviors.",
+      "tags": [
+        "component",
+        "graph-view",
+        "react-flow"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx:TourFitView",
+      "type": "function",
+      "name": "TourFitView",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "lineRange": [
+        95,
+        179
+      ],
+      "summary": "Helper component that fits the React Flow viewport to the current tour step's highlighted nodes.",
+      "tags": [
+        "component",
+        "react-flow",
+        "tour"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx",
+      "type": "file",
+      "name": "KeyboardShortcutsHelp.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx",
+      "summary": "Modal overlay listing available keyboard shortcuts, formatting key bindings from the shortcuts hook.",
+      "tags": [
+        "component",
+        "keyboard-shortcuts",
+        "modal",
+        "ui"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx:KeyboardShortcutsHelp",
+      "type": "function",
+      "name": "KeyboardShortcutsHelp",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx",
+      "lineRange": [
+        10,
+        105
+      ],
+      "summary": "Renders a dismissible help modal enumerating shortcut keys and their descriptions.",
+      "tags": [
+        "component",
+        "keyboard-shortcuts",
+        "modal"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "type": "file",
+      "name": "KnowledgeGraphView.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "summary": "Renders the wiki knowledge-graph variant as a React Flow diagram, computing node dimensions and a force/dagre layout over CustomNode instances.",
+      "tags": [
+        "component",
+        "graph-view",
+        "layout",
+        "react-flow",
+        "knowledge"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx:computeLayout",
+      "type": "function",
+      "name": "computeLayout",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "lineRange": [
+        51,
+        94
+      ],
+      "summary": "Computes positioned nodes and edges for the knowledge graph using the configured layout algorithm and per-node dimensions.",
+      "tags": [
+        "utility",
+        "layout",
+        "graph-construction"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx:KnowledgeGraphViewInner",
+      "type": "function",
+      "name": "KnowledgeGraphViewInner",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "lineRange": [
+        96,
+        284
+      ],
+      "summary": "Inner component rendering the knowledge graph React Flow canvas with computed layout, controls, and node selection.",
+      "tags": [
+        "component",
+        "graph-view",
+        "react-flow",
+        "knowledge"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx",
+      "type": "file",
+      "name": "LayerClusterNode.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx",
+      "summary": "React Flow node representing an architectural layer cluster in the overview graph, colored by layer and showing aggregate stats.",
+      "tags": [
+        "component",
+        "graph-node",
+        "react-flow",
+        "layer"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx:LayerClusterNode",
+      "type": "function",
+      "name": "LayerClusterNode",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx",
+      "lineRange": [
+        25,
+        102
+      ],
+      "summary": "Renders a clickable layer cluster node with layer color, label, and node-count badge for drilling into the layer.",
+      "tags": [
+        "component",
+        "graph-node",
+        "layer"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "type": "file",
+      "name": "LayerLegend.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "summary": "Legend component mapping architectural layers to palette colors, exporting the shared layer palette and color lookup helper used across graph nodes.",
+      "tags": [
+        "component",
+        "legend",
+        "layer",
+        "ui"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx:LayerLegend",
+      "type": "function",
+      "name": "LayerLegend",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "lineRange": [
+        19,
+        72
+      ],
+      "summary": "Renders the legend listing each layer with its color swatch and label.",
+      "tags": [
+        "component",
+        "legend",
+        "layer"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx:getLayerColor",
+      "type": "function",
+      "name": "getLayerColor",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "lineRange": [
+        15,
+        17
+      ],
+      "summary": "Returns the palette color for a given layer index, exported for reuse by graph node components.",
+      "tags": [
+        "utility",
+        "layer",
+        "color"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx",
+      "type": "file",
+      "name": "LearnPanel.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx",
+      "summary": "Sidebar panel for the Learn persona that presents guided tour content and learning context derived from the dashboard store.",
+      "tags": [
+        "component",
+        "learn",
+        "sidebar",
+        "tour"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx:LearnPanel",
+      "type": "function",
+      "name": "LearnPanel",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx",
+      "lineRange": [
+        6,
+        230
+      ],
+      "summary": "Renders the Learn-mode sidebar with tour steps and progress, bound to the dashboard store.",
+      "tags": [
+        "component",
+        "learn",
+        "tour"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx",
+      "type": "file",
+      "name": "MobileBottomNav.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx",
+      "summary": "Bottom navigation bar for the mobile layout switching between primary dashboard views.",
+      "tags": [
+        "component",
+        "mobile",
+        "navigation",
+        "ui"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx:MobileBottomNav",
+      "type": "function",
+      "name": "MobileBottomNav",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx",
+      "lineRange": [
+        39,
+        71
+      ],
+      "summary": "Renders the mobile bottom nav buttons and reports the selected view to its parent.",
+      "tags": [
+        "component",
+        "mobile",
+        "navigation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "type": "file",
+      "name": "MobileDrawer.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "summary": "Slide-in drawer for mobile aggregating filters, export, diff toggle, theme/persona selectors, and layer legend in a single panel.",
+      "tags": [
+        "component",
+        "mobile",
+        "drawer",
+        "ui"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx:MobileDrawer",
+      "type": "function",
+      "name": "MobileDrawer",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "lineRange": [
+        34,
+        266
+      ],
+      "summary": "Renders the mobile settings/tools drawer composing filter, export, theme, persona, and legend sections.",
+      "tags": [
+        "component",
+        "mobile",
+        "drawer"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "type": "file",
+      "name": "MobileLayout.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "summary": "Top-level mobile layout shell that wires the graph/domain/knowledge views, search, project overview, node info, and bottom nav/drawer into a responsive mobile experience.",
+      "tags": [
+        "component",
+        "mobile",
+        "layout",
+        "container"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx:MobileLayout",
+      "type": "function",
+      "name": "MobileLayout",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "lineRange": [
+        31,
+        233
+      ],
+      "summary": "Composes the mobile dashboard views, navigation, and drawer based on the selected view and store state.",
+      "tags": [
+        "component",
+        "mobile",
+        "layout"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "type": "file",
+      "name": "NodeInfo.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "summary": "Sidebar detail panel for the selected node, rendering summary, tags, complexity, relationships, and specialized views for knowledge and domain node types.",
+      "tags": [
+        "component",
+        "sidebar",
+        "node-detail",
+        "ui"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx:NodeInfo",
+      "type": "function",
+      "name": "NodeInfo",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "lineRange": [
+        259,
+        539
+      ],
+      "summary": "Renders the full node-detail panel including metadata, incoming/outgoing relationships, and navigation into related nodes.",
+      "tags": [
+        "component",
+        "node-detail",
+        "navigation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx:KnowledgeNodeDetails",
+      "type": "function",
+      "name": "KnowledgeNodeDetails",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "lineRange": [
+        46,
+        136
+      ],
+      "summary": "Renders detail fields specific to knowledge-graph nodes such as entities, claims, and topic relationships.",
+      "tags": [
+        "component",
+        "node-detail",
+        "knowledge"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx:DomainNodeDetails",
+      "type": "function",
+      "name": "DomainNodeDetails",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "lineRange": [
+        138,
+        257
+      ],
+      "summary": "Renders detail fields specific to domain/flow/step nodes including flows, steps, and cross-domain links.",
+      "tags": [
+        "component",
+        "node-detail",
+        "domain"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx",
+      "type": "file",
+      "name": "NodeTooltip.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx",
+      "summary": "Hover tooltip rendering a compact preview of a graph node's name, type, and summary, reusing CustomNode styling.",
+      "tags": [
+        "component",
+        "tooltip",
+        "ui"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx:NodeTooltip",
+      "type": "function",
+      "name": "NodeTooltip",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx",
+      "lineRange": [
+        12,
+        124
+      ],
+      "summary": "Renders the positioned node hover tooltip with name, type badge, and truncated summary.",
+      "tags": [
+        "component",
+        "tooltip"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx",
+      "type": "file",
+      "name": "OnboardingOverlay.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx",
+      "summary": "First-run onboarding overlay walking new users through dashboard features, dismissible and persisted to localStorage.",
+      "tags": [
+        "component",
+        "onboarding",
+        "overlay",
+        "ui"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx:OnboardingOverlay",
+      "type": "function",
+      "name": "OnboardingOverlay",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx",
+      "lineRange": [
+        21,
+        130
+      ],
+      "summary": "Renders the multi-step onboarding overlay with navigation controls and a dismiss action.",
+      "tags": [
+        "component",
+        "onboarding",
+        "overlay"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "type": "file",
+      "name": "App.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "summary": "Root dashboard application component that bootstraps the token gate, fetches and validates the knowledge graph plus diff/domain overlays, and wires the graph-first layout with sidebar, view modes, and keyboard shortcuts.",
+      "tags": [
+        "entry-point",
+        "component",
+        "data-loading",
+        "layout",
+        "state"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Composes multiple useDashboardStore selectors and chained fetch().then() pipelines feeding Zustand store actions."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/App.tsx:Dashboard",
+      "type": "function",
+      "name": "Dashboard",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "lineRange": [
+        110,
+        220
+      ],
+      "summary": "Loads meta, config, knowledge-graph, diff-overlay, and domain-graph JSON via token-scoped fetches, validates them, and seeds the dashboard store before rendering DashboardContent.",
+      "tags": [
+        "component",
+        "data-loading",
+        "validation",
+        "effect"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/App.tsx:DashboardContent",
+      "type": "function",
+      "name": "DashboardContent",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "lineRange": [
+        222,
+        713
+      ],
+      "summary": "Main dashboard chrome rendering the graph view, sidebar tabs, view-mode and detail-level controls, node-type filters, and registering keyboard shortcuts against store actions.",
+      "tags": [
+        "component",
+        "layout",
+        "event-handler",
+        "keyboard-shortcuts"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/App.tsx:dataUrl",
+      "type": "function",
+      "name": "dataUrl",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "lineRange": [
+        50,
+        66
+      ],
+      "summary": "Builds a base-aware, access-token-scoped URL for fetching dashboard data JSON files from the dev server.",
+      "tags": [
+        "utility",
+        "url",
+        "data-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/App.tsx:resolveInitialToken",
+      "type": "function",
+      "name": "resolveInitialToken",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "lineRange": [
+        72,
+        87
+      ],
+      "summary": "Resolves the initial access token from the URL query string, persisting it to sessionStorage and scrubbing it from the visible URL.",
+      "tags": [
+        "utility",
+        "security",
+        "session"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx",
+      "type": "file",
+      "name": "Breadcrumb.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx",
+      "summary": "Renders a navigation breadcrumb reflecting the current overview/layer drill-down state from the dashboard store.",
+      "tags": [
+        "component",
+        "navigation",
+        "ui"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+      "type": "file",
+      "name": "CodeViewer.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+      "summary": "Slide-up/full-screen source code viewer that fetches file content via a token-gated endpoint and renders it with prism-react-renderer syntax highlighting.",
+      "tags": [
+        "component",
+        "code-viewer",
+        "data-loading",
+        "syntax-highlighting"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx:CodeViewer",
+      "type": "function",
+      "name": "CodeViewer",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+      "lineRange": [
+        59,
+        259
+      ],
+      "summary": "Component that loads and displays the selected file's source with loading/error states, supporting sidebar and expanded modal presentations.",
+      "tags": [
+        "component",
+        "code-viewer",
+        "data-loading"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx:fallbackLanguage",
+      "type": "function",
+      "name": "fallbackLanguage",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+      "lineRange": [
+        31,
+        51
+      ],
+      "summary": "Infers a Prism language id from a file extension for syntax highlighting when no explicit language is provided.",
+      "tags": [
+        "utility",
+        "syntax-highlighting"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx",
+      "type": "file",
+      "name": "ContainerNode.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx",
+      "summary": "React Flow custom node rendering a collapsible directory/container grouping with layer coloring and a toggle handler.",
+      "tags": [
+        "component",
+        "graph-node",
+        "react-flow"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx:ContainerNodeComponent",
+      "type": "function",
+      "name": "ContainerNodeComponent",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx",
+      "lineRange": [
+        21,
+        96
+      ],
+      "summary": "Renders the container node body with layer-derived color and an expand/collapse toggle that stops event propagation.",
+      "tags": [
+        "component",
+        "graph-node",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx",
+      "type": "file",
+      "name": "CustomNode.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx",
+      "summary": "Primary React Flow node component rendering a graph node with type-based styling, tags, diff highlighting, and click handling.",
+      "tags": [
+        "component",
+        "graph-node",
+        "react-flow",
+        "ui"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx:CustomNodeComponent",
+      "type": "function",
+      "name": "CustomNodeComponent",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx",
+      "lineRange": [
+        84,
+        187
+      ],
+      "summary": "Renders an individual knowledge-graph node with label truncation, tag badges, and an onNodeClick callback.",
+      "tags": [
+        "component",
+        "graph-node",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+      "type": "file",
+      "name": "DiffToggle.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+      "summary": "Toggle control that enables/disables diff-overlay mode in the graph, reading and updating the dashboard store.",
+      "tags": [
+        "component",
+        "ui",
+        "diff",
+        "control"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx:DiffToggle",
+      "type": "function",
+      "name": "DiffToggle",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+      "lineRange": [
+        4,
+        66
+      ],
+      "summary": "Renders a diff-mode toggle button bound to the store's diff overlay state.",
+      "tags": [
+        "component",
+        "control",
+        "diff"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx",
+      "type": "file",
+      "name": "DomainClusterNode.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx",
+      "summary": "React Flow node representing a business domain cluster, listing sample entities and navigating into the domain detail view on click.",
+      "tags": [
+        "component",
+        "graph-node",
+        "domain",
+        "navigation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx:DomainClusterNode",
+      "type": "function",
+      "name": "DomainClusterNode",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx",
+      "lineRange": [
+        17,
+        64
+      ],
+      "summary": "Renders a domain cluster node with entity preview and a click handler that selects the node and drills into the domain.",
+      "tags": [
+        "component",
+        "graph-node",
+        "domain"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "type": "file",
+      "name": "DomainGraphView.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "summary": "Renders the domain knowledge graph as a React Flow diagram, building overview (domains) or detail (flows and steps) topologies and laying them out via ELK.",
+      "tags": [
+        "component",
+        "domain",
+        "graph-view",
+        "layout",
+        "react-flow"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx:buildDomainOverview",
+      "type": "function",
+      "name": "buildDomainOverview",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "lineRange": [
+        41,
+        88
+      ],
+      "summary": "Constructs the domain-overview node/edge topology from domain nodes and cross-domain edges, sizing nodes by contained flow count.",
+      "tags": [
+        "utility",
+        "domain",
+        "graph-construction"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx:buildDomainDetail",
+      "type": "function",
+      "name": "buildDomainDetail",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "lineRange": [
+        90,
+        165
+      ],
+      "summary": "Builds the detailed flow-and-step topology for a single domain from contains_flow and step edges, ordering steps and sizing nodes.",
+      "tags": [
+        "utility",
+        "domain",
+        "graph-construction"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx:DomainGraphViewInner",
+      "type": "function",
+      "name": "DomainGraphViewInner",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "lineRange": [
+        167,
+        271
+      ],
+      "summary": "Inner component that memoizes the domain topology, applies async ELK layout, surfaces layout issues to the store, and renders the React Flow canvas.",
+      "tags": [
+        "component",
+        "domain",
+        "layout",
+        "react-flow"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "type": "file",
+      "name": "ExportMenu.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "summary": "Dropdown menu that exports the current graph as PNG, SVG, or filtered JSON, building a clean SVG from React Flow nodes/edges and triggering browser downloads.",
+      "tags": [
+        "component",
+        "export",
+        "serialization",
+        "ui"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx:ExportMenu",
+      "type": "function",
+      "name": "ExportMenu",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "lineRange": [
+        22,
+        279
+      ],
+      "summary": "Renders the export dropdown with click-outside handling and PNG/SVG/JSON export actions that filter and serialize the graph.",
+      "tags": [
+        "component",
+        "export",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx:downloadBlob",
+      "type": "function",
+      "name": "downloadBlob",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "lineRange": [
+        11,
+        20
+      ],
+      "summary": "Triggers a browser file download for a Blob by creating a temporary object URL and anchor element.",
+      "tags": [
+        "utility",
+        "download",
+        "dom"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "type": "file",
+      "name": "FileExplorer.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "summary": "Builds and renders a collapsible file tree from the structural graph's file nodes, letting users navigate to and select files.",
+      "tags": [
+        "component",
+        "file-tree",
+        "navigation",
+        "ui"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx:buildFileTree",
+      "type": "function",
+      "name": "buildFileTree",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "lineRange": [
+        27,
+        82
+      ],
+      "summary": "Transforms a flat list of file-path nodes into a nested directory/file tree structure for rendering.",
+      "tags": [
+        "utility",
+        "file-tree",
+        "data-structure"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx:FileTreeRow",
+      "type": "function",
+      "name": "FileTreeRow",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "lineRange": [
+        84,
+        140
+      ],
+      "summary": "Recursive row component rendering a single file/folder entry with indentation, expand/collapse, and selection handling.",
+      "tags": [
+        "component",
+        "file-tree",
+        "recursion"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx:FileExplorer",
+      "type": "function",
+      "name": "FileExplorer",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "lineRange": [
+        142,
+        214
+      ],
+      "summary": "Top-level file explorer that derives the tree from the graph and renders the scrollable tree view.",
+      "tags": [
+        "component",
+        "file-tree",
+        "navigation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+      "type": "file",
+      "name": "FilterPanel.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+      "summary": "Panel providing controls to filter the graph by node type, complexity, and edge category, reading and updating filter state in the store.",
+      "tags": [
+        "component",
+        "filter",
+        "control",
+        "ui"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx:FilterPanel",
+      "type": "function",
+      "name": "FilterPanel",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+      "lineRange": [
+        6,
+        219
+      ],
+      "summary": "Renders node-type, complexity, and edge-category filter toggles bound to the dashboard store.",
+      "tags": [
+        "component",
+        "filter",
+        "control"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx",
+      "type": "file",
+      "name": "FlowNode.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx",
+      "summary": "React Flow custom node representing a business flow within the domain graph.",
+      "tags": [
+        "component",
+        "graph-node",
+        "domain",
+        "react-flow"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx:FlowNode",
+      "type": "function",
+      "name": "FlowNode",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx",
+      "lineRange": [
+        17,
+        50
+      ],
+      "summary": "Renders a flow node with label and handles for the domain detail graph.",
+      "tags": [
+        "component",
+        "graph-node",
+        "domain"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx",
+      "type": "file",
+      "name": "PathFinderModal.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx",
+      "summary": "Modal that lets users pick two graph nodes and runs a BFS over the edge list to find and visualize the shortest path between them.",
+      "tags": [
+        "component",
+        "modal",
+        "graph-traversal",
+        "path-finding"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Builds an undirected adjacency map from edges and runs breadth-first search to compute the shortest node path."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx:PathFinderModal",
+      "type": "function",
+      "name": "PathFinderModal",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx",
+      "lineRange": [
+        9,
+        311
+      ],
+      "summary": "React component rendering the path-finder modal: from/to node selectors, BFS shortest-path computation, and a clickable result trail.",
+      "tags": [
+        "component",
+        "modal",
+        "graph-traversal",
+        "react"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "type": "file",
+      "name": "PersonaSelector.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "summary": "Small control that lets the user switch the dashboard persona (e.g. explore vs. learn), reading and updating persona state in the store.",
+      "tags": [
+        "component",
+        "ui-control",
+        "persona",
+        "state"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx",
+      "type": "file",
+      "name": "PortalNode.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx",
+      "summary": "React Flow custom node representing a portal to another architectural layer, color-coded by layer and clickable to navigate.",
+      "tags": [
+        "component",
+        "react-flow",
+        "custom-node",
+        "navigation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx:PortalNode",
+      "type": "function",
+      "name": "PortalNode",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx",
+      "lineRange": [
+        16,
+        62
+      ],
+      "summary": "Renders a layer-portal node with a layer-derived accent color and an onNavigate click handler from node data.",
+      "tags": [
+        "component",
+        "react-flow",
+        "custom-node"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "type": "file",
+      "name": "ProjectOverview.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "summary": "Default sidebar panel summarizing the analyzed project: node/edge stats, category and type breakdowns, languages, frameworks, and most-connected nodes.",
+      "tags": [
+        "component",
+        "overview",
+        "statistics",
+        "sidebar"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Computes node-connection counts and type/complexity distributions from the graph at render time."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx:ProjectOverview",
+      "type": "function",
+      "name": "ProjectOverview",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "lineRange": [
+        4,
+        222
+      ],
+      "summary": "Computes and renders project-level statistics (connectivity, type/complexity breakdowns, languages, frameworks, top nodes) from the loaded graph.",
+      "tags": [
+        "component",
+        "overview",
+        "statistics"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "type": "file",
+      "name": "SearchBar.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "summary": "Search input with a results dropdown that queries graph nodes, supports search modes, and navigates to the selected node within its layer.",
+      "tags": [
+        "component",
+        "search",
+        "ui-control",
+        "navigation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx:SearchBar",
+      "type": "function",
+      "name": "SearchBar",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "lineRange": [
+        24,
+        191
+      ],
+      "summary": "Renders the search field and live results dropdown, handling keyboard escape, click-outside dismissal, search modes, and result selection.",
+      "tags": [
+        "component",
+        "search",
+        "react"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx",
+      "type": "file",
+      "name": "StepNode.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx",
+      "summary": "React Flow custom node representing a process step in the domain flow graph, selectable to drive the store's node selection.",
+      "tags": [
+        "component",
+        "react-flow",
+        "custom-node",
+        "domain-flow"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx:StepNode",
+      "type": "function",
+      "name": "StepNode",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx",
+      "lineRange": [
+        16,
+        51
+      ],
+      "summary": "Renders a domain-flow step node and dispatches selectNode to the store when clicked.",
+      "tags": [
+        "component",
+        "react-flow",
+        "custom-node"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "type": "file",
+      "name": "ThemePicker.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "summary": "Dropdown control for selecting a theme preset, accent swatch, and heading font, driving the theme context.",
+      "tags": [
+        "component",
+        "theme",
+        "ui-control",
+        "dropdown"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx:ThemePicker",
+      "type": "function",
+      "name": "ThemePicker",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "lineRange": [
+        6,
+        180
+      ],
+      "summary": "Renders the theme picker dropdown with preset, accent, and heading-font selection wired to the theme context.",
+      "tags": [
+        "component",
+        "theme",
+        "react"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx",
+      "type": "file",
+      "name": "TokenGate.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx",
+      "summary": "Access gate that prompts for an access token and validates it against the dev server before allowing dashboard content to load.",
+      "tags": [
+        "component",
+        "security",
+        "authentication",
+        "form"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx:TokenGate",
+      "type": "function",
+      "name": "TokenGate",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx",
+      "lineRange": [
+        7,
+        79
+      ],
+      "summary": "Renders a token-entry form, validates the token via fetch, and invokes onTokenValid on success.",
+      "tags": [
+        "component",
+        "security",
+        "form"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+      "type": "file",
+      "name": "WarningBanner.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+      "summary": "Banner that surfaces graph schema validation issues (fatal, auto-corrected, dropped), groups them by severity, and offers copy-to-clipboard of a report.",
+      "tags": [
+        "component",
+        "validation",
+        "error-display",
+        "banner"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx:buildCopyText",
+      "type": "function",
+      "name": "buildCopyText",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+      "lineRange": [
+        8,
+        43
+      ],
+      "summary": "Formats a sorted, human-readable text report of validation issues for copying to the clipboard.",
+      "tags": [
+        "utility",
+        "serialization",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx:WarningBanner",
+      "type": "function",
+      "name": "WarningBanner",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+      "lineRange": [
+        45,
+        253
+      ],
+      "summary": "Renders the validation-issue banner, partitioning issues into fatal/auto-corrected/dropped groups with expand and copy controls.",
+      "tags": [
+        "component",
+        "validation",
+        "error-display"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "file",
+      "name": "I18nContext.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "summary": "React context and provider that resolve the active locale and expose translation strings via the useI18n hook.",
+      "tags": [
+        "context",
+        "i18n",
+        "provider",
+        "hook"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx:I18nProvider",
+      "type": "function",
+      "name": "I18nProvider",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "lineRange": [
+        20,
+        44
+      ],
+      "summary": "Context provider that resolves the locale key, loads the matching locale strings, and memoizes the i18n value for children.",
+      "tags": [
+        "provider",
+        "i18n",
+        "context"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx:useI18n",
+      "type": "function",
+      "name": "useI18n",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "lineRange": [
+        12,
+        18
+      ],
+      "summary": "Hook that reads the i18n context and throws if used outside an I18nProvider.",
+      "tags": [
+        "hook",
+        "i18n",
+        "context"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts",
+      "type": "file",
+      "name": "useIsMobile.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts",
+      "summary": "React hook that tracks whether the viewport is below a breakpoint using a matchMedia listener.",
+      "tags": [
+        "hook",
+        "responsive",
+        "media-query"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts:useIsMobile",
+      "type": "function",
+      "name": "useIsMobile",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts",
+      "lineRange": [
+        5,
+        21
+      ],
+      "summary": "Subscribes to a matchMedia query for the given breakpoint and returns whether the viewport is currently mobile-sized.",
+      "tags": [
+        "hook",
+        "responsive",
+        "media-query"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "type": "file",
+      "name": "useKeyboardShortcuts.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "summary": "Hook that registers a global keydown listener to fire registered keyboard shortcuts, plus a helper to format shortcut keys for display.",
+      "tags": [
+        "hook",
+        "keyboard-shortcuts",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts:useKeyboardShortcuts",
+      "type": "function",
+      "name": "useKeyboardShortcuts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "lineRange": [
+        14,
+        50
+      ],
+      "summary": "Attaches a document keydown listener that matches events against registered shortcuts and invokes their actions, skipping input fields.",
+      "tags": [
+        "hook",
+        "keyboard-shortcuts",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts:formatShortcutKey",
+      "type": "function",
+      "name": "formatShortcutKey",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "lineRange": [
+        52,
+        71
+      ],
+      "summary": "Builds a platform-aware display string for a keyboard shortcut, using Cmd on macOS and Ctrl elsewhere.",
+      "tags": [
+        "utility",
+        "keyboard-shortcuts",
+        "formatting"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/main.tsx",
+      "type": "file",
+      "name": "main.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/main.tsx",
+      "summary": "Dashboard entry point that mounts the root App component into the DOM and imports global styles.",
+      "tags": [
+        "entry-point",
+        "bootstrap",
+        "react"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "file",
+      "name": "store.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/store.ts",
+      "summary": "Central Zustand store for the dashboard: graph data, filters, selection, layer navigation, tours, and derived graph indexes shared across all components.",
+      "tags": [
+        "service",
+        "state-management",
+        "zustand",
+        "store"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Zustand store exporting node-type/complexity/edge-category constants and helpers for building graph indexes and layer navigation."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/store.ts:buildGraphIndexes",
+      "type": "function",
+      "name": "buildGraphIndexes",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/store.ts",
+      "lineRange": [
+        74,
+        95
+      ],
+      "summary": "Builds lookup maps from a graph: nodes-by-id and node-to-layer associations used for fast filtering and navigation.",
+      "tags": [
+        "utility",
+        "indexing",
+        "graph"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/store.ts:navigateTourToLayer",
+      "type": "function",
+      "name": "navigateTourToLayer",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/store.ts",
+      "lineRange": [
+        248,
+        261
+      ],
+      "summary": "Resolves the layer for a set of tour node ids and computes the layer navigation target for a tour step.",
+      "tags": [
+        "utility",
+        "navigation",
+        "tour"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/store.ts:layerResetIfChanged",
+      "type": "function",
+      "name": "layerResetIfChanged",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/store.ts",
+      "lineRange": [
+        272,
+        287
+      ],
+      "summary": "Resets layer navigation state when the active layer changes from the previous one.",
+      "tags": [
+        "utility",
+        "navigation",
+        "state"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/themes/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/index.ts",
+      "summary": "Barrel module re-exporting the theme provider, hooks, presets, and theme types for the dashboard.",
+      "tags": [
+        "barrel",
+        "theme",
+        "re-export"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/edgeAggregation.test.ts",
+      "type": "file",
+      "name": "edgeAggregation.test.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/edgeAggregation.test.ts",
+      "summary": "Vitest suite validating the edge aggregation utilities that collapse node edges into layer- and container-level edges.",
+      "tags": [
+        "test",
+        "edge-aggregation",
+        "vitest"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/elk-layout.test.ts",
+      "type": "file",
+      "name": "elk-layout.test.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/elk-layout.test.ts",
+      "summary": "Vitest suite covering ELK input repair: dimension filling, dedup, dangling edge removal, and cycle stripping.",
+      "tags": [
+        "test",
+        "layout",
+        "vitest"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/filters.test.ts",
+      "type": "file",
+      "name": "filters.test.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/filters.test.ts",
+      "summary": "Vitest suite verifying node and edge filtering logic across node types, complexities, layers, and edge categories.",
+      "tags": [
+        "test",
+        "filtering",
+        "vitest"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/layerStats.test.ts",
+      "type": "file",
+      "name": "layerStats.test.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/layerStats.test.ts",
+      "summary": "Vitest suite validating per-layer statistics computation including node counts and complexity tallies.",
+      "tags": [
+        "test",
+        "statistics",
+        "vitest"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "type": "file",
+      "name": "edgeAggregation.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "summary": "Utilities that aggregate fine-grained graph edges into layer-level and container-level edges and compute portal nodes for cross-layer navigation.",
+      "tags": [
+        "utility",
+        "graph",
+        "edge-aggregation",
+        "layout",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:aggregateLayerEdges",
+      "type": "function",
+      "name": "aggregateLayerEdges",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "lineRange": [
+        21,
+        70
+      ],
+      "summary": "Collapses node-to-node edges into deduplicated layer-to-layer edges, tracking the set of underlying edge types per pair.",
+      "tags": [
+        "utility",
+        "graph",
+        "edge-aggregation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:computePortals",
+      "type": "function",
+      "name": "computePortals",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "lineRange": [
+        77,
+        106
+      ],
+      "summary": "Derives portal nodes for the active layer from aggregated layer edges, mapping connected layers into navigable portals.",
+      "tags": [
+        "utility",
+        "graph",
+        "navigation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:findCrossLayerFileNodes",
+      "type": "function",
+      "name": "findCrossLayerFileNodes",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "lineRange": [
+        113,
+        135
+      ],
+      "summary": "Finds file nodes that connect the active layer to a target layer by scanning edges across both layers' node sets.",
+      "tags": [
+        "utility",
+        "graph",
+        "cross-layer"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:aggregateContainerEdges",
+      "type": "function",
+      "name": "aggregateContainerEdges",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "lineRange": [
+        158,
+        208
+      ],
+      "summary": "Splits edges into intra-container and aggregated inter-container edges based on each node's container assignment.",
+      "tags": [
+        "utility",
+        "graph",
+        "edge-aggregation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "type": "file",
+      "name": "elk-layout.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "summary": "Wraps the ELK layout engine, first repairing the input graph (filling dimensions, deduping, dropping dangling edges, stripping cycles) before running layout.",
+      "tags": [
+        "utility",
+        "layout",
+        "elk",
+        "graph",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Defensive input sanitization recursively walks the ELK node tree and removes structural problems ELK would otherwise reject."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts:repairElkInput",
+      "type": "function",
+      "name": "repairElkInput",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "lineRange": [
+        56,
+        212
+      ],
+      "summary": "Sanitizes an ELK graph input by filling node dimensions, deduping children, removing dangling edges, and stripping parent cycles, collecting issues along the way.",
+      "tags": [
+        "utility",
+        "layout",
+        "validation",
+        "elk"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts:applyElkLayout",
+      "type": "function",
+      "name": "applyElkLayout",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "lineRange": [
+        225,
+        244
+      ],
+      "summary": "Repairs the input then runs the ELK layout engine, returning positioned nodes or surfacing errors.",
+      "tags": [
+        "utility",
+        "layout",
+        "elk"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "type": "file",
+      "name": "filters.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "summary": "Pure functions that filter graph nodes and edges by node type, complexity, layer, and edge category according to the active filter state.",
+      "tags": [
+        "utility",
+        "filtering",
+        "graph",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/filters.ts:filterNodes",
+      "type": "function",
+      "name": "filterNodes",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "lineRange": [
+        19,
+        52
+      ],
+      "summary": "Filters nodes by selected node types, complexities, and layer membership using the node-to-layer index.",
+      "tags": [
+        "utility",
+        "filtering",
+        "graph"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/filters.ts:filterEdges",
+      "type": "function",
+      "name": "filterEdges",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "lineRange": [
+        57,
+        76
+      ],
+      "summary": "Keeps only edges whose endpoints are both visible and whose category passes the active edge-category filter.",
+      "tags": [
+        "utility",
+        "filtering",
+        "graph"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts",
+      "type": "file",
+      "name": "layerStats.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts",
+      "summary": "Computes per-layer statistics such as node count and complexity distribution from a layer and a nodes-by-id index.",
+      "tags": [
+        "utility",
+        "statistics",
+        "graph",
+        "tested"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts:computeLayerStats",
+      "type": "function",
+      "name": "computeLayerStats",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts",
+      "lineRange": [
+        20,
+        39
+      ],
+      "summary": "Tallies node count and complexity breakdown for a single layer by resolving its node ids against the nodes index.",
+      "tags": [
+        "utility",
+        "statistics",
+        "graph"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "type": "file",
+      "name": "layout.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "summary": "Graph layout utilities offering Dagre and D3-force algorithms plus ELK input conversion and position merging, with shared node-size constants.",
+      "tags": [
+        "utility",
+        "layout",
+        "graph",
+        "dagre"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Combines dagre hierarchical layout with a D3 force simulation that uses community-based clustering forces."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:applyDagreLayout",
+      "type": "function",
+      "name": "applyDagreLayout",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "lineRange": [
+        30,
+        79
+      ],
+      "summary": "Runs a Dagre hierarchical layout over the given nodes and edges and returns positioned nodes with their dimensions applied.",
+      "tags": [
+        "utility",
+        "layout",
+        "dagre"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:applyForceLayout",
+      "type": "function",
+      "name": "applyForceLayout",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "lineRange": [
+        94,
+        189
+      ],
+      "summary": "Runs a D3 force simulation with link, charge, center, collision, and community-clustering forces to position nodes organically.",
+      "tags": [
+        "utility",
+        "layout",
+        "force-simulation",
+        "d3"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:nodesToElkInput",
+      "type": "function",
+      "name": "nodesToElkInput",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "lineRange": [
+        206,
+        229
+      ],
+      "summary": "Converts dashboard nodes and edges into the ELK graph input format with per-node dimensions and layout options.",
+      "tags": [
+        "utility",
+        "layout",
+        "elk",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:mergeElkPositions",
+      "type": "function",
+      "name": "mergeElkPositions",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "lineRange": [
+        231,
+        266
+      ],
+      "summary": "Merges ELK-computed positions back into the original node list by id.",
+      "tags": [
+        "utility",
+        "layout",
+        "elk"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts",
+      "type": "file",
+      "name": "change-classifier.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts",
+      "summary": "Unit tests for the change classifier, verifying that file additions, deletions, and modifications are correctly categorized into incremental vs full re-analysis decisions.",
+      "tags": [
+        "test",
+        "change-detection",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/domain-normalize.test.ts",
+      "type": "file",
+      "name": "domain-normalize.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/domain-normalize.test.ts",
+      "summary": "Unit tests covering normalization of domain-flow graph batch output via the normalize-graph module.",
+      "tags": [
+        "test",
+        "normalization",
+        "domain",
+        "unit-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/domain-persistence.test.ts",
+      "type": "file",
+      "name": "domain-persistence.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/domain-persistence.test.ts",
+      "summary": "Tests for saving and loading the domain graph through the persistence layer, ensuring round-trip integrity of domain data on disk.",
+      "tags": [
+        "test",
+        "persistence",
+        "domain",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/domain-types.test.ts",
+      "type": "file",
+      "name": "domain-types.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/domain-types.test.ts",
+      "summary": "Validates domain-related schema and type definitions against the Zod schemas in schema.ts.",
+      "tags": [
+        "test",
+        "schema",
+        "type-definition",
+        "domain"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts",
+      "type": "file",
+      "name": "embedding-search.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts",
+      "summary": "Tests the semantic embedding search engine, covering cosine similarity scoring and nearest-node retrieval.",
+      "tags": [
+        "test",
+        "search",
+        "embeddings",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/fingerprint.test.ts",
+      "type": "file",
+      "name": "fingerprint.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/fingerprint.test.ts",
+      "summary": "Comprehensive test suite for file fingerprinting, content hashing, fingerprint comparison, and change analysis used by incremental updates.",
+      "tags": [
+        "test",
+        "fingerprint",
+        "change-detection",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts",
+      "type": "file",
+      "name": "language-lesson.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts",
+      "summary": "Tests the language-lesson analyzer, verifying concept detection, prompt construction, and parsing of LLM lesson responses for TypeScript.",
+      "tags": [
+        "test",
+        "language-lesson",
+        "analyzer",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/layer-detector.test.ts",
+      "type": "file",
+      "name": "layer-detector.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/layer-detector.test.ts",
+      "summary": "Tests architectural layer detection from a knowledge graph, including heuristic file-to-layer matching and LLM layer application.",
+      "tags": [
+        "test",
+        "layer-detection",
+        "analyzer",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts",
+      "type": "file",
+      "name": "normalize-graph.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts",
+      "summary": "Extensive tests for graph normalization, node-ID canonicalization, complexity normalization, and dangling-edge dropping.",
+      "tags": [
+        "test",
+        "normalization",
+        "graph",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "type": "file",
+      "name": "parsers.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "summary": "Broad test suite exercising all non-code file parsers (Markdown, YAML, JSON, TOML, env, Dockerfile, SQL, GraphQL, Protobuf, Terraform, Makefile, shell) and the plugin registry.",
+      "tags": [
+        "test",
+        "parser",
+        "plugins",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/plugin-registry.test.ts",
+      "type": "file",
+      "name": "plugin-registry.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/plugin-registry.test.ts",
+      "summary": "Tests the plugin registry's registration, lookup, and parser resolution behavior using mock plugins.",
+      "tags": [
+        "test",
+        "plugins",
+        "registry",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/schema.test.ts",
+      "type": "file",
+      "name": "schema.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/schema.test.ts",
+      "summary": "Large test suite validating the knowledge graph Zod schemas, alias maps, sanitization, and auto-fix routines in schema.ts.",
+      "tags": [
+        "test",
+        "schema",
+        "validation",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/search.test.ts",
+      "type": "file",
+      "name": "search.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/search.test.ts",
+      "summary": "Tests the lexical SearchEngine, verifying node indexing, query matching, and result ranking.",
+      "tags": [
+        "test",
+        "search",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts",
+      "type": "file",
+      "name": "staleness.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts",
+      "summary": "Tests staleness detection and incremental graph merge logic, covering changed-file detection and update merging.",
+      "tags": [
+        "test",
+        "staleness",
+        "change-detection",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/tour-generator.test.ts",
+      "type": "file",
+      "name": "tour-generator.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/tour-generator.test.ts",
+      "summary": "Tests the guided-tour generator, covering prompt building, LLM response parsing, and the heuristic tour fallback.",
+      "tags": [
+        "test",
+        "tour",
+        "analyzer",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.test.ts",
+      "type": "file",
+      "name": "graph-builder.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/graph-builder.test.ts",
+      "summary": "Tests the GraphBuilder class, verifying node/edge accumulation, deduplication, import/call edges, and non-code child node mapping.",
+      "tags": [
+        "test",
+        "graph",
+        "analyzer",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "type": "file",
+      "name": "graph-builder.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "summary": "Defines the GraphBuilder class that accumulates files, functions, classes, and non-code child nodes into a deduplicated knowledge graph with import and call edges.",
+      "tags": [
+        "graph",
+        "analyzer",
+        "builder",
+        "factory",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "type": "file",
+      "name": "language-lesson.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "summary": "Generates language-specific learning lessons: detects language concepts on nodes, builds LLM prompts, and parses lesson responses.",
+      "tags": [
+        "analyzer",
+        "language-lesson",
+        "llm-prompt",
+        "parsing",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "type": "file",
+      "name": "layer-detector.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "summary": "Detects architectural layers from a knowledge graph using path heuristics and LLM-assisted layer assignment, then applies layers back onto nodes.",
+      "tags": [
+        "analyzer",
+        "layer-detection",
+        "architecture",
+        "llm-prompt",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "type": "file",
+      "name": "normalize-graph.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "summary": "Normalizes raw batch graph output: canonicalizes node IDs to valid prefixes, normalizes complexity, dedupes nodes/edges, and drops dangling edges.",
+      "tags": [
+        "analyzer",
+        "normalization",
+        "graph",
+        "validation",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "type": "file",
+      "name": "tour-generator.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "summary": "Builds guided learning tours: constructs LLM prompts, parses tour responses, and generates a heuristic topological tour fallback from the graph.",
+      "tags": [
+        "analyzer",
+        "tour",
+        "llm-prompt",
+        "graph-traversal",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "type": "file",
+      "name": "change-classifier.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "summary": "Classifies file changes to decide between incremental and full re-analysis, detecting directory-level structural changes and summarizing change sets.",
+      "tags": [
+        "change-detection",
+        "classification",
+        "incremental-update",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "type": "file",
+      "name": "embedding-search.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "summary": "Implements a semantic search engine over node embeddings using cosine similarity, with incremental embedding updates.",
+      "tags": [
+        "search",
+        "embeddings",
+        "semantic-search",
+        "service",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts:GraphBuilder",
+      "type": "class",
+      "name": "GraphBuilder",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "lineRange": [
+        60,
+        337
+      ],
+      "summary": "Accumulates files, code definitions, and non-code child nodes into a deduplicated knowledge graph, emitting import and call edges and producing the final graph with metadata.",
+      "tags": [
+        "builder",
+        "graph",
+        "factory",
+        "analyzer"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:detectLanguageConcepts",
+      "type": "function",
+      "name": "detectLanguageConcepts",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "lineRange": [
+        69,
+        93
+      ],
+      "summary": "Detects language-specific concepts present on a node by matching configured concept keyword patterns against node tags, summary, and language notes.",
+      "tags": [
+        "analyzer",
+        "detection",
+        "language-lesson"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:buildLanguageLessonPrompt",
+      "type": "function",
+      "name": "buildLanguageLessonPrompt",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "lineRange": [
+        112,
+        155
+      ],
+      "summary": "Builds the LLM prompt for generating a language lesson, incorporating node metadata, edges, and detected concepts.",
+      "tags": [
+        "analyzer",
+        "llm-prompt",
+        "language-lesson"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:parseLanguageLessonResponse",
+      "type": "function",
+      "name": "parseLanguageLessonResponse",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "lineRange": [
+        178,
+        210
+      ],
+      "summary": "Parses and validates an LLM language-lesson response, extracting structured concept name/explanation pairs.",
+      "tags": [
+        "analyzer",
+        "parsing",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:detectLayers",
+      "type": "function",
+      "name": "detectLayers",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "lineRange": [
+        105,
+        144
+      ],
+      "summary": "Detects architectural layers heuristically from a graph by matching file paths against known layer patterns and grouping nodes accordingly.",
+      "tags": [
+        "analyzer",
+        "layer-detection",
+        "heuristic"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:buildLayerDetectionPrompt",
+      "type": "function",
+      "name": "buildLayerDetectionPrompt",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "lineRange": [
+        150,
+        170
+      ],
+      "summary": "Builds the LLM prompt asking for architectural layer assignments from the list of file paths in the graph.",
+      "tags": [
+        "analyzer",
+        "llm-prompt",
+        "layer-detection"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:parseLayerDetectionResponse",
+      "type": "function",
+      "name": "parseLayerDetectionResponse",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "lineRange": [
+        177,
+        220
+      ],
+      "summary": "Parses an LLM layer-detection response into validated layer objects with names, descriptions, and file patterns.",
+      "tags": [
+        "analyzer",
+        "parsing",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:applyLLMLayers",
+      "type": "function",
+      "name": "applyLLMLayers",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "lineRange": [
+        227,
+        284
+      ],
+      "summary": "Applies LLM-derived layer definitions to the graph, assigning each node to a layer by path matching and collecting unmatched nodes into an 'other' layer.",
+      "tags": [
+        "analyzer",
+        "layer-detection",
+        "graph"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeNodeId",
+      "type": "function",
+      "name": "normalizeNodeId",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "lineRange": [
+        64,
+        111
+      ],
+      "summary": "Canonicalizes a node ID by stripping to a valid type prefix and inferring or correcting the type segment based on the node data.",
+      "tags": [
+        "normalization",
+        "graph",
+        "node-id"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeComplexity",
+      "type": "function",
+      "name": "normalizeComplexity",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "lineRange": [
+        134,
+        152
+      ],
+      "summary": "Normalizes an arbitrary complexity value to one of the valid complexity levels, mapping numeric or alias inputs.",
+      "tags": [
+        "normalization",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeBatchOutput",
+      "type": "function",
+      "name": "normalizeBatchOutput",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "lineRange": [
+        202,
+        329
+      ],
+      "summary": "Normalizes a complete batch graph fragment: canonicalizes node IDs, dedupes nodes and edges, rewrites edge endpoints, and drops dangling edges.",
+      "tags": [
+        "normalization",
+        "graph",
+        "deduplication"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts:buildTourGenerationPrompt",
+      "type": "function",
+      "name": "buildTourGenerationPrompt",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "lineRange": [
+        7,
+        62
+      ],
+      "summary": "Builds the LLM prompt for tour generation, summarizing graph nodes, edges, layers, and project metadata.",
+      "tags": [
+        "analyzer",
+        "llm-prompt",
+        "tour"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts:parseTourGenerationResponse",
+      "type": "function",
+      "name": "parseTourGenerationResponse",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "lineRange": [
+        70,
+        120
+      ],
+      "summary": "Parses an LLM tour-generation response into validated tour steps with titles, descriptions, and node references.",
+      "tags": [
+        "analyzer",
+        "parsing",
+        "tour"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts:generateHeuristicTour",
+      "type": "function",
+      "name": "generateHeuristicTour",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "lineRange": [
+        135,
+        293
+      ],
+      "summary": "Generates a fallback tour without an LLM by topologically sorting code nodes, grouping by layer, and producing ordered pedagogical steps.",
+      "tags": [
+        "analyzer",
+        "tour",
+        "graph-traversal",
+        "heuristic"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/change-classifier.ts:classifyUpdate",
+      "type": "function",
+      "name": "classifyUpdate",
+      "filePath": "understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "lineRange": [
+        21,
+        87
+      ],
+      "summary": "Classifies a change analysis into an incremental or full re-analysis decision based on change volume and directory-level structural shifts.",
+      "tags": [
+        "change-detection",
+        "classification",
+        "incremental-update"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/change-classifier.ts:detectDirectoryChanges",
+      "type": "function",
+      "name": "detectDirectoryChanges",
+      "filePath": "understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "lineRange": [
+        94,
+        114
+      ],
+      "summary": "Detects newly added or removed top-level directories by comparing new and deleted files against the known file set.",
+      "tags": [
+        "change-detection",
+        "directory-analysis"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/embedding-search.ts:cosineSimilarity",
+      "type": "function",
+      "name": "cosineSimilarity",
+      "filePath": "understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "lineRange": [
+        14,
+        30
+      ],
+      "summary": "Computes the cosine similarity between two embedding vectors.",
+      "tags": [
+        "embeddings",
+        "math",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/embedding-search.ts:SemanticSearchEngine",
+      "type": "class",
+      "name": "SemanticSearchEngine",
+      "filePath": "understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "lineRange": [
+        37,
+        83
+      ],
+      "summary": "Stores node embeddings and performs cosine-similarity-based semantic search with optional type filtering and incremental node updates.",
+      "tags": [
+        "search",
+        "embeddings",
+        "semantic-search",
+        "service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "type": "file",
+      "name": "fingerprint.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "summary": "Computes structural fingerprints of source files (hashed exports, functions, classes, imports) and diffs them to classify changes as cosmetic or structural for incremental graph updates.",
+      "tags": [
+        "fingerprint",
+        "change-detection",
+        "serialization",
+        "incremental",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses SHA-256 content hashing plus sorted-set comparison to keep diffs order-insensitive."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:extractFileFingerprint",
+      "type": "function",
+      "name": "extractFileFingerprint",
+      "filePath": "understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "lineRange": [
+        79,
+        122
+      ],
+      "summary": "Builds a FileFingerprint from a file's content and analysis, capturing hashed signatures of its exports, functions, classes, and imports.",
+      "tags": [
+        "fingerprint",
+        "factory",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:compareFingerprints",
+      "type": "function",
+      "name": "compareFingerprints",
+      "filePath": "understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "lineRange": [
+        131,
+        246
+      ],
+      "summary": "Diffs two fingerprints to produce a list of added, removed, and modified functions, classes, imports, and exports.",
+      "tags": [
+        "change-detection",
+        "diff",
+        "comparison"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:buildFingerprintStore",
+      "type": "function",
+      "name": "buildFingerprintStore",
+      "filePath": "understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "lineRange": [
+        253,
+        291
+      ],
+      "summary": "Analyzes a set of project files and assembles a complete FingerprintStore keyed by file path, recording per-file hashes and metadata.",
+      "tags": [
+        "fingerprint",
+        "factory",
+        "persistence"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:analyzeChanges",
+      "type": "function",
+      "name": "analyzeChanges",
+      "filePath": "understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "lineRange": [
+        297,
+        385
+      ],
+      "summary": "Compares changed files against an existing fingerprint store to categorize them as new, deleted, unchanged, cosmetic-only, or structurally changed.",
+      "tags": [
+        "change-detection",
+        "incremental",
+        "diff"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "summary": "Disk persistence layer that reads and writes the knowledge graph, project meta, fingerprints, config, and domain graph to the project's .understand-anything directory, sanitising absolute file paths to project-relative form.",
+      "tags": [
+        "persistence",
+        "serialization",
+        "utility",
+        "barrel",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/persistence/index.ts:sanitiseFilePaths",
+      "type": "function",
+      "name": "sanitiseFilePaths",
+      "filePath": "understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "lineRange": [
+        38,
+        67
+      ],
+      "summary": "Rewrites node filePath fields to project-relative paths, stripping the project root prefix so persisted graphs stay portable.",
+      "tags": [
+        "serialization",
+        "utility",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/persistence/index.ts:loadGraph",
+      "type": "function",
+      "name": "loadGraph",
+      "filePath": "understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "lineRange": [
+        85,
+        105
+      ],
+      "summary": "Loads the persisted knowledge graph from disk and runs schema validation before returning it.",
+      "tags": [
+        "persistence",
+        "deserialization",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/persistence/index.ts:loadDomainGraph",
+      "type": "function",
+      "name": "loadDomainGraph",
+      "filePath": "understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "lineRange": [
+        162,
+        182
+      ],
+      "summary": "Loads the persisted domain graph from disk with optional schema validation.",
+      "tags": [
+        "persistence",
+        "deserialization",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/persistence/persistence.test.ts",
+      "type": "file",
+      "name": "persistence.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/persistence/persistence.test.ts",
+      "summary": "Vitest suite covering the persistence layer's save/load round-trips for graphs, fingerprints, meta, and config, including path sanitisation behaviour.",
+      "tags": [
+        "test",
+        "persistence",
+        "vitest"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts",
+      "type": "file",
+      "name": "dockerfile-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts",
+      "summary": "Lightweight parser that extracts build stages, exposed ports, and step instructions from Dockerfiles for the plugin registry.",
+      "tags": [
+        "parser",
+        "infrastructure",
+        "containerization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts:DockerfileParser",
+      "type": "class",
+      "name": "DockerfileParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts",
+      "lineRange": [
+        8,
+        86
+      ],
+      "summary": "Parser plugin that analyzes Dockerfile content into stages (FROM directives, exposed ports) and steps (instructions).",
+      "tags": [
+        "parser",
+        "containerization",
+        "service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts",
+      "type": "file",
+      "name": "env-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts",
+      "summary": "Parser that extracts variable definitions from .env files for the plugin registry.",
+      "tags": [
+        "parser",
+        "configuration",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts:EnvParser",
+      "type": "class",
+      "name": "EnvParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts",
+      "lineRange": [
+        8,
+        41
+      ],
+      "summary": "Parser plugin that reads KEY=value lines from .env files into variable definitions.",
+      "tags": [
+        "parser",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts",
+      "type": "file",
+      "name": "graphql-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts",
+      "summary": "Parser that extracts GraphQL type definitions, fields, and query/mutation endpoints from .graphql schema files.",
+      "tags": [
+        "parser",
+        "schema-definition",
+        "api-schema"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts:GraphQLParser",
+      "type": "class",
+      "name": "GraphQLParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts",
+      "lineRange": [
+        8,
+        122
+      ],
+      "summary": "Parser plugin that scans GraphQL SDL for type definitions and root-level query/mutation endpoints via regex.",
+      "tags": [
+        "parser",
+        "schema-definition",
+        "api-schema"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "summary": "Barrel module that re-exports all non-code parsers and provides registerAllParsers to register them with the plugin registry.",
+      "tags": [
+        "barrel",
+        "entry-point",
+        "factory",
+        "parser"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts:registerAllParsers",
+      "type": "function",
+      "name": "registerAllParsers",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "lineRange": [
+        31,
+        44
+      ],
+      "summary": "Registers every bundled non-code parser (markdown, yaml, json, dockerfile, sql, etc.) into the supplied plugin registry.",
+      "tags": [
+        "factory",
+        "parser",
+        "registration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "type": "file",
+      "name": "json-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "summary": "Parser that strips JSONC syntax then extracts top-level sections and $ref-style references from JSON config files.",
+      "tags": [
+        "parser",
+        "configuration",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts:stripJsoncSyntax",
+      "type": "function",
+      "name": "stripJsoncSyntax",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "lineRange": [
+        11,
+        59
+      ],
+      "summary": "Removes comments and trailing commas from JSONC content so it can be parsed as strict JSON, preserving string literals.",
+      "tags": [
+        "utility",
+        "serialization",
+        "parser"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts:JSONConfigParser",
+      "type": "class",
+      "name": "JSONConfigParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "lineRange": [
+        69,
+        136
+      ],
+      "summary": "Parser plugin that analyzes JSON config files into sections and cross-file references.",
+      "tags": [
+        "parser",
+        "configuration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts",
+      "type": "file",
+      "name": "makefile-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts",
+      "summary": "Parser that extracts targets from Makefiles, skipping pattern rules and variable assignments.",
+      "tags": [
+        "parser",
+        "build-system",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts:MakefileParser",
+      "type": "class",
+      "name": "MakefileParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts",
+      "lineRange": [
+        8,
+        51
+      ],
+      "summary": "Parser plugin that scans Makefile lines for build targets.",
+      "tags": [
+        "parser",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts",
+      "type": "file",
+      "name": "markdown-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts",
+      "summary": "Parser that extracts heading sections and internal link references from Markdown documents.",
+      "tags": [
+        "parser",
+        "documentation",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts:MarkdownParser",
+      "type": "class",
+      "name": "MarkdownParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts",
+      "lineRange": [
+        8,
+        78
+      ],
+      "summary": "Parser plugin that walks Markdown lines to collect heading sections and relative link references.",
+      "tags": [
+        "parser",
+        "documentation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts",
+      "type": "file",
+      "name": "protobuf-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts",
+      "summary": "Parser that extracts messages, enums, and service RPC methods from Protocol Buffer .proto files.",
+      "tags": [
+        "parser",
+        "schema-definition",
+        "data-pipeline"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts:ProtobufParser",
+      "type": "class",
+      "name": "ProtobufParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts",
+      "lineRange": [
+        8,
+        141
+      ],
+      "summary": "Parser plugin that scans .proto content for message/enum definitions and service RPC endpoints using brace-matching helpers.",
+      "tags": [
+        "parser",
+        "schema-definition",
+        "data-pipeline"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts",
+      "type": "file",
+      "name": "shell-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts",
+      "summary": "Parser that extracts function definitions and sourced-file references from shell scripts.",
+      "tags": [
+        "parser",
+        "script",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts:ShellParser",
+      "type": "class",
+      "name": "ShellParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts",
+      "lineRange": [
+        8,
+        86
+      ],
+      "summary": "Parser plugin that detects shell function declarations and source/dot include references.",
+      "tags": [
+        "parser",
+        "script"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts",
+      "type": "file",
+      "name": "sql-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts",
+      "summary": "Parser that extracts table, view, and index definitions plus column lists from SQL files.",
+      "tags": [
+        "parser",
+        "database",
+        "schema-definition"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts:SQLParser",
+      "type": "class",
+      "name": "SQLParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts",
+      "lineRange": [
+        8,
+        102
+      ],
+      "summary": "Parser plugin that scans SQL DDL for CREATE TABLE/VIEW/INDEX statements and extracts column definitions.",
+      "tags": [
+        "parser",
+        "database",
+        "schema-definition"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts",
+      "type": "file",
+      "name": "terraform-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts",
+      "summary": "Parser that extracts resources, data sources, modules, variables, and outputs from Terraform HCL files.",
+      "tags": [
+        "parser",
+        "infrastructure",
+        "deployment"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts:TerraformParser",
+      "type": "class",
+      "name": "TerraformParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts",
+      "lineRange": [
+        8,
+        130
+      ],
+      "summary": "Parser plugin that scans Terraform HCL for resource/data/module blocks and variable/output definitions using brace matching.",
+      "tags": [
+        "parser",
+        "infrastructure",
+        "deployment"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts",
+      "type": "file",
+      "name": "toml-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts",
+      "summary": "Parser that extracts table and array-of-table section headers from TOML config files.",
+      "tags": [
+        "parser",
+        "configuration",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts:TOMLParser",
+      "type": "class",
+      "name": "TOMLParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts",
+      "lineRange": [
+        8,
+        46
+      ],
+      "summary": "Parser plugin that reads TOML [section] and [[array]] headers into sections.",
+      "tags": [
+        "parser",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts",
+      "type": "file",
+      "name": "yaml-parser.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts",
+      "summary": "Parser that parses YAML config files into top-level sections, falling back to line scanning when structured parsing fails.",
+      "tags": [
+        "parser",
+        "configuration",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts:YAMLConfigParser",
+      "type": "class",
+      "name": "YAMLConfigParser",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts",
+      "lineRange": [
+        14,
+        106
+      ],
+      "summary": "Parser plugin that uses a YAML library plus regex line-matching to extract top-level keys as document sections.",
+      "tags": [
+        "parser",
+        "configuration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "type": "file",
+      "name": "registry.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "summary": "Central plugin registry that maps languages and file extensions to analysis plugins and delegates file analysis, import resolution, and call-graph extraction.",
+      "tags": [
+        "registry",
+        "factory",
+        "service",
+        "plugin",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/plugins/registry.ts:PluginRegistry",
+      "type": "class",
+      "name": "PluginRegistry",
+      "filePath": "understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "lineRange": [
+        11,
+        81
+      ],
+      "summary": "Registry that stores analysis plugins keyed by language, resolves the right plugin per file via the language registry, and dispatches analyzeFile/resolveImports/extractCallGraph calls.",
+      "tags": [
+        "registry",
+        "factory",
+        "plugin"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "type": "file",
+      "name": "schema.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/schema.ts",
+      "summary": "Zod schema definitions and validation pipeline for the knowledge graph, including alias normalization, sanitisation, auto-fixing, and reference integrity checks for nodes, edges, layers, and tour steps.",
+      "tags": [
+        "schema",
+        "validation",
+        "type-definition",
+        "serialization",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Builds on Zod with alias maps to coerce loosely-typed LLM output into the canonical graph schema before validating."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/schema.ts:sanitizeGraph",
+      "type": "function",
+      "name": "sanitizeGraph",
+      "filePath": "understand-anything-plugin/packages/core/src/schema.ts",
+      "lineRange": [
+        148,
+        194
+      ],
+      "summary": "Lowercases and alias-maps node types, edge types, complexity, and direction fields so loosely-formatted graph data conforms to the schema.",
+      "tags": [
+        "validation",
+        "serialization",
+        "normalization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/schema.ts:autoFixGraph",
+      "type": "function",
+      "name": "autoFixGraph",
+      "filePath": "understand-anything-plugin/packages/core/src/schema.ts",
+      "lineRange": [
+        196,
+        351
+      ],
+      "summary": "Repairs recoverable graph defects (missing fields, out-of-range weights, malformed entries) and collects the issues fixed for reporting.",
+      "tags": [
+        "validation",
+        "auto-fix",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/schema.ts:normalizeGraph",
+      "type": "function",
+      "name": "normalizeGraph",
+      "filePath": "understand-anything-plugin/packages/core/src/schema.ts",
+      "lineRange": [
+        462,
+        497
+      ],
+      "summary": "Normalizes raw graph node and edge records into a canonical shape ahead of schema validation.",
+      "tags": [
+        "validation",
+        "normalization",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/schema.ts:validateGraph",
+      "type": "function",
+      "name": "validateGraph",
+      "filePath": "understand-anything-plugin/packages/core/src/schema.ts",
+      "lineRange": [
+        499,
+        663
+      ],
+      "summary": "Runs the full validation pipeline (sanitise, normalize, auto-fix, Zod parse, reference integrity) and returns valid nodes/edges/layers/tour plus collected issues.",
+      "tags": [
+        "validation",
+        "schema",
+        "integrity-check"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/search.ts",
+      "type": "file",
+      "name": "search.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/search.ts",
+      "summary": "Fuse.js-backed fuzzy search engine over graph nodes with type filtering and result limiting.",
+      "tags": [
+        "search",
+        "service",
+        "utility",
+        "tested"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:understand-anything-plugin/packages/core/src/search.ts:SearchEngine",
+      "type": "class",
+      "name": "SearchEngine",
+      "filePath": "understand-anything-plugin/packages/core/src/search.ts",
+      "lineRange": [
+        27,
+        65
+      ],
+      "summary": "Wraps Fuse.js to perform weighted fuzzy search across node names, summaries, and tags, with optional type filtering and a configurable result limit.",
+      "tags": [
+        "search",
+        "service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/staleness.ts",
+      "type": "file",
+      "name": "staleness.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/staleness.ts",
+      "summary": "Detects graph staleness via git diff against a recorded commit and merges incremental node/edge updates into an existing graph by replacing changed files' contributions.",
+      "tags": [
+        "change-detection",
+        "incremental",
+        "utility",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses execFileSync to invoke git diff for the list of changed files since the last analyzed commit."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/staleness.ts:getChangedFiles",
+      "type": "function",
+      "name": "getChangedFiles",
+      "filePath": "understand-anything-plugin/packages/core/src/staleness.ts",
+      "lineRange": [
+        13,
+        29
+      ],
+      "summary": "Returns the list of files changed since a given commit by invoking git diff.",
+      "tags": [
+        "change-detection",
+        "git",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/staleness.ts:mergeGraphUpdate",
+      "type": "function",
+      "name": "mergeGraphUpdate",
+      "filePath": "understand-anything-plugin/packages/core/src/staleness.ts",
+      "lineRange": [
+        54,
+        90
+      ],
+      "summary": "Removes nodes and edges belonging to changed files from an existing graph and merges in freshly analyzed nodes/edges, updating the commit hash.",
+      "tags": [
+        "incremental",
+        "merge",
+        "change-detection"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/types.test.ts",
+      "type": "file",
+      "name": "types.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/types.test.ts",
+      "summary": "Vitest suite that exercises the core type definitions and their structural expectations.",
+      "tags": [
+        "test",
+        "type-definition",
+        "vitest"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "file",
+      "name": "types.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/types.ts",
+      "summary": "Central TypeScript type definitions for the core analysis engine — graph nodes, edges, fingerprints, plugins, and project metadata shared across packages.",
+      "tags": [
+        "type-definition",
+        "data-model",
+        "entry-point",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Pure type-declaration module with no runtime code; the foundational contract imported throughout the core package."
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/locales/en.ts",
+      "type": "file",
+      "name": "en.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/en.ts",
+      "summary": "English locale dictionary for the dashboard UI; serves as the canonical Locale shape that all other translations conform to.",
+      "tags": [
+        "i18n",
+        "localization",
+        "data-model",
+        "configuration",
+        "dashboard"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Default-exported object literal whose inferred type becomes the Locale type used by index.ts."
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "summary": "Barrel module aggregating all locale dictionaries into a typed registry and exposing helpers to fetch a locale and normalize a language string into a LocaleKey.",
+      "tags": [
+        "i18n",
+        "localization",
+        "barrel",
+        "entry-point",
+        "utility"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Derives the Locale type from the English dictionary (typeof en) and re-exports locales under a const Record keyed by LocaleKey."
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/locales/ja.ts",
+      "type": "file",
+      "name": "ja.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/ja.ts",
+      "summary": "Japanese locale dictionary providing translated UI strings for the dashboard, matching the canonical English Locale shape.",
+      "tags": [
+        "i18n",
+        "localization",
+        "data-model",
+        "configuration",
+        "dashboard"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/locales/ko.ts",
+      "type": "file",
+      "name": "ko.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/ko.ts",
+      "summary": "Korean locale dictionary providing translated UI strings for the dashboard, matching the canonical English Locale shape.",
+      "tags": [
+        "i18n",
+        "localization",
+        "data-model",
+        "configuration",
+        "dashboard"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/locales/ru.ts",
+      "type": "file",
+      "name": "ru.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/ru.ts",
+      "summary": "Russian locale dictionary providing translated UI strings for the dashboard, matching the canonical English Locale shape.",
+      "tags": [
+        "i18n",
+        "localization",
+        "data-model",
+        "configuration",
+        "dashboard"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts",
+      "type": "file",
+      "name": "zh-TW.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts",
+      "summary": "Traditional Chinese locale dictionary providing translated UI strings for the dashboard, matching the canonical English Locale shape.",
+      "tags": [
+        "i18n",
+        "localization",
+        "data-model",
+        "configuration",
+        "dashboard"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/locales/zh.ts",
+      "type": "file",
+      "name": "zh.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/zh.ts",
+      "summary": "Simplified Chinese locale dictionary providing translated UI strings for the dashboard, matching the canonical English Locale shape.",
+      "tags": [
+        "i18n",
+        "localization",
+        "data-model",
+        "configuration",
+        "dashboard"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/locales/index.ts:getLocale",
+      "type": "function",
+      "name": "getLocale",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "lineRange": [
+        20,
+        22
+      ],
+      "summary": "Returns the locale dictionary for a given LocaleKey, falling back to English when the key is unknown.",
+      "tags": [
+        "i18n",
+        "localization",
+        "utility",
+        "lookup"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/locales/index.ts:resolveLocaleKey",
+      "type": "function",
+      "name": "resolveLocaleKey",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "lineRange": [
+        24,
+        33
+      ],
+      "summary": "Normalizes an arbitrary language string (case, separators, aliases like 'chinese'/'zh-cn') into a supported LocaleKey, defaulting to English.",
+      "tags": [
+        "i18n",
+        "localization",
+        "utility",
+        "normalization",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts",
+      "type": "file",
+      "name": "ignore-filter.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts",
+      "summary": "Vitest suite verifying the ignore-filter's default patterns, .gitignore/.understandignore merging, and path-matching behavior.",
+      "tags": [
+        "test",
+        "validation",
+        "ignore-filter"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts",
+      "type": "file",
+      "name": "ignore-generator.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts",
+      "summary": "Vitest suite covering starter .understandignore generation, gitignore pattern parsing, default-coverage deduplication, and directory detection.",
+      "tags": [
+        "test",
+        "validation",
+        "ignore-generator"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/ignore-filter.ts",
+      "type": "file",
+      "name": "ignore-filter.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/ignore-filter.ts",
+      "summary": "Builds a path ignore filter from baked-in default patterns plus the project's .gitignore and .understandignore files, used to exclude files during scanning.",
+      "tags": [
+        "utility",
+        "ignore-filter",
+        "factory",
+        "service",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Wraps the `ignore` npm package and layers .gitignore/.understandignore on top of DEFAULT_IGNORE_PATTERNS."
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "type": "file",
+      "name": "ignore-generator.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "summary": "Generates a starter .understandignore file by parsing the project's .gitignore, dropping patterns already covered by defaults, and detecting common build/output directories.",
+      "tags": [
+        "utility",
+        "ignore-generator",
+        "serialization",
+        "service",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/ignore-filter.ts:createIgnoreFilter",
+      "type": "function",
+      "name": "createIgnoreFilter",
+      "filePath": "understand-anything-plugin/packages/core/src/ignore-filter.ts",
+      "lineRange": [
+        86,
+        111
+      ],
+      "summary": "Constructs an ignore instance seeded with default patterns and the project's .gitignore and .understandignore entries, returning an isIgnored path predicate.",
+      "tags": [
+        "factory",
+        "utility",
+        "ignore-filter"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/ignore-generator.ts:detectDirectories",
+      "type": "function",
+      "name": "detectDirectories",
+      "filePath": "understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "lineRange": [
+        103,
+        123
+      ],
+      "summary": "Scans the project root for build/output directories matching exact names or suffix globs to include in the generated ignore file.",
+      "tags": [
+        "utility",
+        "filesystem",
+        "ignore-generator"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/ignore-generator.ts:generateStarterIgnoreFile",
+      "type": "function",
+      "name": "generateStarterIgnoreFile",
+      "filePath": "understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "lineRange": [
+        130,
+        168
+      ],
+      "summary": "Assembles the text of a starter .understandignore file from parsed gitignore patterns, default-coverage filtering, and detected directories.",
+      "tags": [
+        "serialization",
+        "utility",
+        "ignore-generator"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "type": "file",
+      "name": "ThemeContext.tsx",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "summary": "React context provider and hook that manage the dashboard's active theme configuration, persisting it to localStorage and applying CSS variables on change.",
+      "tags": [
+        "component",
+        "hook",
+        "service",
+        "theming",
+        "react"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses React context with useCallback-wrapped setters and a useEffect that re-applies the theme and syncs localStorage."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx:ThemeProvider",
+      "type": "function",
+      "name": "ThemeProvider",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "lineRange": [
+        58,
+        100
+      ],
+      "summary": "Context provider that holds theme config state, applies the theme via applyTheme, persists changes to localStorage, and exposes preset/accent/mode setters.",
+      "tags": [
+        "component",
+        "react",
+        "theming",
+        "state"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx:useTheme",
+      "type": "function",
+      "name": "useTheme",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "lineRange": [
+        102,
+        106
+      ],
+      "summary": "Hook that reads the theme context, throwing if used outside a ThemeProvider.",
+      "tags": [
+        "hook",
+        "react",
+        "theming"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx:loadFromLocalStorage",
+      "type": "function",
+      "name": "loadFromLocalStorage",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "lineRange": [
+        27,
+        39
+      ],
+      "summary": "Reads and parses the persisted theme config from localStorage, returning null on failure.",
+      "tags": [
+        "utility",
+        "serialization",
+        "persistence"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "type": "file",
+      "name": "presets.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "summary": "Defines the catalog of built-in theme presets with their color tokens and accent swatches, plus lookup helpers for resolving presets and accents by id.",
+      "tags": [
+        "data-model",
+        "theming",
+        "configuration",
+        "factory"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/themes/presets.ts:getPreset",
+      "type": "function",
+      "name": "getPreset",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "lineRange": [
+        173,
+        175
+      ],
+      "summary": "Resolves a theme preset by id from the PRESETS catalog, falling back to the first preset.",
+      "tags": [
+        "utility",
+        "theming",
+        "lookup"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/themes/presets.ts:getAccent",
+      "type": "function",
+      "name": "getAccent",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "lineRange": [
+        177,
+        183
+      ],
+      "summary": "Resolves an accent swatch within a preset by id, defaulting to the preset's first accent when not found.",
+      "tags": [
+        "utility",
+        "theming",
+        "lookup"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "type": "file",
+      "name": "theme-engine.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "summary": "Core theming engine that translates a theme config into CSS custom properties on the document root, deriving accent-based color variations.",
+      "tags": [
+        "service",
+        "theming",
+        "utility",
+        "css"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Manipulates the DOM directly via documentElement.style.setProperty to drive CSS variable-based theming."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts:applyTheme",
+      "type": "function",
+      "name": "applyTheme",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "lineRange": [
+        33,
+        65
+      ],
+      "summary": "Applies a theme config by resolving its preset and accent, then writing the resulting color tokens as CSS custom properties on the document root.",
+      "tags": [
+        "service",
+        "theming",
+        "css",
+        "dom"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts:deriveFromAccent",
+      "type": "function",
+      "name": "deriveFromAccent",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "lineRange": [
+        10,
+        31
+      ],
+      "summary": "Derives a set of tinted color variations from a base accent hex color for light or dark mode.",
+      "tags": [
+        "utility",
+        "theming",
+        "color"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/themes/types.ts",
+      "type": "file",
+      "name": "types.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/themes/types.ts",
+      "summary": "Type definitions for the theming system (theme config, presets, accent swatches) and the default theme configuration constant.",
+      "tags": [
+        "type-definition",
+        "theming",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/containers.test.ts",
+      "type": "file",
+      "name": "containers.test.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/containers.test.ts",
+      "summary": "Unit tests for the container-derivation utility, verifying folder-based grouping, community fallback, and node assignment for the dashboard graph.",
+      "tags": [
+        "test",
+        "dashboard",
+        "graph",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "type": "file",
+      "name": "containers.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "summary": "Derives visual container groupings for the dashboard graph by clustering nodes via common folder prefixes, falling back to Louvain community detection when folder grouping is too sparse.",
+      "tags": [
+        "dashboard",
+        "graph",
+        "utility",
+        "clustering",
+        "data-model",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/louvain.ts",
+      "type": "file",
+      "name": "louvain.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/louvain.ts",
+      "summary": "Wraps the Louvain modularity algorithm to detect node communities from a node/edge graph, returning a per-node community assignment for dashboard clustering.",
+      "tags": [
+        "dashboard",
+        "graph",
+        "utility",
+        "clustering",
+        "algorithm"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/containers.ts:deriveContainers",
+      "type": "function",
+      "name": "deriveContainers",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "lineRange": [
+        91,
+        156
+      ],
+      "summary": "Main exported function that produces container groups from graph nodes and edges, choosing between folder-based grouping and Louvain community detection and assigning ungrouped nodes.",
+      "tags": [
+        "clustering",
+        "graph",
+        "factory",
+        "utility"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/containers.ts:groupByFolder",
+      "type": "function",
+      "name": "groupByFolder",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "lineRange": [
+        52,
+        75
+      ],
+      "summary": "Groups nodes by their first path segment after stripping a common prefix, separating rooted top-level nodes from folder-based buckets.",
+      "tags": [
+        "clustering",
+        "grouping",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/containers.ts:shouldFallbackToCommunity",
+      "type": "function",
+      "name": "shouldFallbackToCommunity",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "lineRange": [
+        77,
+        89
+      ],
+      "summary": "Heuristic that decides whether folder grouping is too sparse and the graph should instead use Louvain community detection.",
+      "tags": [
+        "heuristic",
+        "clustering",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/containers.ts:commonPrefix",
+      "type": "function",
+      "name": "commonPrefix",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "lineRange": [
+        30,
+        45
+      ],
+      "summary": "Computes the longest common directory prefix shared by a list of file paths.",
+      "tags": [
+        "utility",
+        "path",
+        "string"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/utils/louvain.ts:detectCommunities",
+      "type": "function",
+      "name": "detectCommunities",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/louvain.ts",
+      "lineRange": [
+        17,
+        47
+      ],
+      "summary": "Builds a graph from node ids and edges and runs the Louvain algorithm to assign each node a community index for clustering.",
+      "tags": [
+        "clustering",
+        "algorithm",
+        "graph",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/__tests__/context-builder.test.ts",
+      "type": "file",
+      "name": "context-builder.test.ts",
+      "filePath": "understand-anything-plugin/src/__tests__/context-builder.test.ts",
+      "summary": "Vitest unit tests for the chat context builder, verifying node selection, relationship expansion, and prompt formatting via a makeNode fixture helper.",
+      "tags": [
+        "test",
+        "vitest",
+        "context-builder",
+        "unit-test"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/context-builder.ts",
+      "type": "file",
+      "name": "context-builder.ts",
+      "filePath": "understand-anything-plugin/src/context-builder.ts",
+      "summary": "Builds and formats a focused subset of the knowledge graph for chat prompts by searching for query-relevant nodes, expanding their relationships, and rendering the result as prompt text.",
+      "tags": [
+        "context-builder",
+        "search",
+        "serialization",
+        "chat",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/understand-chat.ts",
+      "type": "file",
+      "name": "understand-chat.ts",
+      "filePath": "understand-anything-plugin/src/understand-chat.ts",
+      "summary": "Composes the system prompt for the /understand-chat skill by combining graph-derived context with instruction text and the user's question.",
+      "tags": [
+        "chat",
+        "prompt-builder",
+        "entry-point"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/src/context-builder.ts:buildChatContext",
+      "type": "function",
+      "name": "buildChatContext",
+      "filePath": "understand-anything-plugin/src/context-builder.ts",
+      "lineRange": [
+        25,
+        80
+      ],
+      "summary": "Searches the knowledge graph for query-relevant nodes, expands them with directly connected edges and layers, and returns a capped, focused chat context.",
+      "tags": [
+        "search",
+        "graph-traversal",
+        "context-builder"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/src/context-builder.ts:formatContextForPrompt",
+      "type": "function",
+      "name": "formatContextForPrompt",
+      "filePath": "understand-anything-plugin/src/context-builder.ts",
+      "lineRange": [
+        85,
+        147
+      ],
+      "summary": "Renders a chat context object into a human-readable prompt string describing project metadata, relevant nodes, and their relationships.",
+      "tags": [
+        "serialization",
+        "formatting",
+        "prompt-builder"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/src/understand-chat.ts:buildChatPrompt",
+      "type": "function",
+      "name": "buildChatPrompt",
+      "filePath": "understand-anything-plugin/src/understand-chat.ts",
+      "lineRange": [
+        8,
+        29
+      ],
+      "summary": "Assembles the full chat prompt by building graph context, formatting it, and prepending assistant instructions and the user's question.",
+      "tags": [
+        "prompt-builder",
+        "chat",
+        "composition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "pipeline:.github/workflows/ci.yml",
+      "type": "pipeline",
+      "name": "ci.yml",
+      "filePath": ".github/workflows/ci.yml",
+      "summary": "GitHub Actions CI workflow that runs on pull requests and pushes to main, installing dependencies and running lint, build, and test steps across the core and skill packages on Node 22 with pnpm.",
+      "tags": [
+        "ci-cd",
+        "infrastructure",
+        "build-system",
+        "test"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses concurrency groups keyed on github.ref to cancel in-flight runs for the same ref and save runner minutes."
+    },
+    {
+      "id": "step:.github/workflows/ci.yml:ci",
+      "type": "pipeline",
+      "name": "ci",
+      "filePath": ".github/workflows/ci.yml",
+      "summary": "Single ubuntu-latest job that checks out the repo, sets up pnpm and Node 22, installs dependencies, then lints, builds core and skill, and runs core and skill test suites.",
+      "tags": [
+        "ci-cd",
+        "build-system",
+        "test",
+        "lint"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "pipeline:.github/workflows/deploy-homepage.yml",
+      "type": "pipeline",
+      "name": "deploy-homepage.yml",
+      "filePath": ".github/workflows/deploy-homepage.yml",
+      "summary": "GitHub Actions workflow that builds the homepage and demo dashboard and deploys the combined output to GitHub Pages on pushes to main touching homepage, dashboard, or core paths.",
+      "tags": [
+        "ci-cd",
+        "deployment",
+        "infrastructure",
+        "build-system"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses GitHub Pages deployment with id-token write permission for OIDC and a two-job build/deploy pipeline gated by needs."
+    },
+    {
+      "id": "step:.github/workflows/deploy-homepage.yml:build",
+      "type": "pipeline",
+      "name": "build",
+      "filePath": ".github/workflows/deploy-homepage.yml",
+      "summary": "Build job that compiles the homepage, the core package, and the demo dashboard (with VITE_* env vars), merges the demo build into the homepage output, and uploads it as a Pages artifact.",
+      "tags": [
+        "ci-cd",
+        "build-system",
+        "deployment"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "step:.github/workflows/deploy-homepage.yml:deploy",
+      "type": "pipeline",
+      "name": "deploy",
+      "filePath": ".github/workflows/deploy-homepage.yml",
+      "summary": "Deploy job that depends on the build job and publishes the uploaded artifact to the github-pages environment via actions/deploy-pages.",
+      "tags": [
+        "ci-cd",
+        "deployment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/ISSUE_TEMPLATE/bug_report.yml",
+      "type": "config",
+      "name": "bug_report.yml",
+      "filePath": ".github/ISSUE_TEMPLATE/bug_report.yml",
+      "summary": "GitHub issue form template for structured bug reports, defining input fields for description, reproduction steps, environment, and expected behavior.",
+      "tags": [
+        "configuration",
+        "github",
+        "issue-template",
+        "bug-report"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses GitHub's YAML issue forms schema (name/description/title/labels/body with typed body elements)."
+    },
+    {
+      "id": "config:.github/ISSUE_TEMPLATE/config.yml",
+      "type": "config",
+      "name": "config.yml",
+      "filePath": ".github/ISSUE_TEMPLATE/config.yml",
+      "summary": "Issue template chooser configuration that toggles blank issues and defines external contact links shown in the new-issue picker.",
+      "tags": [
+        "configuration",
+        "github",
+        "issue-template"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/ISSUE_TEMPLATE/feature_request.yml",
+      "type": "config",
+      "name": "feature_request.yml",
+      "filePath": ".github/ISSUE_TEMPLATE/feature_request.yml",
+      "summary": "GitHub issue form template for feature requests, capturing the proposed feature, motivation, and alternatives considered.",
+      "tags": [
+        "configuration",
+        "github",
+        "issue-template",
+        "feature-request"
+      ],
+      "complexity": "simple",
+      "languageNotes": "GitHub YAML issue forms schema with typed body elements."
+    },
+    {
+      "id": "config:.github/ISSUE_TEMPLATE/question.yml",
+      "type": "config",
+      "name": "question.yml",
+      "filePath": ".github/ISSUE_TEMPLATE/question.yml",
+      "summary": "GitHub issue form template for user questions, collecting the question text and relevant context.",
+      "tags": [
+        "configuration",
+        "github",
+        "issue-template",
+        "question"
+      ],
+      "complexity": "simple",
+      "languageNotes": "GitHub YAML issue forms schema with typed body elements."
+    },
+    {
+      "id": "document:CLAUDE.md",
+      "type": "document",
+      "name": "CLAUDE.md",
+      "filePath": "CLAUDE.md",
+      "summary": "Project instruction file for Claude Code agents covering architecture, key commands, conventions, gotchas, versioning, and local plugin testing for the monorepo.",
+      "tags": [
+        "documentation",
+        "agent-instructions",
+        "conventions",
+        "build-system"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:CODE_OF_CONDUCT.md",
+      "type": "document",
+      "name": "CODE_OF_CONDUCT.md",
+      "filePath": "CODE_OF_CONDUCT.md",
+      "summary": "Community code of conduct outlining expected behavior, prohibited conduct, reporting channels, and scope.",
+      "tags": [
+        "documentation",
+        "community",
+        "governance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:CONTRIBUTING.md",
+      "type": "document",
+      "name": "CONTRIBUTING.md",
+      "filePath": "CONTRIBUTING.md",
+      "summary": "Contributor guide detailing setup, development workflow, testing, code style, translation, bug reports, and the pull request checklist.",
+      "tags": [
+        "documentation",
+        "development",
+        "contributing",
+        "guidelines"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "README.md",
+      "summary": "Primary project overview with features, quick start, multi-platform installation, team sharing, and an explanation of the tree-sitter + LLM hybrid multi-agent pipeline.",
+      "tags": [
+        "documentation",
+        "entry-point",
+        "overview",
+        "installation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:SECURITY.md",
+      "type": "document",
+      "name": "SECURITY.md",
+      "filePath": "SECURITY.md",
+      "summary": "Security policy describing how to report vulnerabilities, what to include, expected response, and the scope of coverage.",
+      "tags": [
+        "documentation",
+        "security",
+        "governance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:install.ps1",
+      "type": "file",
+      "name": "install.ps1",
+      "filePath": "install.ps1",
+      "summary": "Windows PowerShell installer that clones the repo and creates skill symlinks/junctions per target platform, with install, uninstall, and update commands.",
+      "tags": [
+        "installation",
+        "deployment",
+        "script",
+        "powershell"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses NTFS junctions (New-Item -ItemType Junction) instead of symlinks to avoid requiring elevated privileges, and an ordered hashtable to drive the per-platform skill layout."
+    },
+    {
+      "id": "file:install.sh",
+      "type": "file",
+      "name": "install.sh",
+      "filePath": "install.sh",
+      "summary": "POSIX shell installer that clones the repo and symlinks skills for the selected platform, supporting interactive platform selection plus install, uninstall, and update subcommands.",
+      "tags": [
+        "installation",
+        "deployment",
+        "script",
+        "shell"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "config:package.json",
+      "type": "config",
+      "name": "package.json",
+      "filePath": "package.json",
+      "summary": "Root monorepo manifest defining workspace metadata, the pinned pnpm package manager, build/test/lint scripts, and dev dependencies.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "monorepo",
+        "npm"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:pnpm-workspace.yaml",
+      "type": "config",
+      "name": "pnpm-workspace.yaml",
+      "filePath": "pnpm-workspace.yaml",
+      "summary": "pnpm workspace definition enumerating the plugin packages, plugin root, and homepage as workspace members.",
+      "tags": [
+        "configuration",
+        "monorepo",
+        "build-system",
+        "pnpm"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:tsconfig.json",
+      "type": "config",
+      "name": "tsconfig.json",
+      "filePath": "tsconfig.json",
+      "summary": "Root TypeScript compiler configuration providing shared compilerOptions for the monorepo packages.",
+      "tags": [
+        "configuration",
+        "typescript",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.ps1:Show-Usage",
+      "type": "function",
+      "name": "Show-Usage",
+      "filePath": "install.ps1",
+      "lineRange": [
+        46,
+        63
+      ],
+      "summary": "Prints installer usage, supported platforms, and environment variable overrides.",
+      "tags": [
+        "cli",
+        "help",
+        "powershell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.ps1:Resolve-Platform",
+      "type": "function",
+      "name": "Resolve-Platform",
+      "filePath": "install.ps1",
+      "lineRange": [
+        65,
+        70
+      ],
+      "summary": "Looks up a platform id in the platform table, erroring out if it is unknown.",
+      "tags": [
+        "validation",
+        "lookup",
+        "powershell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.ps1:Prompt-Platform",
+      "type": "function",
+      "name": "Prompt-Platform",
+      "filePath": "install.ps1",
+      "lineRange": [
+        72,
+        84
+      ],
+      "summary": "Interactively prompts the user to choose a target platform from a numbered list and validates the selection.",
+      "tags": [
+        "cli",
+        "interactive",
+        "powershell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.ps1:Clone-Or-Update",
+      "type": "function",
+      "name": "Clone-Or-Update",
+      "filePath": "install.ps1",
+      "lineRange": [
+        88,
+        98
+      ],
+      "summary": "Clones the repository or fast-forward-pulls an existing checkout into the install directory.",
+      "tags": [
+        "git",
+        "installation",
+        "powershell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.ps1:Remove-Reparse",
+      "type": "function",
+      "name": "Remove-Reparse",
+      "filePath": "install.ps1",
+      "lineRange": [
+        112,
+        124
+      ],
+      "summary": "Safely deletes a junction or symlink without touching its target, refusing to remove real files or directories.",
+      "tags": [
+        "filesystem",
+        "safety",
+        "powershell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.ps1:New-Junction",
+      "type": "function",
+      "name": "New-Junction",
+      "filePath": "install.ps1",
+      "lineRange": [
+        126,
+        135
+      ],
+      "summary": "Creates an NTFS junction from a link path to a target, replacing an existing junction but refusing to overwrite real files.",
+      "tags": [
+        "filesystem",
+        "symlink",
+        "powershell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.ps1:Link-Skills",
+      "type": "function",
+      "name": "Link-Skills",
+      "filePath": "install.ps1",
+      "lineRange": [
+        137,
+        157
+      ],
+      "summary": "Creates skill junctions into a platform target directory using either per-skill or single-folder layout styles.",
+      "tags": [
+        "installation",
+        "filesystem",
+        "powershell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.ps1:Unlink-Skills",
+      "type": "function",
+      "name": "Unlink-Skills",
+      "filePath": "install.ps1",
+      "lineRange": [
+        159,
+        184
+      ],
+      "summary": "Removes skill junctions from a platform target, scanning for stale links when the checkout is already gone.",
+      "tags": [
+        "uninstall",
+        "filesystem",
+        "powershell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.ps1:Link-Plugin-Root",
+      "type": "function",
+      "name": "Link-Plugin-Root",
+      "filePath": "install.ps1",
+      "lineRange": [
+        186,
+        194
+      ],
+      "summary": "Creates a universal junction to the plugin root directory, leaving an existing link untouched.",
+      "tags": [
+        "installation",
+        "filesystem",
+        "powershell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.ps1:Cmd-Install",
+      "type": "function",
+      "name": "Cmd-Install",
+      "filePath": "install.ps1",
+      "lineRange": [
+        201,
+        244
+      ],
+      "summary": "Orchestrates a full install: clones/updates the repo, links skills and plugin root, and generates Kiro agent configuration when targeting Kiro.",
+      "tags": [
+        "installation",
+        "orchestration",
+        "powershell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.ps1:Cmd-Uninstall",
+      "type": "function",
+      "name": "Cmd-Uninstall",
+      "filePath": "install.ps1",
+      "lineRange": [
+        246,
+        264
+      ],
+      "summary": "Removes all skill links and platform-specific config for a given platform while preserving the shared checkout.",
+      "tags": [
+        "uninstall",
+        "orchestration",
+        "powershell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.ps1:Cmd-Update",
+      "type": "function",
+      "name": "Cmd-Update",
+      "filePath": "install.ps1",
+      "lineRange": [
+        266,
+        272
+      ],
+      "summary": "Fast-forward-pulls the existing repository checkout to update the installation.",
+      "tags": [
+        "git",
+        "update",
+        "powershell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:platforms_table",
+      "type": "function",
+      "name": "platforms_table",
+      "filePath": "install.sh",
+      "lineRange": [
+        29,
+        46
+      ],
+      "summary": "Emits the table of supported platforms with their target skill directory and linking style.",
+      "tags": [
+        "configuration",
+        "data",
+        "shell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:resolve_platform",
+      "type": "function",
+      "name": "resolve_platform",
+      "filePath": "install.sh",
+      "lineRange": [
+        50,
+        60
+      ],
+      "summary": "Resolves a platform id to its target directory and style, erroring on unknown platforms.",
+      "tags": [
+        "validation",
+        "lookup",
+        "shell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:prompt_platform",
+      "type": "function",
+      "name": "prompt_platform",
+      "filePath": "install.sh",
+      "lineRange": [
+        62,
+        91
+      ],
+      "summary": "Interactively prompts the user to select a platform from a numbered menu and validates input.",
+      "tags": [
+        "cli",
+        "interactive",
+        "shell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.sh:list_skills",
+      "type": "function",
+      "name": "list_skills",
+      "filePath": "install.sh",
+      "lineRange": [
+        106,
+        118
+      ],
+      "summary": "Lists the available skill directory names from the plugin skills root.",
+      "tags": [
+        "filesystem",
+        "listing",
+        "shell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:link_skills",
+      "type": "function",
+      "name": "link_skills",
+      "filePath": "install.sh",
+      "lineRange": [
+        120,
+        142
+      ],
+      "summary": "Creates skill symlinks into a target directory using per-skill or folder linking styles.",
+      "tags": [
+        "installation",
+        "filesystem",
+        "shell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.sh:unlink_skills",
+      "type": "function",
+      "name": "unlink_skills",
+      "filePath": "install.sh",
+      "lineRange": [
+        144,
+        170
+      ],
+      "summary": "Removes skill symlinks from a target directory for the selected linking style.",
+      "tags": [
+        "uninstall",
+        "filesystem",
+        "shell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.sh:cmd_install",
+      "type": "function",
+      "name": "cmd_install",
+      "filePath": "install.sh",
+      "lineRange": [
+        181,
+        232
+      ],
+      "summary": "Drives a full install: clones/updates the repo, links skills and plugin root, and applies platform-specific setup.",
+      "tags": [
+        "installation",
+        "orchestration",
+        "shell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.sh:cmd_uninstall",
+      "type": "function",
+      "name": "cmd_uninstall",
+      "filePath": "install.sh",
+      "lineRange": [
+        234,
+        255
+      ],
+      "summary": "Removes skill links and platform config while keeping the shared checkout.",
+      "tags": [
+        "uninstall",
+        "orchestration",
+        "shell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:install.sh:usage",
+      "type": "function",
+      "name": "usage",
+      "filePath": "install.sh",
+      "lineRange": [
+        266,
+        283
+      ],
+      "summary": "Prints the installer usage text, supported platforms, and environment overrides.",
+      "tags": [
+        "cli",
+        "help",
+        "shell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:install.sh:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "install.sh",
+      "lineRange": [
+        285,
+        316
+      ],
+      "summary": "Entry point that parses arguments and dispatches to install, uninstall, update, or usage.",
+      "tags": [
+        "entry-point",
+        "cli",
+        "shell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:READMEs/README.es-ES.md",
+      "type": "document",
+      "name": "README.es-ES.md",
+      "filePath": "READMEs/README.es-ES.md",
+      "summary": "Spanish (es-ES) translation of the project README, covering features, quick start, multi-platform installation, team graph sharing, and how the tree-sitter + LLM pipeline works.",
+      "tags": [
+        "documentation",
+        "localization",
+        "readme",
+        "overview"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Localized README; mirrors the canonical English README structure with 24 sections."
+    },
+    {
+      "id": "document:READMEs/README.ja-JP.md",
+      "type": "document",
+      "name": "README.ja-JP.md",
+      "filePath": "READMEs/README.ja-JP.md",
+      "summary": "Japanese (ja-JP) translation of the project README, covering features, quick start, multi-platform installation, team graph sharing, and the multi-agent analysis pipeline.",
+      "tags": [
+        "documentation",
+        "localization",
+        "readme",
+        "overview"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Localized README; mirrors the canonical English README structure with 24 sections."
+    },
+    {
+      "id": "document:READMEs/README.ko-KR.md",
+      "type": "document",
+      "name": "README.ko-KR.md",
+      "filePath": "READMEs/README.ko-KR.md",
+      "summary": "Korean (ko-KR) translation of the project README, covering features, quick start, multi-platform installation, team graph sharing, and how the analysis works under the hood.",
+      "tags": [
+        "documentation",
+        "localization",
+        "readme",
+        "overview"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Localized README; mirrors the canonical English README structure with 24 sections."
+    },
+    {
+      "id": "document:READMEs/README.ru-RU.md",
+      "type": "document",
+      "name": "README.ru-RU.md",
+      "filePath": "READMEs/README.ru-RU.md",
+      "summary": "Russian (ru-RU) translation of the project README, covering features, quick start, multi-platform installation, team graph sharing, and the tree-sitter + LLM hybrid pipeline.",
+      "tags": [
+        "documentation",
+        "localization",
+        "readme",
+        "overview"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Localized README; mirrors the canonical English README structure with 24 sections."
+    },
+    {
+      "id": "document:READMEs/README.tr-TR.md",
+      "type": "document",
+      "name": "README.tr-TR.md",
+      "filePath": "READMEs/README.tr-TR.md",
+      "summary": "Turkish (tr-TR) translation of the project README, covering features, quick start, multi-platform installation, team graph sharing, and the multi-agent analysis pipeline.",
+      "tags": [
+        "documentation",
+        "localization",
+        "readme",
+        "overview"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Localized README; mirrors the canonical English README structure with 24 sections."
+    },
+    {
+      "id": "document:READMEs/README.zh-CN.md",
+      "type": "document",
+      "name": "README.zh-CN.md",
+      "filePath": "READMEs/README.zh-CN.md",
+      "summary": "Simplified Chinese (zh-CN) translation of the project README, covering core features, quick start, multi-platform support, team graph sharing, and the technical pipeline.",
+      "tags": [
+        "documentation",
+        "localization",
+        "readme",
+        "overview"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Localized README; mirrors the canonical English README structure with 24 sections."
+    },
+    {
+      "id": "document:READMEs/README.zh-TW.md",
+      "type": "document",
+      "name": "README.zh-TW.md",
+      "filePath": "READMEs/README.zh-TW.md",
+      "summary": "Traditional Chinese (zh-TW) translation of the project README, covering core features, quick start, multi-platform support, team graph sharing, and the technical pipeline.",
+      "tags": [
+        "documentation",
+        "localization",
+        "readme",
+        "overview"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Localized README; mirrors the canonical English README structure with 24 sections."
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-14-phase1-implementation.md",
+      "type": "document",
+      "name": "2026-03-14-phase1-implementation.md",
+      "filePath": "docs/superpowers/plans/2026-03-14-phase1-implementation.md",
+      "summary": "Phase 1 implementation plan covering the foundational monorepo scaffolding, core package types and persistence, the tree-sitter analyzer plugin, the LLM analysis engine, and the initial Vite + React dashboard with React Flow, Monaco, and search.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "scaffolding",
+        "architecture",
+        "core"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Task-structured plan with 10 sequential tasks and inline code snippets and a verification checklist."
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-14-phase2-implementation.md",
+      "type": "document",
+      "name": "2026-03-14-phase2-implementation.md",
+      "filePath": "docs/superpowers/plans/2026-03-14-phase2-implementation.md",
+      "summary": "Phase 2 (Intelligence) implementation plan adding Zod schema validation for graph loading, fuzzy search, Dagre auto-layout, staleness detection, layer auto-detection, the /understand-chat skill, and dashboard chat and layer visualization.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "search",
+        "validation",
+        "dashboard"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-14-phase3-implementation.md",
+      "type": "document",
+      "name": "2026-03-14-phase3-implementation.md",
+      "filePath": "docs/superpowers/plans/2026-03-14-phase3-implementation.md",
+      "summary": "Phase 3 (Learn Mode) implementation plan covering the tour generation engine, LearnPanel and tour store, graph-highlighting tour player, contextual node explanation, language lesson prompt builder, and persona mode system.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "tours",
+        "learn-mode",
+        "dashboard"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-14-phase4-implementation.md",
+      "type": "document",
+      "name": "2026-03-14-phase4-implementation.md",
+      "filePath": "docs/superpowers/plans/2026-03-14-phase4-implementation.md",
+      "summary": "Phase 4 (Advanced) implementation plan introducing the /understand-diff, /understand-explain, and /understand-onboard skills, a plugin registry and loader, plugin configuration/discovery, and embedding-based semantic search with dashboard integration.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "skills",
+        "plugins",
+        "embeddings"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-15-homepage-implementation.md",
+      "type": "document",
+      "name": "2026-03-15-homepage-implementation.md",
+      "filePath": "docs/superpowers/plans/2026-03-15-homepage-implementation.md",
+      "summary": "Homepage implementation plan scaffolding an Astro site with self-hosted fonts, nav, hero, dashboard showcase, feature cards, install CTA, and footer components, plus a GitHub Actions deployment workflow and favicon.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "homepage",
+        "astro",
+        "deployment"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-18-multi-platform-simple-implementation.md",
+      "type": "document",
+      "name": "2026-03-18-multi-platform-simple-implementation.md",
+      "filePath": "docs/superpowers/plans/2026-03-18-multi-platform-simple-implementation.md",
+      "summary": "Multi-platform support plan moving pipeline agents into skills as prompt templates, adding context injection to SKILL.md dispatch, creating the knowledge-graph-guide agent, and adding plugin descriptors and platform INSTALL.md files.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "multi-platform",
+        "agents",
+        "plugins"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-21-language-agnostic-plan.md",
+      "type": "document",
+      "name": "2026-03-21-language-agnostic-plan.md",
+      "filePath": "docs/superpowers/plans/2026-03-21-language-agnostic-plan.md",
+      "summary": "Language-agnostic support plan defining LanguageConfig types and a LanguageRegistry, twelve language configs, a GenericTreeSitterPlugin using WASM grammars, language prompt snippets, and prompt-injection logic in the skill source.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "language-support",
+        "tree-sitter",
+        "core"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-25-dashboard-robustness-impl.md",
+      "type": "document",
+      "name": "2026-03-25-dashboard-robustness-impl.md",
+      "filePath": "docs/superpowers/plans/2026-03-25-dashboard-robustness-impl.md",
+      "summary": "Dashboard robustness implementation plan adding a tiered permissive graph-loading pipeline (sanitize, auto-fix, drop-with-warning) with a GraphIssue type, rewritten validateGraph, and a WarningBanner component wired into App.tsx.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "dashboard",
+        "validation",
+        "robustness"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-25-dashboard-robustness-plan.md",
+      "type": "document",
+      "name": "2026-03-25-dashboard-robustness-plan.md",
+      "filePath": "docs/superpowers/plans/2026-03-25-dashboard-robustness-plan.md",
+      "summary": "Design document for permissive graph loading describing the four-tier robustness pipeline (sanitize silently, auto-fix with notice, drop with warning, fatal), return types, the WarningBanner UI, and test coverage.",
+      "tags": [
+        "documentation",
+        "design",
+        "dashboard",
+        "validation",
+        "robustness"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-26-theme-system-implementation.md",
+      "type": "document",
+      "name": "2026-03-26-theme-system-implementation.md",
+      "filePath": "docs/superpowers/plans/2026-03-26-theme-system-implementation.md",
+      "summary": "Theme system implementation plan renaming gold to accent CSS variables, consolidating RGBA values, defining theme types and presets, building a theme engine and ThemeContext, and adding a ThemePicker with light-theme adjustments.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "theme",
+        "dashboard",
+        "css"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-27-token-reduction-impl.md",
+      "type": "document",
+      "name": "2026-03-27-token-reduction-impl.md",
+      "filePath": "docs/superpowers/plans/2026-03-27-token-reduction-impl.md",
+      "summary": "Token reduction implementation plan gating graph-reviewer behind a --review flag, slimming architecture and tour-builder node payloads, removing language addendums from file-analyzer batches, and pre-resolving imports in the scanner via batchImportData.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "token-optimization",
+        "agents",
+        "pipeline"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Fine-grained plan broken into 9 tasks with 57 numbered step subsections including explicit commit checkpoints."
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-28-understand-anything-extension-impl.md",
+      "type": "document",
+      "name": "2026-03-28-understand-anything-extension-impl.md",
+      "filePath": "docs/superpowers/plans/2026-03-28-understand-anything-extension-impl.md",
+      "summary": "Universal file type support plan extending core node and edge types, adding Zod schema aliases, 26 non-code language configs and 12 custom parsers, updating GraphBuilder and all agent prompts, plus dashboard node-type colors, filters, and sidebar updates.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "file-types",
+        "parsers",
+        "dashboard"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-03-29-homepage-update-impl.md",
+      "type": "document",
+      "name": "2026-03-29-homepage-update-impl.md",
+      "filePath": "docs/superpowers/plans/2026-03-29-homepage-update-impl.md",
+      "summary": "Short homepage feature update plan replacing three feature cards with six, adding a multi-platform note to the install section, and updating the footer tagline.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "homepage",
+        "astro",
+        "content-update"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-04-01-business-domain-knowledge-impl.md",
+      "type": "document",
+      "name": "2026-04-01-business-domain-knowledge-impl.md",
+      "filePath": "docs/superpowers/plans/2026-04-01-business-domain-knowledge-impl.md",
+      "summary": "Business domain knowledge extraction plan extending core types with domain/flow/step nodes, adding domain graph persistence and normalization, dashboard domain view components and view-mode toggle, a domain-analyzer agent, and the /understand-domain skill.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "domain-model",
+        "dashboard",
+        "agents"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-04-09-understand-knowledge.md",
+      "type": "document",
+      "name": "2026-04-09-understand-knowledge.md",
+      "filePath": "docs/superpowers/plans/2026-04-09-understand-knowledge.md",
+      "summary": "/understand-knowledge implementation plan extending core types and schema for knowledge graphs, adding dashboard CSS variables, knowledge sidebar and reading panel components, vertical layout and edge styling, agent definitions, and the SKILL.md.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "knowledge-graph",
+        "dashboard",
+        "skills"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-04-10-understandignore-impl.md",
+      "type": "document",
+      "name": "2026-04-10-understandignore-impl.md",
+      "filePath": "docs/superpowers/plans/2026-04-10-understandignore-impl.md",
+      "summary": ".understandignore implementation plan adding the ignore dependency, TDD-built IgnoreFilter and IgnoreGenerator modules, core exports, project-scanner agent updates, and a Phase 0.5 in the /understand skill.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "ignore-filter",
+        "tdd",
+        "core"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-04-15-language-extractors-impl.md",
+      "type": "document",
+      "name": "2026-04-15-language-extractors-impl.md",
+      "filePath": "docs/superpowers/plans/2026-04-15-language-extractors-impl.md",
+      "summary": "Language-specific extractor architecture plan defining a LanguageExtractor interface and per-language extractors for ten languages, extractCallGraph in PluginRegistry, the bundled extract-structure.mjs script, and a rewritten file-analyzer Phase 1.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "language-support",
+        "tree-sitter",
+        "extractors"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-05-03-graph-layout-scaling.md",
+      "type": "document",
+      "name": "2026-05-03-graph-layout-scaling.md",
+      "filePath": "docs/superpowers/plans/2026-05-03-graph-layout-scaling.md",
+      "summary": "Graph layout scaling plan introducing container derivation (folder strategy plus Louvain community fallback), container edge aggregation, ELK layout with input repair, store extensions, a ContainerNode component, staged layer-detail expansion, and performance benchmarks.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "graph-layout",
+        "dashboard",
+        "performance"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-05-24-semantic-batching-and-output-chunking-impl.md",
+      "type": "document",
+      "name": "2026-05-24-semantic-batching-and-output-chunking-impl.md",
+      "filePath": "docs/superpowers/plans/2026-05-24-semantic-batching-and-output-chunking-impl.md",
+      "summary": "Semantic batching and output chunking plan adding graphology-based Louvain batching in compute-batches.mjs, size enforcement, exports extraction, non-code batching, batchImportData and neighborMap, a fallback path, --changed-files mode, file-analyzer multi-part protocol, and merge-batch-graphs.py updates.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "batching",
+        "pipeline",
+        "agents"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/plans/2026-06-03-language-auto-detection.md",
+      "type": "document",
+      "name": "2026-06-03-language-auto-detection.md",
+      "filePath": "docs/superpowers/plans/2026-06-03-language-auto-detection.md",
+      "summary": "Conversation-language auto-detection plan expanding the language-resolution branch in SKILL.md, documenting first-run auto-detection in the README, and adding manual verification and PR steps.",
+      "tags": [
+        "documentation",
+        "implementation-plan",
+        "language-detection",
+        "skills",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-03-14-understand-anything-design.md",
+      "type": "document",
+      "name": "2026-03-14-understand-anything-design.md",
+      "filePath": "docs/superpowers/specs/2026-03-14-understand-anything-design.md",
+      "summary": "Foundational design and implementation plan for Understand Anything, covering the monorepo architecture, knowledge graph schema, multi-panel React dashboard, skill commands, persistence, plugin system, and a four-phase rollout.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "architecture",
+        "overview",
+        "roadmap"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Master design doc spanning 16 sections from architecture through phased verification."
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-03-15-homepage-design.md",
+      "type": "document",
+      "name": "2026-03-15-homepage-design.md",
+      "filePath": "docs/superpowers/specs/2026-03-15-homepage-design.md",
+      "summary": "Design spec for the project marketing homepage, defining tech stack, deployment, scroll-order page structure (hero, showcase, feature cards, install CTA, footer), and the dark-luxury visual design system.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "homepage",
+        "ui-design",
+        "marketing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-03-18-multi-platform-simple-design.md",
+      "type": "document",
+      "name": "2026-03-18-multi-platform-simple-design.md",
+      "filePath": "docs/superpowers/specs/2026-03-18-multi-platform-simple-design.md",
+      "summary": "Simplified design for multi-platform skill support, moving pipeline agents into the skill, registering the knowledge-graph-guide agent, and adding platform installation files for cross-platform compatibility.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "multi-platform",
+        "agent-pipeline",
+        "compatibility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-03-21-language-agnostic-design.md",
+      "type": "document",
+      "name": "2026-03-21-language-agnostic-design.md",
+      "filePath": "docs/superpowers/specs/2026-03-21-language-agnostic-design.md",
+      "summary": "Design for language-agnostic codebase support via a LanguageConfig registry, a GenericTreeSitterPlugin with WASM grammar loading, language-aware prompts, and graceful degradation for unknown languages.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "language-support",
+        "tree-sitter",
+        "extensibility"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-03-26-theme-system-design.md",
+      "type": "document",
+      "name": "2026-03-26-theme-system-design.md",
+      "filePath": "docs/superpowers/specs/2026-03-26-theme-system-design.md",
+      "summary": "Comprehensive theme system design covering preset color definitions, glass effects, the theme engine, React context, Zustand integration, persistence/resolution order, hardcoded color consolidation, and light-theme support.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "theme-system",
+        "ui-design",
+        "dashboard"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-03-27-token-reduction-design.md",
+      "type": "document",
+      "name": "2026-03-27-token-reduction-design.md",
+      "filePath": "docs/superpowers/specs/2026-03-27-token-reduction-design.md",
+      "summary": "Token reduction design proposing five changes (pre-resolved imports, larger batches, removed prompt addendums, slimmer payloads, and a gated graph-reviewer) to cut the agent pipeline's token cost.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "token-optimization",
+        "agent-pipeline",
+        "performance"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-03-28-understand-anything-extension-design.md",
+      "type": "document",
+      "name": "2026-03-28-understand-anything-extension-design.md",
+      "filePath": "docs/superpowers/specs/2026-03-28-understand-anything-extension-design.md",
+      "summary": "Design for universal file-type support, adding 26 new file types across docs/config/infra/data/script/markup with corresponding schema node/edge extensions, custom parsers, and dashboard visualizations.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "file-type-support",
+        "schema-extension",
+        "extensibility"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-03-29-homepage-update-design.md",
+      "type": "document",
+      "name": "2026-03-29-homepage-update-design.md",
+      "filePath": "docs/superpowers/specs/2026-03-29-homepage-update-design.md",
+      "summary": "Incremental homepage update spec expanding the features section from 3 to 6 cards and revising the install and footer sections.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "homepage",
+        "ui-design",
+        "iteration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-04-01-business-domain-knowledge-design.md",
+      "type": "document",
+      "name": "2026-04-01-business-domain-knowledge-design.md",
+      "filePath": "docs/superpowers/specs/2026-04-01-business-domain-knowledge-design.md",
+      "summary": "Design spec for business-domain knowledge extraction, defining a three-level domain/flow/step graph schema, dual analysis pipeline, preprocessing script, dashboard domain view, and the /understand-domain skill.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "domain-modeling",
+        "knowledge-graph",
+        "agent-pipeline"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-04-09-understand-knowledge-design.md",
+      "type": "document",
+      "name": "2026-04-09-understand-knowledge-design.md",
+      "filePath": "docs/superpowers/specs/2026-04-09-understand-knowledge-design.md",
+      "summary": "Design for the /understand-knowledge personal knowledge-base plugin, covering schema extensions, format auto-detection and guides, an agent pipeline with incremental ingest, and dashboard reading-mode changes.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "knowledge-base",
+        "knowledge-graph",
+        "agent-pipeline"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-04-10-understandignore-design.md",
+      "type": "document",
+      "name": "2026-04-10-understandignore-design.md",
+      "filePath": "docs/superpowers/specs/2026-04-10-understandignore-design.md",
+      "summary": "Design for the .understandignore feature, specifying an IgnoreFilter module with default patterns, a starter-file generator with detection logic, skill integration via a new ignore-setup phase, and test coverage.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "ignore-filter",
+        "configuration",
+        "agent-pipeline"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-05-03-graph-layout-scaling-design.md",
+      "type": "document",
+      "name": "2026-05-03-graph-layout-scaling-design.md",
+      "filePath": "docs/superpowers/specs/2026-05-03-graph-layout-scaling-design.md",
+      "summary": "Design for scaling dashboard graph layout, covering container derivation, ELK layout integration, edge aggregation, a ContainerNode visual, lazy two-stage layout with a state machine, and a files/test plan.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "graph-layout",
+        "dashboard",
+        "performance"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-05-24-semantic-batching-and-output-chunking-design.md",
+      "type": "document",
+      "name": "2026-05-24-semantic-batching-and-output-chunking-design.md",
+      "filePath": "docs/superpowers/specs/2026-05-24-semantic-batching-and-output-chunking-design.md",
+      "summary": "Design for semantic batching and output chunking, introducing compute-batches.mjs with Louvain clustering, SKILL.md analyze-phase changes, file-analyzer cross-batch context, and merge-batch-graphs.py multi-part awareness.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "semantic-batching",
+        "agent-pipeline",
+        "scalability"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:docs/superpowers/specs/2026-06-03-language-auto-detection-design.md",
+      "type": "document",
+      "name": "2026-06-03-language-auto-detection-design.md",
+      "filePath": "docs/superpowers/specs/2026-06-03-language-auto-detection-design.md",
+      "summary": "Design for conversation-language auto-detection in /understand, defining a resolution chain rewriting SKILL.md step 3.6, a confirmation gate for non-English detection, edge-case handling, and verification.",
+      "tags": [
+        "documentation",
+        "design-spec",
+        "language-detection",
+        "internationalization",
+        "skill"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:homepage/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "homepage/README.md",
+      "summary": "Documentation for the homepage Astro site, describing the project structure, the Egonex organization identity for public messaging, and the pnpm filter commands for dev/build/preview.",
+      "tags": [
+        "documentation",
+        "entry-point",
+        "astro",
+        "homepage"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:homepage/package.json",
+      "type": "config",
+      "name": "package.json",
+      "filePath": "homepage/package.json",
+      "summary": "Package manifest for the homepage workspace, declaring Astro 6 as the sole dependency and exposing dev/build/preview/astro scripts; pins Node >= 22.12.0.",
+      "tags": [
+        "configuration",
+        "astro",
+        "build-system",
+        "package-manifest"
+      ],
+      "complexity": "simple",
+      "languageNotes": "ESM package (\"type\": \"module\") with the Astro CLI driving all scripts."
+    },
+    {
+      "id": "config:homepage/tsconfig.json",
+      "type": "config",
+      "name": "tsconfig.json",
+      "filePath": "homepage/tsconfig.json",
+      "summary": "TypeScript configuration for the homepage site, extending Astro's strict preset and including generated Astro types while excluding the dist build output.",
+      "tags": [
+        "configuration",
+        "typescript",
+        "astro",
+        "build-system"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Extends astro/tsconfigs/strict for Astro-aware strict type checking."
+    },
+    {
+      "id": "config:tests/skill/understand/fixtures/scan-result-3-cliques.json",
+      "type": "config",
+      "name": "scan-result-3-cliques.json",
+      "filePath": "tests/skill/understand/fixtures/scan-result-3-cliques.json",
+      "summary": "Project-scanner ScanResult test fixture with three disjoint import cliques (auth, api, db) used to exercise Louvain community detection in the understand skill's batching logic.",
+      "tags": [
+        "test",
+        "fixture",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Mirrors the ScanResult schema (files, importMap, estimatedComplexity) consumed by the project-scanner pipeline."
+    },
+    {
+      "id": "config:tests/skill/understand/fixtures/scan-result-large-community.json",
+      "type": "config",
+      "name": "scan-result-large-community.json",
+      "filePath": "tests/skill/understand/fixtures/scan-result-large-community.json",
+      "summary": "Project-scanner ScanResult test fixture of 40 mutually-importing files forming one community above the max=35 cap, used to verify large-community splitting during batch assembly.",
+      "tags": [
+        "test",
+        "fixture",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Large hand-crafted importMap (1895 lines) stressing the batch size cap."
+    },
+    {
+      "id": "config:tests/skill/understand/fixtures/scan-result-merge-respects-non-mergeable.json",
+      "type": "config",
+      "name": "scan-result-merge-respects-non-mergeable.json",
+      "filePath": "tests/skill/understand/fixtures/scan-result-merge-respects-non-mergeable.json",
+      "summary": "Regression fixture ensuring mergeSmallBatches never pools a non-mergeable Dockerfile cluster into the misc bucket alongside isolated code singletons, preserving per-service infra context.",
+      "tags": [
+        "test",
+        "fixture",
+        "configuration",
+        "regression"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:tests/skill/understand/fixtures/scan-result-non-code.json",
+      "type": "config",
+      "name": "scan-result-non-code.json",
+      "filePath": "tests/skill/understand/fixtures/scan-result-non-code.json",
+      "summary": "ScanResult fixture mixing non-code files across batching Groups A-E, with a 3-file code clique that survives merge-small, used to assert non-code batches follow code batches.",
+      "tags": [
+        "test",
+        "fixture",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:tests/skill/understand/fixtures/scan-result-singletons.json",
+      "type": "config",
+      "name": "scan-result-singletons.json",
+      "filePath": "tests/skill/understand/fixtures/scan-result-singletons.json",
+      "summary": "ScanResult fixture of 100 isolated TypeScript files expected to merge into roughly four misc batches, used to test singleton pooling in batch assembly.",
+      "tags": [
+        "test",
+        "fixture",
+        "configuration",
+        "data-model"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "document:understand-anything-plugin/agents/architecture-analyzer.md",
+      "type": "document",
+      "name": "architecture-analyzer.md",
+      "filePath": "understand-anything-plugin/agents/architecture-analyzer.md",
+      "summary": "Agent definition for the architecture-analyzer, which runs a structural analysis script then performs semantic layer assignment to group every file node into 3-10 logical architectural layers based on dependency direction, summaries, and tags.",
+      "tags": [
+        "documentation",
+        "agent-definition",
+        "architecture",
+        "layering"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Two-phase agent prompt: deterministic script extraction followed by LLM semantic layer assignment."
+    },
+    {
+      "id": "document:understand-anything-plugin/agents/article-analyzer.md",
+      "type": "document",
+      "name": "article-analyzer.md",
+      "filePath": "understand-anything-plugin/agents/article-analyzer.md",
+      "summary": "Agent definition for the article-analyzer, which extracts knowledge graph nodes and edges (entities, claims, implicit relationships) from markdown articles using pre-parsed structural data and LLM inference.",
+      "tags": [
+        "documentation",
+        "agent-definition",
+        "knowledge-extraction",
+        "entities"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:understand-anything-plugin/agents/assemble-reviewer.md",
+      "type": "document",
+      "name": "assemble-reviewer.md",
+      "filePath": "understand-anything-plugin/agents/assemble-reviewer.md",
+      "summary": "Agent definition for the assemble-reviewer, which reviews the output of merge-batch-graphs.py for semantic issues, recovers dropped nodes/edges, and fills cross-batch edge gaps that the merge script cannot catch.",
+      "tags": [
+        "documentation",
+        "agent-definition",
+        "graph-assembly",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:understand-anything-plugin/agents/domain-analyzer.md",
+      "type": "document",
+      "name": "domain-analyzer.md",
+      "filePath": "understand-anything-plugin/agents/domain-analyzer.md",
+      "summary": "Agent definition for the domain-analyzer, which extracts business domain knowledge as a three-level hierarchy of domains, business flows, and process steps to produce a domain-graph.json.",
+      "tags": [
+        "documentation",
+        "agent-definition",
+        "domain-modeling",
+        "business-flow"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:understand-anything-plugin/agents/file-analyzer.md",
+      "type": "document",
+      "name": "file-analyzer.md",
+      "filePath": "understand-anything-plugin/agents/file-analyzer.md",
+      "summary": "Agent definition for the file-analyzer, which analyzes batches of source files in two phases: bundled tree-sitter structural extraction followed by LLM semantic analysis producing graph nodes and edges per file.",
+      "tags": [
+        "documentation",
+        "agent-definition",
+        "structural-extraction",
+        "graph-nodes"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Defines strict node ID conventions, edge-type tables, and batch output file naming required by the downstream merge script."
+    },
+    {
+      "id": "document:understand-anything-plugin/agents/graph-reviewer.md",
+      "type": "document",
+      "name": "graph-reviewer.md",
+      "filePath": "understand-anything-plugin/agents/graph-reviewer.md",
+      "summary": "Agent definition for the graph-reviewer, which runs a validation script over the assembled knowledge graph and renders an approval or rejection decision based on correctness, completeness, and quality checks.",
+      "tags": [
+        "documentation",
+        "agent-definition",
+        "validation",
+        "quality-gate"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:understand-anything-plugin/agents/knowledge-graph-guide.md",
+      "type": "document",
+      "name": "knowledge-graph-guide.md",
+      "filePath": "understand-anything-plugin/agents/knowledge-graph-guide.md",
+      "summary": "Agent definition for the knowledge-graph-guide, which helps users understand and query an Understand-Anything graph by explaining graph locations, node/edge types, layers, tours, and domain-graph specifics.",
+      "tags": [
+        "documentation",
+        "agent-definition",
+        "user-guide",
+        "knowledge-graph"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:understand-anything-plugin/agents/project-scanner.md",
+      "type": "document",
+      "name": "project-scanner.md",
+      "filePath": "understand-anything-plugin/agents/project-scanner.md",
+      "summary": "Agent definition for the project-scanner, the pipeline's first stage that produces a file inventory via bundled scan and import-map scripts plus an LLM narrative of languages, frameworks, and complexity.",
+      "tags": [
+        "documentation",
+        "agent-definition",
+        "project-scan",
+        "import-map"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:understand-anything-plugin/agents/tour-builder.md",
+      "type": "document",
+      "name": "tour-builder.md",
+      "filePath": "understand-anything-plugin/agents/tour-builder.md",
+      "summary": "Agent definition for the tour-builder, which runs a graph-topology script then designs 5-15 pedagogical tour steps using BFS traversal, clusters, and layers to teach a project's architecture in logical order.",
+      "tags": [
+        "documentation",
+        "agent-definition",
+        "tours",
+        "pedagogy"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses graph topology (BFS, clustering, layers) as the structural backbone for narrative tour design."
+    },
+    {
+      "id": "config:understand-anything-plugin/package.json",
+      "type": "config",
+      "name": "package.json",
+      "filePath": "understand-anything-plugin/package.json",
+      "summary": "Plugin package manifest for @understand-anything/skill, declaring the TypeScript build/test scripts and dependencies on the workspace core package, graphology, and Louvain community detection.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "manifest",
+        "dependencies"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses pnpm workspace protocol (workspace:*) to link the @understand-anything/core package locally; ESM module type with tsc-based build."
+    },
+    {
+      "id": "config:understand-anything-plugin/pnpm-workspace.yaml",
+      "type": "config",
+      "name": "pnpm-workspace.yaml",
+      "filePath": "understand-anything-plugin/pnpm-workspace.yaml",
+      "summary": "pnpm workspace definition mapping all subdirectories under packages/* (core and dashboard) as workspace packages.",
+      "tags": [
+        "configuration",
+        "monorepo",
+        "build-system",
+        "workspace"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:understand-anything-plugin/tsconfig.json",
+      "type": "config",
+      "name": "tsconfig.json",
+      "filePath": "understand-anything-plugin/tsconfig.json",
+      "summary": "TypeScript compiler configuration for the skill package, enabling strict mode, ES2022/ESNext output with bundler module resolution, declaration maps, and source maps, compiling src into dist.",
+      "tags": [
+        "configuration",
+        "typescript",
+        "build-system",
+        "strict-mode"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Bundler moduleResolution paired with ESNext modules and resolveJsonModule; emits declarations and source maps for downstream consumption."
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/index.html",
+      "type": "file",
+      "name": "index.html",
+      "filePath": "understand-anything-plugin/packages/dashboard/index.html",
+      "summary": "Vite HTML entry point for the dashboard SPA; mounts the React app at #root via /src/main.tsx and preloads the DM Serif Display, Inter, and JetBrains Mono web fonts.",
+      "tags": [
+        "entry-point",
+        "markup",
+        "spa",
+        "vite"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Vite uses index.html as the build entry, loading the app through a type=\"module\" script tag rather than bundling separately."
+    },
+    {
+      "id": "config:understand-anything-plugin/packages/dashboard/package.json",
+      "type": "config",
+      "name": "package.json",
+      "filePath": "understand-anything-plugin/packages/dashboard/package.json",
+      "summary": "Package manifest for the @understand-anything/dashboard React SPA; declares Vite/Vitest scripts and dependencies including React 19, @xyflow/react (React Flow), Zustand, graphology, and the workspace core package.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "dependencies",
+        "dashboard"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Depends on @understand-anything/core via workspace:* protocol, linking to the local monorepo core package rather than a published version."
+    },
+    {
+      "id": "config:understand-anything-plugin/packages/dashboard/tsconfig.app.json",
+      "type": "config",
+      "name": "tsconfig.app.json",
+      "filePath": "understand-anything-plugin/packages/dashboard/tsconfig.app.json",
+      "summary": "TypeScript compiler configuration for the dashboard application source; enables strict mode, bundler module resolution, react-jsx, and DOM libs targeting ES2020 with no emit (Vite handles transpilation).",
+      "tags": [
+        "configuration",
+        "typescript",
+        "build-system",
+        "strict-mode"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Uses moduleResolution \"bundler\" and noEmit, the standard Vite + TypeScript project-reference setup where tsc only type-checks."
+    },
+    {
+      "id": "config:understand-anything-plugin/packages/dashboard/tsconfig.json",
+      "type": "config",
+      "name": "tsconfig.json",
+      "filePath": "understand-anything-plugin/packages/dashboard/tsconfig.json",
+      "summary": "Root TypeScript project-reference config for the dashboard package; holds no files of its own and delegates to tsconfig.app.json via project references.",
+      "tags": [
+        "configuration",
+        "typescript",
+        "build-system"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Solution-style tsconfig using project references to compose the app config under a single tsc -b build."
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/frameworks/django.md",
+      "type": "document",
+      "name": "django.md",
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/django.md",
+      "summary": "Django framework addendum guiding the analysis agents on canonical file roles, edge patterns, architectural layers, and notable Django-specific patterns to capture.",
+      "tags": [
+        "documentation",
+        "framework-addendum",
+        "django",
+        "analysis-guidance",
+        "architecture"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Reference doc consumed by file-analyzer and architecture-analyzer agents to tailor knowledge-graph extraction for Django projects."
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/frameworks/express.md",
+      "type": "document",
+      "name": "express.md",
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/express.md",
+      "summary": "Express framework addendum describing canonical file roles, edge patterns, and architectural layers for Node.js Express projects analyzed by the agents.",
+      "tags": [
+        "documentation",
+        "framework-addendum",
+        "express",
+        "analysis-guidance",
+        "architecture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/frameworks/fastapi.md",
+      "type": "document",
+      "name": "fastapi.md",
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/fastapi.md",
+      "summary": "FastAPI framework addendum outlining canonical file roles, edge patterns, and architectural layers used when analyzing FastAPI applications.",
+      "tags": [
+        "documentation",
+        "framework-addendum",
+        "fastapi",
+        "analysis-guidance",
+        "architecture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/frameworks/flask.md",
+      "type": "document",
+      "name": "flask.md",
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/flask.md",
+      "summary": "Flask framework addendum documenting canonical file roles, edge patterns, and architectural layers for analyzing Flask web applications.",
+      "tags": [
+        "documentation",
+        "framework-addendum",
+        "flask",
+        "analysis-guidance",
+        "architecture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/frameworks/gin.md",
+      "type": "document",
+      "name": "gin.md",
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/gin.md",
+      "summary": "Gin (Go) framework addendum describing canonical file roles, edge patterns, and architectural layers for analyzing Go web services built on Gin.",
+      "tags": [
+        "documentation",
+        "framework-addendum",
+        "gin",
+        "analysis-guidance",
+        "architecture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/frameworks/nextjs.md",
+      "type": "document",
+      "name": "nextjs.md",
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/nextjs.md",
+      "summary": "Next.js framework addendum outlining canonical file roles, edge patterns, and architectural layers used when analyzing Next.js applications.",
+      "tags": [
+        "documentation",
+        "framework-addendum",
+        "nextjs",
+        "analysis-guidance",
+        "architecture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/frameworks/rails.md",
+      "type": "document",
+      "name": "rails.md",
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/rails.md",
+      "summary": "Ruby on Rails framework addendum documenting canonical file roles, edge patterns, and architectural layers for analyzing Rails applications.",
+      "tags": [
+        "documentation",
+        "framework-addendum",
+        "rails",
+        "analysis-guidance",
+        "architecture"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/frameworks/react.md",
+      "type": "document",
+      "name": "react.md",
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/react.md",
+      "summary": "React framework addendum describing canonical file roles, edge patterns, and architectural layers used when analyzing React frontends.",
+      "tags": [
+        "documentation",
+        "framework-addendum",
+        "react",
+        "analysis-guidance",
+        "architecture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/frameworks/spring.md",
+      "type": "document",
+      "name": "spring.md",
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/spring.md",
+      "summary": "Spring Boot framework addendum outlining canonical file roles, edge patterns, and architectural layers for analyzing Java Spring Boot applications.",
+      "tags": [
+        "documentation",
+        "framework-addendum",
+        "spring",
+        "analysis-guidance",
+        "architecture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/frameworks/vue.md",
+      "type": "document",
+      "name": "vue.md",
+      "filePath": "understand-anything-plugin/skills/understand/frameworks/vue.md",
+      "summary": "Vue framework addendum describing canonical file roles, edge patterns, and architectural layers used when analyzing Vue frontends.",
+      "tags": [
+        "documentation",
+        "framework-addendum",
+        "vue",
+        "analysis-guidance",
+        "architecture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/cpp.md",
+      "type": "document",
+      "name": "cpp.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/cpp.md",
+      "summary": "C++ language prompt snippet guiding the file-analyzer on C++ key concepts, include/import patterns, file patterns, and common frameworks for accurate analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "cpp"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/csharp.md",
+      "type": "document",
+      "name": "csharp.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/csharp.md",
+      "summary": "C# language prompt snippet describing key concepts, using-directive import patterns, file patterns, and common frameworks to steer C# file analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "csharp"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/css.md",
+      "type": "document",
+      "name": "css.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/css.md",
+      "summary": "CSS language prompt snippet covering key concepts, notable file patterns, and edge patterns to guide analysis of stylesheet files.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "css"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/dockerfile.md",
+      "type": "document",
+      "name": "dockerfile.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/dockerfile.md",
+      "summary": "Dockerfile language prompt snippet describing key concepts, file patterns, and deployment edge patterns to guide analysis of container build files.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "dockerfile"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/go.md",
+      "type": "document",
+      "name": "go.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/go.md",
+      "summary": "Go language prompt snippet outlining key concepts, package import patterns, file patterns, and common frameworks to steer Go file analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "go"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/graphql.md",
+      "type": "document",
+      "name": "graphql.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/graphql.md",
+      "summary": "GraphQL language prompt snippet covering schema key concepts, file patterns, and edge patterns to guide analysis of GraphQL schema files.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "graphql"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/html.md",
+      "type": "document",
+      "name": "html.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/html.md",
+      "summary": "HTML language prompt snippet describing key concepts, notable file patterns, and edge patterns to guide analysis of markup files.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "html"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/java.md",
+      "type": "document",
+      "name": "java.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/java.md",
+      "summary": "Java language prompt snippet outlining key concepts, import patterns, file patterns, and common frameworks to steer Java file analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "java"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/javascript.md",
+      "type": "document",
+      "name": "javascript.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/javascript.md",
+      "summary": "JavaScript language prompt snippet describing key concepts, import/require patterns, file patterns, and common frameworks to guide JavaScript file analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "javascript"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/json.md",
+      "type": "document",
+      "name": "json.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/json.md",
+      "summary": "JSON language prompt snippet covering key concepts, notable file patterns, and edge patterns to guide analysis of JSON configuration and data files.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "json"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/kotlin.md",
+      "type": "document",
+      "name": "kotlin.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/kotlin.md",
+      "summary": "Kotlin language prompt snippet outlining key concepts, import patterns, file patterns, and common frameworks to steer Kotlin file analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "kotlin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/markdown.md",
+      "type": "document",
+      "name": "markdown.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/markdown.md",
+      "summary": "Markdown language prompt snippet describing key concepts, notable file patterns, and edge patterns to guide analysis of documentation files.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "markdown"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/php.md",
+      "type": "document",
+      "name": "php.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/php.md",
+      "summary": "PHP language prompt snippet outlining key concepts, import/use patterns, file patterns, and common frameworks to steer PHP file analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "php"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/protobuf.md",
+      "type": "document",
+      "name": "protobuf.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/protobuf.md",
+      "summary": "Protobuf language prompt snippet covering schema key concepts, file patterns, and edge patterns to guide analysis of Protocol Buffer definition files.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "protobuf"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/python.md",
+      "type": "document",
+      "name": "python.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/python.md",
+      "summary": "Python language prompt snippet describing key concepts, import patterns, file patterns, and common frameworks to guide Python file analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "python"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/ruby.md",
+      "type": "document",
+      "name": "ruby.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/ruby.md",
+      "summary": "Ruby language prompt snippet outlining key concepts, require import patterns, file patterns, and common frameworks to steer Ruby file analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "ruby"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/rust.md",
+      "type": "document",
+      "name": "rust.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/rust.md",
+      "summary": "Rust language prompt snippet describing key concepts, use/module import patterns, file patterns, and common frameworks to guide Rust file analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "rust"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/shell.md",
+      "type": "document",
+      "name": "shell.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/shell.md",
+      "summary": "Shell language prompt snippet covering key concepts, notable file patterns, and edge patterns to guide analysis of shell scripts.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "shell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/sql.md",
+      "type": "document",
+      "name": "sql.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/sql.md",
+      "summary": "SQL language prompt snippet covering key concepts, notable file patterns, and migration/schema edge patterns to guide analysis of SQL files.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "sql"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/swift.md",
+      "type": "document",
+      "name": "swift.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/swift.md",
+      "summary": "Swift language prompt snippet outlining key concepts, import patterns, file patterns, and common frameworks to steer Swift file analysis.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "language-guide",
+        "swift"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/terraform.md",
+      "type": "document",
+      "name": "terraform.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/terraform.md",
+      "summary": "Terraform language prompt snippet that guides the analysis agents on Terraform key concepts, notable file patterns, edge patterns, and summary style for infrastructure-as-code files.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "infrastructure",
+        "terraform"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/typescript.md",
+      "type": "document",
+      "name": "typescript.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/typescript.md",
+      "summary": "TypeScript language prompt snippet covering key concepts, import and file patterns, common frameworks, and example language notes to steer the agents when analyzing TypeScript code.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "typescript",
+        "language-guide"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/languages/yaml.md",
+      "type": "document",
+      "name": "yaml.md",
+      "filePath": "understand-anything-plugin/skills/understand/languages/yaml.md",
+      "summary": "YAML language prompt snippet describing key concepts, notable file patterns, edge patterns, and summary style for analyzing YAML configuration and pipeline files.",
+      "tags": [
+        "documentation",
+        "prompt-snippet",
+        "yaml",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/locales/en.md",
+      "type": "document",
+      "name": "en.md",
+      "filePath": "understand-anything-plugin/skills/understand/locales/en.md",
+      "summary": "English output guidance for the /understand skill, defining tag conventions, summary style, technical-term handling, and layer naming for generated knowledge graphs.",
+      "tags": [
+        "documentation",
+        "localization",
+        "guidelines",
+        "skill",
+        "english"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/locales/ja.md",
+      "type": "document",
+      "name": "ja.md",
+      "filePath": "understand-anything-plugin/skills/understand/locales/ja.md",
+      "summary": "Japanese output guidance for the /understand skill, specifying localized tag conventions, summary style, technical-term handling, and layer naming.",
+      "tags": [
+        "documentation",
+        "localization",
+        "guidelines",
+        "skill",
+        "japanese"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/locales/ko.md",
+      "type": "document",
+      "name": "ko.md",
+      "filePath": "understand-anything-plugin/skills/understand/locales/ko.md",
+      "summary": "Korean output guidance for the /understand skill, specifying localized tag conventions, summary style, technical-term handling, and layer naming.",
+      "tags": [
+        "documentation",
+        "localization",
+        "guidelines",
+        "skill",
+        "korean"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/locales/ru.md",
+      "type": "document",
+      "name": "ru.md",
+      "filePath": "understand-anything-plugin/skills/understand/locales/ru.md",
+      "summary": "Russian output guidance for the /understand skill, specifying localized tag conventions, summary style, technical-term handling, and layer naming.",
+      "tags": [
+        "documentation",
+        "localization",
+        "guidelines",
+        "skill",
+        "russian"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/locales/zh-TW.md",
+      "type": "document",
+      "name": "zh-TW.md",
+      "filePath": "understand-anything-plugin/skills/understand/locales/zh-TW.md",
+      "summary": "Traditional Chinese output guidance for the /understand skill, specifying localized tag conventions, summary style, technical-term handling, and layer naming.",
+      "tags": [
+        "documentation",
+        "localization",
+        "guidelines",
+        "skill",
+        "chinese"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/locales/zh.md",
+      "type": "document",
+      "name": "zh.md",
+      "filePath": "understand-anything-plugin/skills/understand/locales/zh.md",
+      "summary": "Simplified Chinese output guidance for the /understand skill, specifying localized tag conventions, summary style, technical-term handling, and layer naming.",
+      "tags": [
+        "documentation",
+        "localization",
+        "guidelines",
+        "skill",
+        "chinese"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.claude-plugin/marketplace.json",
+      "type": "config",
+      "name": "marketplace.json",
+      "filePath": ".claude-plugin/marketplace.json",
+      "summary": "Claude Code marketplace manifest declaring the understand-anything plugin entry, owner metadata, and plugin source for marketplace installation.",
+      "tags": [
+        "configuration",
+        "plugin-manifest",
+        "marketplace"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.claude-plugin/plugin.json",
+      "type": "config",
+      "name": "plugin.json",
+      "filePath": ".claude-plugin/plugin.json",
+      "summary": "Claude Code plugin manifest defining the plugin name, version, author, repository, license, and keywords for the understand-anything plugin.",
+      "tags": [
+        "configuration",
+        "plugin-manifest",
+        "metadata"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.copilot-plugin/plugin.json",
+      "type": "config",
+      "name": "plugin.json",
+      "filePath": ".copilot-plugin/plugin.json",
+      "summary": "GitHub Copilot plugin manifest mirroring the plugin metadata with the skills and agents arrays for Copilot-compatible installation.",
+      "tags": [
+        "configuration",
+        "plugin-manifest",
+        "copilot"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.cursor-plugin/plugin.json",
+      "type": "config",
+      "name": "plugin.json",
+      "filePath": ".cursor-plugin/plugin.json",
+      "summary": "Cursor plugin manifest declaring display name, metadata, skills, and agents to make the understand-anything plugin installable in Cursor.",
+      "tags": [
+        "configuration",
+        "plugin-manifest",
+        "cursor"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/PULL_REQUEST_TEMPLATE.md",
+      "type": "document",
+      "name": "PULL_REQUEST_TEMPLATE.md",
+      "filePath": ".github/PULL_REQUEST_TEMPLATE.md",
+      "summary": "GitHub pull request template prompting contributors for a summary, linked issues, testing notes, and versioning checklist.",
+      "tags": [
+        "documentation",
+        "github",
+        "development"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.npmrc",
+      "type": "config",
+      "name": ".npmrc",
+      "filePath": ".npmrc",
+      "summary": "npm/pnpm configuration file setting registry or hoisting behavior for the monorepo workspace.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "package-manager"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:eslint.config.mjs",
+      "type": "config",
+      "name": "eslint.config.mjs",
+      "filePath": "eslint.config.mjs",
+      "summary": "Flat ESLint configuration defining lint rules, TypeScript plugin setup, and ignore patterns across the monorepo.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "linting"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses the modern ESLint flat config format (eslint.config.mjs) rather than legacy .eslintrc."
+    },
+    {
+      "id": "config:homepage/astro.config.mjs",
+      "type": "config",
+      "name": "astro.config.mjs",
+      "filePath": "homepage/astro.config.mjs",
+      "summary": "Astro framework configuration for the marketing homepage, defining build and site settings.",
+      "tags": [
+        "configuration",
+        "astro",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:homepage/public/.gitkeep",
+      "type": "file",
+      "name": ".gitkeep",
+      "filePath": "homepage/public/.gitkeep",
+      "summary": "Empty placeholder file keeping the homepage public assets directory tracked in git.",
+      "tags": [
+        "placeholder",
+        "git",
+        "static-assets"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:homepage/public/CNAME",
+      "type": "file",
+      "name": "CNAME",
+      "filePath": "homepage/public/CNAME",
+      "summary": "GitHub Pages custom domain file specifying the canonical hostname for the deployed homepage.",
+      "tags": [
+        "deployment",
+        "github-pages",
+        "static-assets"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:homepage/src/components/CommunityVideo.astro",
+      "type": "file",
+      "name": "CommunityVideo.astro",
+      "filePath": "homepage/src/components/CommunityVideo.astro",
+      "summary": "Astro component rendering a community/demo video section on the marketing homepage.",
+      "tags": [
+        "component",
+        "astro",
+        "homepage"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:homepage/src/components/Features.astro",
+      "type": "file",
+      "name": "Features.astro",
+      "filePath": "homepage/src/components/Features.astro",
+      "summary": "Astro component presenting the product feature grid on the marketing homepage.",
+      "tags": [
+        "component",
+        "astro",
+        "homepage"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:homepage/src/components/Footer.astro",
+      "type": "file",
+      "name": "Footer.astro",
+      "filePath": "homepage/src/components/Footer.astro",
+      "summary": "Astro footer component with site links and project attribution for the marketing homepage.",
+      "tags": [
+        "component",
+        "astro",
+        "homepage"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:homepage/src/components/Hero.astro",
+      "type": "file",
+      "name": "Hero.astro",
+      "filePath": "homepage/src/components/Hero.astro",
+      "summary": "Large Astro hero component for the homepage landing section, including headline, call-to-action, and inline styling and scripts.",
+      "tags": [
+        "component",
+        "astro",
+        "homepage",
+        "entry-point"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Largest homepage component (~594 lines) bundling markup, scoped CSS, and client-side scripts in a single Astro file."
+    },
+    {
+      "id": "file:homepage/src/components/Install.astro",
+      "type": "file",
+      "name": "Install.astro",
+      "filePath": "homepage/src/components/Install.astro",
+      "summary": "Astro component presenting installation instructions and copyable commands for the plugin on the homepage.",
+      "tags": [
+        "component",
+        "astro",
+        "homepage",
+        "documentation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:homepage/src/components/Nav.astro",
+      "type": "file",
+      "name": "Nav.astro",
+      "filePath": "homepage/src/components/Nav.astro",
+      "summary": "Astro navigation bar component providing the top-level site navigation links on the homepage.",
+      "tags": [
+        "component",
+        "astro",
+        "homepage",
+        "navigation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:homepage/src/components/Problem.astro",
+      "type": "file",
+      "name": "Problem.astro",
+      "filePath": "homepage/src/components/Problem.astro",
+      "summary": "Astro component describing the problem the tool solves, framing the value proposition on the homepage.",
+      "tags": [
+        "component",
+        "astro",
+        "homepage"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:homepage/src/components/Showcase.astro",
+      "type": "file",
+      "name": "Showcase.astro",
+      "filePath": "homepage/src/components/Showcase.astro",
+      "summary": "Astro component showcasing the dashboard and product capabilities with visuals on the homepage.",
+      "tags": [
+        "component",
+        "astro",
+        "homepage"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:homepage/src/layouts/Layout.astro",
+      "type": "file",
+      "name": "Layout.astro",
+      "filePath": "homepage/src/layouts/Layout.astro",
+      "summary": "Base Astro layout wrapping all pages with the HTML document shell and importing the global stylesheet.",
+      "tags": [
+        "layout",
+        "astro",
+        "homepage",
+        "entry-point"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:homepage/src/pages/index.astro",
+      "type": "file",
+      "name": "index.astro",
+      "filePath": "homepage/src/pages/index.astro",
+      "summary": "Homepage entry page composing the Layout with all section components (Nav, Hero, Problem, Showcase, etc.) to assemble the landing page.",
+      "tags": [
+        "entry-point",
+        "astro",
+        "homepage",
+        "page"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:homepage/src/styles/global.css",
+      "type": "file",
+      "name": "global.css",
+      "filePath": "homepage/src/styles/global.css",
+      "summary": "Global stylesheet defining the dark luxury theme, typography, and shared CSS variables for the marketing homepage.",
+      "tags": [
+        "styling",
+        "css",
+        "homepage",
+        "theme"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:scripts/generate-large-graph.mjs",
+      "type": "file",
+      "name": "generate-large-graph.mjs",
+      "filePath": "scripts/generate-large-graph.mjs",
+      "summary": "Developer script that generates a synthetic large knowledge graph (nodes, edges, layers, tours) with injected quality issues for dashboard performance testing.",
+      "tags": [
+        "script",
+        "test-fixture",
+        "performance",
+        "data-pipeline"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:scripts/generate-large-graph.mjs:generateNodes",
+      "type": "function",
+      "name": "generateNodes",
+      "filePath": "scripts/generate-large-graph.mjs",
+      "lineRange": [
+        42,
+        58
+      ],
+      "summary": "Generates the requested count of synthetic graph nodes with random types, complexity, and metadata.",
+      "tags": [
+        "factory",
+        "data-generation",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:scripts/generate-large-graph.mjs:generateEdges",
+      "type": "function",
+      "name": "generateEdges",
+      "filePath": "scripts/generate-large-graph.mjs",
+      "lineRange": [
+        60,
+        84
+      ],
+      "summary": "Generates unique random edges between the provided nodes, deduplicating pairs and assigning random weights.",
+      "tags": [
+        "factory",
+        "data-generation",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:scripts/generate-large-graph.mjs:generateLayers",
+      "type": "function",
+      "name": "generateLayers",
+      "filePath": "scripts/generate-large-graph.mjs",
+      "lineRange": [
+        86,
+        104
+      ],
+      "summary": "Partitions generated nodes into synthetic architectural layers for the test graph.",
+      "tags": [
+        "factory",
+        "data-generation",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:scripts/generate-large-graph.mjs:generateTour",
+      "type": "function",
+      "name": "generateTour",
+      "filePath": "scripts/generate-large-graph.mjs",
+      "lineRange": [
+        106,
+        119
+      ],
+      "summary": "Builds a synthetic guided tour with a bounded number of steps referencing generated nodes.",
+      "tags": [
+        "factory",
+        "data-generation",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:scripts/generate-large-graph.mjs:injectTier1",
+      "type": "function",
+      "name": "injectTier1",
+      "filePath": "scripts/generate-large-graph.mjs",
+      "lineRange": [
+        124,
+        139
+      ],
+      "summary": "Randomly injects tier-1 quality issues into a node to exercise the graph reviewer and validation paths.",
+      "tags": [
+        "test-fixture",
+        "data-generation",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:scripts/generate-large-graph.mjs:injectTier2Node",
+      "type": "function",
+      "name": "injectTier2Node",
+      "filePath": "scripts/generate-large-graph.mjs",
+      "lineRange": [
+        142,
+        165
+      ],
+      "summary": "Randomly injects tier-2 quality issues into a node, such as malformed fields and invalid metadata.",
+      "tags": [
+        "test-fixture",
+        "data-generation",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:scripts/generate-large-graph.mjs:injectTier2Edge",
+      "type": "function",
+      "name": "injectTier2Edge",
+      "filePath": "scripts/generate-large-graph.mjs",
+      "lineRange": [
+        167,
+        185
+      ],
+      "summary": "Randomly injects tier-2 quality issues into an edge, such as invalid types, weights, or directions.",
+      "tags": [
+        "test-fixture",
+        "data-generation",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:scripts/generate-large-graph.mjs:applyMessy",
+      "type": "function",
+      "name": "applyMessy",
+      "filePath": "scripts/generate-large-graph.mjs",
+      "lineRange": [
+        216,
+        250
+      ],
+      "summary": "Orchestrates injection of tiered quality issues across nodes and edges to produce a deliberately messy test graph.",
+      "tags": [
+        "orchestration",
+        "test-fixture",
+        "data-generation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/skill/understand/test_compute_batches.test.mjs",
+      "type": "file",
+      "name": "test_compute_batches.test.mjs",
+      "filePath": "tests/skill/understand/test_compute_batches.test.mjs",
+      "summary": "Vitest suite verifying the compute-batches skill script correctly partitions scanned project files into analysis batches across fixtures.",
+      "tags": [
+        "test",
+        "skill",
+        "batching"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:tests/skill/understand/test_compute_batches.test.mjs:runScript",
+      "type": "function",
+      "name": "runScript",
+      "filePath": "tests/skill/understand/test_compute_batches.test.mjs",
+      "lineRange": [
+        13,
+        17
+      ],
+      "summary": "Helper that synchronously spawns the compute-batches script against a given project root for assertions.",
+      "tags": [
+        "test",
+        "helper",
+        "subprocess"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:tests/skill/understand/test_compute_batches.test.mjs:setupProject",
+      "type": "function",
+      "name": "setupProject",
+      "filePath": "tests/skill/understand/test_compute_batches.test.mjs",
+      "lineRange": [
+        19,
+        26
+      ],
+      "summary": "Creates a temporary project directory seeded from a fixture for batch computation tests.",
+      "tags": [
+        "test",
+        "helper",
+        "fixture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:tests/skill/understand/test_extract_import_map.test.mjs",
+      "type": "file",
+      "name": "test_extract_import_map.test.mjs",
+      "filePath": "tests/skill/understand/test_extract_import_map.test.mjs",
+      "summary": "Large Vitest suite validating the extract-import-map skill script across many languages and module resolution edge cases.",
+      "tags": [
+        "test",
+        "skill",
+        "import-resolution"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:tests/skill/understand/test_extract_import_map.test.mjs:setupTree",
+      "type": "function",
+      "name": "setupTree",
+      "filePath": "tests/skill/understand/test_extract_import_map.test.mjs",
+      "lineRange": [
+        15,
+        23
+      ],
+      "summary": "Materializes a temporary file tree from a map of paths to contents for import-map extraction tests.",
+      "tags": [
+        "test",
+        "helper",
+        "fixture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:tests/skill/understand/test_extract_import_map.test.mjs:runScript",
+      "type": "function",
+      "name": "runScript",
+      "filePath": "tests/skill/understand/test_extract_import_map.test.mjs",
+      "lineRange": [
+        33,
+        49
+      ],
+      "summary": "Writes the input JSON, spawns the extract-import-map script, and parses its output for assertions.",
+      "tags": [
+        "test",
+        "helper",
+        "subprocess"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:tests/skill/understand/test_merge_batch_graphs.py",
+      "type": "file",
+      "name": "test_merge_batch_graphs.py",
+      "filePath": "tests/skill/understand/test_merge_batch_graphs.py",
+      "summary": "Comprehensive unittest suite for merge-batch-graphs.py covering test-path detection, production pairing, edge direction normalization, dedup, and multi-part batch merging.",
+      "tags": [
+        "test",
+        "skill",
+        "graph-assembly"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Loads the target module dynamically via importlib.util to test a script that is not a packaged module."
+    },
+    {
+      "id": "class:tests/skill/understand/test_merge_batch_graphs.py:IsTestPathTests",
+      "type": "class",
+      "name": "IsTestPathTests",
+      "filePath": "tests/skill/understand/test_merge_batch_graphs.py",
+      "lineRange": [
+        65,
+        146
+      ],
+      "summary": "Unit tests for is_test_path covering test-file detection conventions across JS/TS, Go, Python, Java, Kotlin, C#, and C/C++.",
+      "tags": [
+        "test",
+        "test-detection",
+        "multi-language"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/skill/understand/test_merge_batch_graphs.py:ProductionCandidatesTests",
+      "type": "class",
+      "name": "ProductionCandidatesTests",
+      "filePath": "tests/skill/understand/test_merge_batch_graphs.py",
+      "lineRange": [
+        151,
+        270
+      ],
+      "summary": "Unit tests for production_candidates verifying which production files a test maps to across language layout conventions and priority ordering.",
+      "tags": [
+        "test",
+        "test-detection",
+        "multi-language"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/skill/understand/test_merge_batch_graphs.py:LinkTestsTests",
+      "type": "class",
+      "name": "LinkTestsTests",
+      "filePath": "tests/skill/understand/test_merge_batch_graphs.py",
+      "lineRange": [
+        275,
+        825
+      ],
+      "summary": "Extensive unit tests for link_tests covering tested_by edge emission, direction swapping, dedup, orphan dropping, idempotency, and tag handling.",
+      "tags": [
+        "test",
+        "graph-edges",
+        "tested-by"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/skill/understand/test_merge_batch_graphs.py:MergeIntegrationTests",
+      "type": "class",
+      "name": "MergeIntegrationTests",
+      "filePath": "tests/skill/understand/test_merge_batch_graphs.py",
+      "lineRange": [
+        830,
+        877
+      ],
+      "summary": "Integration test confirming the test linker runs as part of the full merge pipeline.",
+      "tags": [
+        "test",
+        "integration",
+        "graph-assembly"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/skill/understand/test_merge_batch_graphs.py:NormalizeDirectionTests",
+      "type": "class",
+      "name": "NormalizeDirectionTests",
+      "filePath": "tests/skill/understand/test_merge_batch_graphs.py",
+      "lineRange": [
+        880,
+        902
+      ],
+      "summary": "Unit tests for direction normalization covering defaults, valid values, case handling, aliases, and unknown fallbacks.",
+      "tags": [
+        "test",
+        "edge-direction",
+        "normalization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/skill/understand/test_merge_batch_graphs.py:MergeEdgeDirectionTests",
+      "type": "class",
+      "name": "MergeEdgeDirectionTests",
+      "filePath": "tests/skill/understand/test_merge_batch_graphs.py",
+      "lineRange": [
+        905,
+        948
+      ],
+      "summary": "Tests that edge direction is persisted as forward and canonicalized before deduplication during merge.",
+      "tags": [
+        "test",
+        "edge-direction",
+        "graph-assembly"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:tests/skill/understand/test_merge_batch_graphs.py:TestMultiPart",
+      "type": "class",
+      "name": "TestMultiPart",
+      "filePath": "tests/skill/understand/test_merge_batch_graphs.py",
+      "lineRange": [
+        954,
+        1066
+      ],
+      "summary": "Tests merging of multi-part batch files, including malformed and missing parts and the stderr report format.",
+      "tags": [
+        "test",
+        "multi-part",
+        "graph-assembly"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:tests/skill/understand/test_merge_batch_graphs.py:TestUnrecognizedBatchFilename",
+      "type": "class",
+      "name": "TestUnrecognizedBatchFilename",
+      "filePath": "tests/skill/understand/test_merge_batch_graphs.py",
+      "lineRange": [
+        1072,
+        1183
+      ],
+      "summary": "Tests that unrecognized batch filenames (fused/range) emit stderr warnings and surface in the report while recognized batches still load.",
+      "tags": [
+        "test",
+        "graph-assembly",
+        "error-handling"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:tests/skill/understand/test_scan_project.test.mjs",
+      "type": "file",
+      "name": "test_scan_project.test.mjs",
+      "filePath": "tests/skill/understand/test_scan_project.test.mjs",
+      "summary": "Integration test suite for the project-scanner skill script, spawning it against synthetic file trees in temp directories and asserting on the emitted inventory output.",
+      "tags": [
+        "test",
+        "integration-test",
+        "project-scanner",
+        "fixture"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses spawnSync to invoke the scanner as a child process and mkdtempSync-backed temp fixtures, exercising the script end-to-end rather than in-process."
+    },
+    {
+      "id": "function:tests/skill/understand/test_scan_project.test.mjs:setupTree",
+      "type": "function",
+      "name": "setupTree",
+      "filePath": "tests/skill/understand/test_scan_project.test.mjs",
+      "lineRange": [
+        28,
+        45
+      ],
+      "summary": "Creates a temporary directory and materializes a map of relative paths to file contents, then returns the root for scanner runs.",
+      "tags": [
+        "test-helper",
+        "fixture",
+        "filesystem"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:tests/skill/understand/test_scan_project.test.mjs:runScript",
+      "type": "function",
+      "name": "runScript",
+      "filePath": "tests/skill/understand/test_scan_project.test.mjs",
+      "lineRange": [
+        63,
+        77
+      ],
+      "summary": "Spawns the scanner script against a project root and parses the resulting JSON inventory file for assertions.",
+      "tags": [
+        "test-helper",
+        "subprocess",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:understand-anything-plugin/.claude-plugin/plugin.json",
+      "type": "config",
+      "name": "plugin.json",
+      "filePath": "understand-anything-plugin/.claude-plugin/plugin.json",
+      "summary": "Claude Code plugin manifest declaring the understand-anything plugin's name, version, author, homepage, and keywords.",
+      "tags": [
+        "configuration",
+        "plugin-manifest",
+        "metadata"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/hooks/auto-update-prompt.md",
+      "type": "document",
+      "name": "auto-update-prompt.md",
+      "filePath": "understand-anything-plugin/hooks/auto-update-prompt.md",
+      "summary": "Hook-triggered internal prompt defining the multi-phase incremental knowledge-graph update flow: pre-flight checks, structural fingerprinting, targeted re-analysis, and conditional architecture/tour regeneration.",
+      "tags": [
+        "documentation",
+        "hook",
+        "prompt",
+        "incremental-update"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "config:understand-anything-plugin/hooks/hooks.json",
+      "type": "config",
+      "name": "hooks.json",
+      "filePath": "understand-anything-plugin/hooks/hooks.json",
+      "summary": "Hook registration config wiring the auto-update prompt into Claude Code lifecycle events.",
+      "tags": [
+        "configuration",
+        "hook",
+        "plugin-manifest"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:understand-anything-plugin/packages/core/package.json",
+      "type": "config",
+      "name": "package.json",
+      "filePath": "understand-anything-plugin/packages/core/package.json",
+      "summary": "Package manifest for the core analysis engine, declaring subpath exports (./search, ./types, ./schema), build/test scripts, and tree-sitter dependencies.",
+      "tags": [
+        "configuration",
+        "package-manifest",
+        "build-system",
+        "subpath-exports"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.test.ts",
+      "type": "file",
+      "name": "llm-analyzer.test.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.test.ts",
+      "summary": "Unit tests for the LLM analyzer's prompt builders and response parsers, validating JSON extraction, complexity normalization, and malformed-input handling.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "type": "file",
+      "name": "llm-analyzer.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "summary": "Builds LLM prompts for file analysis and project summarization, and parses/validates the model's JSON responses into typed analysis results.",
+      "tags": [
+        "service",
+        "llm",
+        "prompt-builder",
+        "serialization",
+        "validation",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:buildFileAnalysisPrompt",
+      "type": "function",
+      "name": "buildFileAnalysisPrompt",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "lineRange": [
+        19,
+        43
+      ],
+      "summary": "Constructs the LLM prompt for analyzing a single file, embedding the file path, content, and surrounding project context.",
+      "tags": [
+        "prompt-builder",
+        "llm",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:buildProjectSummaryPrompt",
+      "type": "function",
+      "name": "buildProjectSummaryPrompt",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "lineRange": [
+        48,
+        76
+      ],
+      "summary": "Builds the project-summary prompt from a full file list and sampled file contents to elicit frameworks and layer suggestions.",
+      "tags": [
+        "prompt-builder",
+        "llm",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:extractJson",
+      "type": "function",
+      "name": "extractJson",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "lineRange": [
+        81,
+        95
+      ],
+      "summary": "Extracts a JSON payload from an LLM response, handling fenced code blocks and bare object matches with a trimmed fallback.",
+      "tags": [
+        "serialization",
+        "parsing",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:parseFileAnalysisResponse",
+      "type": "function",
+      "name": "parseFileAnalysisResponse",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "lineRange": [
+        102,
+        143
+      ],
+      "summary": "Parses and validates a file-analysis LLM response, normalizing complexity values and filtering tags into a typed result.",
+      "tags": [
+        "parsing",
+        "validation",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:parseProjectSummaryResponse",
+      "type": "function",
+      "name": "parseProjectSummaryResponse",
+      "filePath": "understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "lineRange": [
+        148,
+        186
+      ],
+      "summary": "Parses a project-summary LLM response, validating frameworks and layer definitions with their file patterns into a typed summary.",
+      "tags": [
+        "parsing",
+        "validation",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/index.ts",
+      "summary": "Main barrel entry point for the core package, re-exporting schema, analyzer, search, staleness, tours, plugins, language configs, and ignore-filter APIs.",
+      "tags": [
+        "entry-point",
+        "barrel",
+        "exports"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Aggregates 90+ re-exports; the package also offers browser-safe subpath exports so the dashboard can avoid pulling in Node.js modules via this main entry."
+    },
+    {
+      "id": "service:understand-anything-plugin/packages/core/src/languages/configs/docker-compose.ts",
+      "type": "service",
+      "name": "docker-compose.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/docker-compose.ts",
+      "summary": "Language configuration descriptor declaring how docker-compose files are detected and parsed by the analysis engine.",
+      "tags": [
+        "configuration",
+        "language-config",
+        "infrastructure",
+        "containerization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/index.ts",
+      "summary": "Barrel module re-exporting language/framework config types, schemas, registries, and built-in config collections for the languages subsystem.",
+      "tags": [
+        "entry-point",
+        "barrel",
+        "exports",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:understand-anything-plugin/packages/core/tsconfig.json",
+      "type": "config",
+      "name": "tsconfig.json",
+      "filePath": "understand-anything-plugin/packages/core/tsconfig.json",
+      "summary": "TypeScript compiler configuration for the core package, setting strict mode and the source include paths for the build.",
+      "tags": [
+        "configuration",
+        "typescript",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/vitest.config.ts",
+      "type": "file",
+      "name": "vitest.config.ts",
+      "filePath": "understand-anything-plugin/packages/core/vitest.config.ts",
+      "summary": "Vitest test runner configuration for the core package.",
+      "tags": [
+        "configuration",
+        "test",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:understand-anything-plugin/packages/dashboard/public/knowledge-graph.json",
+      "type": "config",
+      "name": "knowledge-graph.json",
+      "filePath": "understand-anything-plugin/packages/dashboard/public/knowledge-graph.json",
+      "summary": "Bundled sample knowledge graph served by the dashboard, containing nodes, edges, layers, and a tour used as demo/default data.",
+      "tags": [
+        "data",
+        "knowledge-graph",
+        "fixture",
+        "demo"
+      ],
+      "complexity": "complex",
+      "languageNotes": "A large serialized graph snapshot (~3000 lines) consumed by the dashboard at load time rather than hand-edited config."
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "type": "file",
+      "name": "benchmark-aggregations.mjs",
+      "filePath": "understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "summary": "Performance benchmark comparing a naive filter-based layer aggregation against a map-indexed approach across synthetic graphs.",
+      "tags": [
+        "script",
+        "benchmark",
+        "performance"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs:makeGraph",
+      "type": "function",
+      "name": "makeGraph",
+      "filePath": "understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "lineRange": [
+        18,
+        32
+      ],
+      "summary": "Generates a synthetic graph with the given layer count and nodes per layer for benchmarking.",
+      "tags": [
+        "benchmark",
+        "fixture",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs:aggregateBefore",
+      "type": "function",
+      "name": "aggregateBefore",
+      "filePath": "understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "lineRange": [
+        35,
+        50
+      ],
+      "summary": "Baseline layer aggregation that filters all nodes per layer, used as the slow comparison point.",
+      "tags": [
+        "benchmark",
+        "aggregation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs:aggregateAfter",
+      "type": "function",
+      "name": "aggregateAfter",
+      "filePath": "understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "lineRange": [
+        53,
+        73
+      ],
+      "summary": "Optimized layer aggregation using a precomputed node-by-id map to avoid repeated linear scans.",
+      "tags": [
+        "benchmark",
+        "aggregation",
+        "performance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs:bench",
+      "type": "function",
+      "name": "bench",
+      "filePath": "understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "lineRange": [
+        75,
+        94
+      ],
+      "summary": "Runs both aggregation strategies on a generated graph, verifies parity, and logs timing and speedup.",
+      "tags": [
+        "benchmark",
+        "performance",
+        "driver"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs",
+      "type": "file",
+      "name": "benchmark-layout.mjs",
+      "filePath": "understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs",
+      "summary": "Performance benchmark measuring ELK graph layout time across synthetic graphs of varying node counts.",
+      "tags": [
+        "script",
+        "benchmark",
+        "performance",
+        "layout"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs:makeGraph",
+      "type": "function",
+      "name": "makeGraph",
+      "filePath": "understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs",
+      "lineRange": [
+        51,
+        66
+      ],
+      "summary": "Builds a synthetic ELK-shaped graph of the requested node count with random edges for layout benchmarking.",
+      "tags": [
+        "benchmark",
+        "fixture",
+        "layout"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs:fillDims",
+      "type": "function",
+      "name": "fillDims",
+      "filePath": "understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs",
+      "lineRange": [
+        30,
+        38
+      ],
+      "summary": "Recursively assigns default width/height dimensions to ELK child nodes before layout.",
+      "tags": [
+        "layout",
+        "utility",
+        "recursion"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/index.css",
+      "type": "file",
+      "name": "index.css",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/index.css",
+      "summary": "Global stylesheet defining the dashboard's dark luxury theme, typography, and base layout tokens.",
+      "tags": [
+        "stylesheet",
+        "theme",
+        "ui"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "TailwindCSS v4-era global styles establishing the deep-black/gold palette and DM Serif Display typography."
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/smoke.test.ts",
+      "type": "file",
+      "name": "smoke.test.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/__tests__/smoke.test.ts",
+      "summary": "Minimal smoke test verifying the dashboard utils test harness is wired up correctly.",
+      "tags": [
+        "test",
+        "smoke-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.worker.ts",
+      "type": "file",
+      "name": "layout.worker.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/utils/layout.worker.ts",
+      "summary": "Web Worker that offloads ELK graph layout computation off the main thread for the dashboard's graph view.",
+      "tags": [
+        "web-worker",
+        "layout",
+        "performance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/src/vite-env.d.ts",
+      "type": "file",
+      "name": "vite-env.d.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/vite-env.d.ts",
+      "summary": "Vite ambient type-reference declaration file for the dashboard build.",
+      "tags": [
+        "type-definition",
+        "build-system",
+        "vite"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/vite.config.demo.ts",
+      "type": "file",
+      "name": "vite.config.demo.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/vite.config.demo.ts",
+      "summary": "Vite build configuration for the demo dashboard, defining manual vendor chunk splitting for React and markdown rendering libraries.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "vite",
+        "bundling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "type": "file",
+      "name": "vite.config.ts",
+      "filePath": "understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "summary": "Main Vite config for the dashboard, including a dev-server middleware that securely serves source file contents gated by an access token and a graph-derived path allowlist.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "vite",
+        "middleware",
+        "security"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Implements path-traversal defenses (normalize, isAbsolute checks, allowlist membership) around the /file-content.json dev endpoint."
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/vite.config.ts:readSourceFile",
+      "type": "function",
+      "name": "readSourceFile",
+      "filePath": "understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "lineRange": [
+        114,
+        177
+      ],
+      "summary": "Resolves and reads a requested source file for the dev endpoint, enforcing path-traversal protection, project-root containment, and graph-allowlist membership before returning content.",
+      "tags": [
+        "middleware",
+        "security",
+        "filesystem",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/vite.config.ts:normalizeGraphPath",
+      "type": "function",
+      "name": "normalizeGraphPath",
+      "filePath": "understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "lineRange": [
+        34,
+        53
+      ],
+      "summary": "Normalizes a graph-node file path relative to the project root into a canonical posix path, rejecting paths that escape the root.",
+      "tags": [
+        "security",
+        "path-normalization",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/vite.config.ts:graphFilePathSet",
+      "type": "function",
+      "name": "graphFilePathSet",
+      "filePath": "understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "lineRange": [
+        55,
+        70
+      ],
+      "summary": "Reads a knowledge-graph file and builds the set of allowed normalized file paths used to gate source-file requests.",
+      "tags": [
+        "security",
+        "allowlist",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/vite.config.ts:detectLanguage",
+      "type": "function",
+      "name": "detectLanguage",
+      "filePath": "understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "lineRange": [
+        72,
+        102
+      ],
+      "summary": "Maps a file extension to a syntax-highlighting language id for the served source content.",
+      "tags": [
+        "utility",
+        "language-detection"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/packages/tree-sitter-dart-wasm/BUILD.md",
+      "type": "document",
+      "name": "BUILD.md",
+      "filePath": "understand-anything-plugin/packages/tree-sitter-dart-wasm/BUILD.md",
+      "summary": "Documentation explaining why the tree-sitter-dart WASM grammar is vendored, how to rebuild it, its provenance, and when the package can be removed.",
+      "tags": [
+        "documentation",
+        "build-system",
+        "tree-sitter",
+        "wasm"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:understand-anything-plugin/packages/tree-sitter-dart-wasm/package.json",
+      "type": "config",
+      "name": "package.json",
+      "filePath": "understand-anything-plugin/packages/tree-sitter-dart-wasm/package.json",
+      "summary": "Minimal package manifest for the vendored tree-sitter-dart WASM grammar package.",
+      "tags": [
+        "configuration",
+        "package-manifest",
+        "tree-sitter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/tree-sitter-dart-wasm/tree-sitter-dart.wasm",
+      "type": "file",
+      "name": "tree-sitter-dart.wasm",
+      "filePath": "understand-anything-plugin/packages/tree-sitter-dart-wasm/tree-sitter-dart.wasm",
+      "summary": "Vendored compiled tree-sitter Dart grammar (WASM binary) loaded by the WASM-based parser to support Dart source analysis.",
+      "tags": [
+        "binary",
+        "wasm",
+        "tree-sitter",
+        "grammar"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Compiled WebAssembly artifact, not human-authored source; consumed at runtime by web-tree-sitter."
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand-chat/SKILL.md",
+      "type": "document",
+      "name": "SKILL.md",
+      "filePath": "understand-anything-plugin/skills/understand-chat/SKILL.md",
+      "summary": "Skill definition for /understand-chat, documenting the knowledge-graph structure and efficient-reading instructions the agent follows to answer codebase questions.",
+      "tags": [
+        "documentation",
+        "skill-definition",
+        "knowledge-graph"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand-dashboard/SKILL.md",
+      "type": "document",
+      "name": "SKILL.md",
+      "filePath": "understand-anything-plugin/skills/understand-dashboard/SKILL.md",
+      "summary": "Skill definition for the /understand-dashboard command that instructs the agent how to launch the interactive knowledge-graph web dashboard.",
+      "tags": [
+        "documentation",
+        "skill-definition",
+        "dashboard",
+        "command"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand-diff/SKILL.md",
+      "type": "document",
+      "name": "SKILL.md",
+      "filePath": "understand-anything-plugin/skills/understand-diff/SKILL.md",
+      "summary": "Skill definition for the /understand-diff command, describing graph structure references and instructions for analyzing git diffs and pull requests.",
+      "tags": [
+        "documentation",
+        "skill-definition",
+        "diff",
+        "command"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "type": "file",
+      "name": "extract-domain-context.py",
+      "filePath": "understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "summary": "Standalone Python script that performs a lightweight project scan for domain extraction, walking the file tree, detecting entry points, extracting code signatures and metadata, then writing a size-bounded JSON context.",
+      "tags": [
+        "script",
+        "domain-extraction",
+        "scanner",
+        "data-pipeline"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses a nested _walk closure inside scan_file_tree and a token-budget-aware _truncate_to_fit to keep output within a size cap."
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand-domain/SKILL.md",
+      "type": "document",
+      "name": "SKILL.md",
+      "filePath": "understand-anything-plugin/skills/understand-domain/SKILL.md",
+      "summary": "Skill definition for the /understand-domain command, detailing the six-phase workflow for extracting business domain knowledge either standalone or derived from an existing knowledge graph.",
+      "tags": [
+        "documentation",
+        "skill-definition",
+        "domain",
+        "command"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand-explain/SKILL.md",
+      "type": "document",
+      "name": "SKILL.md",
+      "filePath": "understand-anything-plugin/skills/understand-explain/SKILL.md",
+      "summary": "Skill definition for the /understand-explain command that guides deep-dive explanations of a specific file, function, or module using the knowledge graph.",
+      "tags": [
+        "documentation",
+        "skill-definition",
+        "explain",
+        "command"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py",
+      "type": "file",
+      "name": "merge-knowledge-graph.py",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py",
+      "summary": "Python script that merges per-batch wiki knowledge-graph fragments into a single graph, normalizing node/edge/entity types, deduplicating, and building layers and a guided tour.",
+      "tags": [
+        "script",
+        "knowledge-graph",
+        "merge",
+        "data-pipeline"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Type/entity normalization is driven by alias-map lookups; the bulk of logic lives in one large merge() function."
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "type": "file",
+      "name": "parse-knowledge-base.py",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "summary": "Python parser for Karpathy-pattern LLM wiki knowledge bases that detects format, extracts frontmatter, wikilinks, headings, and paragraphs, and resolves wikilinks into article node IDs.",
+      "tags": [
+        "script",
+        "knowledge-base",
+        "parser",
+        "markdown"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Heavy use of precompiled regexes (FRONTMATTER_RE, WIKILINK_RE, HEADING_RE) for markdown structural extraction."
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand-knowledge/SKILL.md",
+      "type": "document",
+      "name": "SKILL.md",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/SKILL.md",
+      "summary": "Skill definition for the /understand-knowledge command, describing how to analyze an LLM wiki knowledge base and generate an interactive knowledge graph.",
+      "tags": [
+        "documentation",
+        "skill-definition",
+        "knowledge-graph",
+        "command"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand-onboard/SKILL.md",
+      "type": "document",
+      "name": "SKILL.md",
+      "filePath": "understand-anything-plugin/skills/understand-onboard/SKILL.md",
+      "summary": "Skill definition for the /understand-onboard command that guides generation of an onboarding guide for new team members.",
+      "tags": [
+        "documentation",
+        "skill-definition",
+        "onboarding",
+        "command"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand/build-fingerprints.mjs",
+      "type": "file",
+      "name": "build-fingerprints.mjs",
+      "filePath": "understand-anything-plugin/skills/understand/build-fingerprints.mjs",
+      "summary": "Node CLI script that computes content fingerprints for project files, used to detect changes between analysis runs.",
+      "tags": [
+        "script",
+        "fingerprint",
+        "cli",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "type": "file",
+      "name": "compute-batches.mjs",
+      "filePath": "understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "summary": "Node CLI that partitions scanned project files into analysis batches, using Louvain community detection over the import graph and merging small batches for balanced file-analyzer dispatch.",
+      "tags": [
+        "script",
+        "batching",
+        "graph-algorithm",
+        "cli"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Implements Louvain community detection (runLouvain) with a count-based fallback assignment for balancing batch sizes."
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "type": "file",
+      "name": "extract-import-map.mjs",
+      "filePath": "understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "summary": "Large multi-language import resolver that parses and resolves project-internal imports across TypeScript/JavaScript, Python, Go, Java, Kotlin, C#, Ruby, PHP, Rust, and C++ into a normalized import map.",
+      "tags": [
+        "script",
+        "import-resolution",
+        "multi-language",
+        "cli"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Per-language resolvers each handle that ecosystem's module conventions (tsconfig paths, go.mod, composer autoload, Rust crate roots, Python packages)."
+    },
+    {
+      "id": "document:understand-anything-plugin/skills/understand/SKILL.md",
+      "type": "document",
+      "name": "SKILL.md",
+      "filePath": "understand-anything-plugin/skills/understand/SKILL.md",
+      "summary": "Primary skill definition for the /understand command, documenting the full multi-phase agent pipeline that scans a codebase and assembles an interactive knowledge graph.",
+      "tags": [
+        "documentation",
+        "skill-definition",
+        "pipeline",
+        "entry-point"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:scan_file_tree",
+      "type": "function",
+      "name": "scan_file_tree",
+      "filePath": "understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "lineRange": [
+        151,
+        192
+      ],
+      "summary": "Recursively walks the project tree up to a max depth, skipping ignored and symlinked entries, returning the list of relevant file paths.",
+      "tags": [
+        "scanner",
+        "file-walk",
+        "recursion"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:detect_entry_points",
+      "type": "function",
+      "name": "detect_entry_points",
+      "filePath": "understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "lineRange": [
+        197,
+        239
+      ],
+      "summary": "Scans files for entry-point patterns, capturing surrounding context lines and ranking candidates by priority.",
+      "tags": [
+        "entry-point",
+        "detection",
+        "domain-extraction"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:extract_file_signatures",
+      "type": "function",
+      "name": "extract_file_signatures",
+      "filePath": "understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "lineRange": [
+        244,
+        301
+      ],
+      "summary": "Reads selected files and extracts function, class, and export signatures via regex to build a compact code-signature summary.",
+      "tags": [
+        "signature-extraction",
+        "regex",
+        "domain-extraction"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:extract_metadata",
+      "type": "function",
+      "name": "extract_metadata",
+      "filePath": "understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "lineRange": [
+        306,
+        338
+      ],
+      "summary": "Extracts project metadata from package.json and other manifest files, including name, description, scripts, and dependencies.",
+      "tags": [
+        "metadata",
+        "manifest",
+        "domain-extraction"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:_truncate_to_fit",
+      "type": "function",
+      "name": "_truncate_to_fit",
+      "filePath": "understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "lineRange": [
+        343,
+        373
+      ],
+      "summary": "Progressively trims the context payload to stay within a serialized size budget before output.",
+      "tags": [
+        "truncation",
+        "size-budget",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "lineRange": [
+        376,
+        424
+      ],
+      "summary": "CLI entry point that orchestrates scanning, entry-point detection, signature and metadata extraction, then writes the bounded JSON context to disk.",
+      "tags": [
+        "entry-point",
+        "cli",
+        "orchestration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py:merge",
+      "type": "function",
+      "name": "merge",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py",
+      "lineRange": [
+        92,
+        380
+      ],
+      "summary": "Loads per-batch fragments, normalizes and deduplicates nodes and edges, assigns layers from index categories, builds a guided tour, and writes the merged wiki knowledge graph.",
+      "tags": [
+        "merge",
+        "knowledge-graph",
+        "deduplication"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py",
+      "lineRange": [
+        383,
+        393
+      ],
+      "summary": "CLI entry point that validates the project-root argument and invokes the merge routine.",
+      "tags": [
+        "entry-point",
+        "cli"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:detect_format",
+      "type": "function",
+      "name": "detect_format",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "lineRange": [
+        38,
+        69
+      ],
+      "summary": "Detects the wiki knowledge-base layout (index/log/raw conventions) and returns the resolved wiki root and format descriptor.",
+      "tags": [
+        "format-detection",
+        "knowledge-base"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:extract_first_paragraph",
+      "type": "function",
+      "name": "extract_first_paragraph",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "lineRange": [
+        113,
+        154
+      ],
+      "summary": "Strips frontmatter and headings to collect the first meaningful prose paragraph from a markdown article for use as a summary.",
+      "tags": [
+        "markdown",
+        "text-extraction",
+        "parser"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:parse_index",
+      "type": "function",
+      "name": "parse_index",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "lineRange": [
+        170,
+        194
+      ],
+      "summary": "Parses the wiki index file into categories and their listed article wikilinks.",
+      "tags": [
+        "index-parser",
+        "categories",
+        "wikilinks"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:parse_log",
+      "type": "function",
+      "name": "parse_log",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "lineRange": [
+        201,
+        216
+      ],
+      "summary": "Parses the wiki log file into dated entries via a compiled regex.",
+      "tags": [
+        "log-parser",
+        "regex"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:build_name_to_stem_map",
+      "type": "function",
+      "name": "build_name_to_stem_map",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "lineRange": [
+        223,
+        249
+      ],
+      "summary": "Builds a lookup mapping article names and basenames to their relative stem paths for wikilink resolution.",
+      "tags": [
+        "mapping",
+        "wikilinks",
+        "resolution"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:resolve_wikilink",
+      "type": "function",
+      "name": "resolve_wikilink",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "lineRange": [
+        252,
+        275
+      ],
+      "summary": "Resolves a wikilink target to a concrete article node ID using the name-to-stem map with fallback suffix matching.",
+      "tags": [
+        "wikilinks",
+        "resolution",
+        "graph"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:parse_wiki",
+      "type": "function",
+      "name": "parse_wiki",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "lineRange": [
+        278,
+        479
+      ],
+      "summary": "Top-level wiki parser that detects format, builds the name map, parses index and log, walks every article extracting metadata and wikilinks, and emits the structured parse result.",
+      "tags": [
+        "parser",
+        "knowledge-base",
+        "orchestration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "lineRange": [
+        482,
+        505
+      ],
+      "summary": "CLI entry point that resolves the knowledge-base root and prints the parsed wiki structure as JSON.",
+      "tags": [
+        "entry-point",
+        "cli"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/build-fingerprints.mjs:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "understand-anything-plugin/skills/understand/build-fingerprints.mjs",
+      "lineRange": [
+        55,
+        88
+      ],
+      "summary": "CLI entry point that reads project files and computes their content fingerprints, writing the fingerprint map to disk.",
+      "tags": [
+        "entry-point",
+        "cli",
+        "fingerprint"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/compute-batches.mjs:extractExports",
+      "type": "function",
+      "name": "extractExports",
+      "filePath": "understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "lineRange": [
+        51,
+        121
+      ],
+      "summary": "Extracts exported symbol names from file content to support batch import-graph edges.",
+      "tags": [
+        "export-extraction",
+        "parsing",
+        "batching"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/compute-batches.mjs:buildNonCodeBatches",
+      "type": "function",
+      "name": "buildNonCodeBatches",
+      "filePath": "understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "lineRange": [
+        131,
+        215
+      ],
+      "summary": "Groups non-code files (docs, config, infra) into balanced batches separately from code files.",
+      "tags": [
+        "batching",
+        "non-code",
+        "grouping"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/compute-batches.mjs:runLouvain",
+      "type": "function",
+      "name": "runLouvain",
+      "filePath": "understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "lineRange": [
+        234,
+        249
+      ],
+      "summary": "Runs Louvain community detection over the import graph to cluster related files into batches.",
+      "tags": [
+        "graph-algorithm",
+        "community-detection",
+        "batching"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/compute-batches.mjs:mergeSmallBatches",
+      "type": "function",
+      "name": "mergeSmallBatches",
+      "filePath": "understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "lineRange": [
+        278,
+        332
+      ],
+      "summary": "Combines undersized batches into larger ones to balance file-analyzer dispatch load.",
+      "tags": [
+        "batching",
+        "balancing",
+        "merge"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/compute-batches.mjs:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "lineRange": [
+        335,
+        558
+      ],
+      "summary": "CLI entry point that loads scan data, builds the import graph, runs clustering and balancing, and writes the computed batch plan.",
+      "tags": [
+        "entry-point",
+        "cli",
+        "orchestration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveTsJsImport",
+      "type": "function",
+      "name": "resolveTsJsImport",
+      "filePath": "understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "lineRange": [
+        492,
+        549
+      ],
+      "summary": "Resolves a TypeScript/JavaScript import specifier to a project-internal file path, honoring tsconfig path aliases and extension probing.",
+      "tags": [
+        "import-resolution",
+        "typescript",
+        "javascript"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolvePythonImport",
+      "type": "function",
+      "name": "resolvePythonImport",
+      "filePath": "understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "lineRange": [
+        685,
+        761
+      ],
+      "summary": "Resolves a Python import statement to a project-internal module file, handling packages and relative imports.",
+      "tags": [
+        "import-resolution",
+        "python"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveGoImport",
+      "type": "function",
+      "name": "resolveGoImport",
+      "filePath": "understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "lineRange": [
+        831,
+        879
+      ],
+      "summary": "Resolves a Go import path to a project-internal package directory using go.mod module data.",
+      "tags": [
+        "import-resolution",
+        "go"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveRustImport",
+      "type": "function",
+      "name": "resolveRustImport",
+      "filePath": "understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "lineRange": [
+        1279,
+        1336
+      ],
+      "summary": "Resolves a Rust use/mod path to a project-internal source file, navigating crate roots and module files.",
+      "tags": [
+        "import-resolution",
+        "rust"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolvePhpImport",
+      "type": "function",
+      "name": "resolvePhpImport",
+      "filePath": "understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "lineRange": [
+        1173,
+        1217
+      ],
+      "summary": "Resolves a PHP namespace use to a project file using composer autoload (PSR-4) mappings.",
+      "tags": [
+        "import-resolution",
+        "php"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveImport",
+      "type": "function",
+      "name": "resolveImport",
+      "filePath": "understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "lineRange": [
+        1420,
+        1455
+      ],
+      "summary": "Language-dispatching import resolver that routes a specifier to the appropriate per-language resolution function.",
+      "tags": [
+        "import-resolution",
+        "dispatch",
+        "multi-language"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "lineRange": [
+        1480,
+        1637
+      ],
+      "summary": "CLI entry point that loads scan data and resolution context, resolves every file's imports, and writes the project import map.",
+      "tags": [
+        "entry-point",
+        "cli",
+        "orchestration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand/extract-structure.mjs",
+      "type": "file",
+      "name": "extract-structure.mjs",
+      "filePath": "understand-anything-plugin/skills/understand/extract-structure.mjs",
+      "summary": "Bundled structural extraction script used by the file-analyzer agent; uses tree-sitter and specialized parsers to extract functions, classes, exports, and sub-file structures from each file in a batch.",
+      "tags": [
+        "script",
+        "tree-sitter",
+        "structural-extraction",
+        "cli",
+        "tested"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand/generate-ignore.mjs",
+      "type": "file",
+      "name": "generate-ignore.mjs",
+      "filePath": "understand-anything-plugin/skills/understand/generate-ignore.mjs",
+      "summary": "Small CLI helper that resolves the plugin root and generates a default ignore file for project scanning.",
+      "tags": [
+        "script",
+        "ignore-file",
+        "cli",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "type": "file",
+      "name": "merge-batch-graphs.py",
+      "filePath": "understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "summary": "Core Python merge script that combines per-batch file-analyzer graph fragments, normalizes node IDs and types, links tests to production files, recovers dropped import edges, and emits the final knowledge graph.",
+      "tags": [
+        "script",
+        "knowledge-graph",
+        "merge",
+        "test-linking"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Includes deterministic test-to-production pairing (link_tests, production_candidates) and import-edge recovery from the scan data as safety nets."
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand/merge-subdomain-graphs.py",
+      "type": "file",
+      "name": "merge-subdomain-graphs.py",
+      "filePath": "understand-anything-plugin/skills/understand/merge-subdomain-graphs.py",
+      "summary": "Python script that merges multiple subdomain graph fragments into a single domain graph, deduplicating nodes and edges across subdomains.",
+      "tags": [
+        "script",
+        "domain-graph",
+        "merge",
+        "data-pipeline"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:understand-anything-plugin/skills/understand/scan-project.mjs",
+      "type": "file",
+      "name": "scan-project.mjs",
+      "filePath": "understand-anything-plugin/skills/understand/scan-project.mjs",
+      "summary": "Node CLI that enumerates project files (via git or filesystem walk), detects language and category, estimates complexity, and counts lines to produce the project inventory consumed by downstream analysis.",
+      "tags": [
+        "script",
+        "project-scanner",
+        "cli",
+        "entry-point"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Prefers git ls-files enumeration with a filesystem-walk fallback, and respects user ignore files when present."
+    },
+    {
+      "id": "file:understand-anything-plugin/src/__tests__/diff-analyzer.test.ts",
+      "type": "file",
+      "name": "diff-analyzer.test.ts",
+      "filePath": "understand-anything-plugin/src/__tests__/diff-analyzer.test.ts",
+      "summary": "Vitest unit tests for the diff-analyzer module, verifying diff context building and analysis formatting.",
+      "tags": [
+        "test",
+        "vitest",
+        "diff-analyzer"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/__tests__/explain-builder.test.ts",
+      "type": "file",
+      "name": "explain-builder.test.ts",
+      "filePath": "understand-anything-plugin/src/__tests__/explain-builder.test.ts",
+      "summary": "Vitest unit tests for the explain-builder module, verifying explain-context building and prompt formatting.",
+      "tags": [
+        "test",
+        "vitest",
+        "explain-builder"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/__tests__/extract-structure.test.mjs",
+      "type": "file",
+      "name": "extract-structure.test.mjs",
+      "filePath": "understand-anything-plugin/src/__tests__/extract-structure.test.mjs",
+      "summary": "Vitest tests exercising the bundled extract-structure.mjs script, asserting it correctly extracts functions and structure from sample files.",
+      "tags": [
+        "test",
+        "vitest",
+        "structural-extraction"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs",
+      "type": "file",
+      "name": "merge-recover-imports.test.mjs",
+      "filePath": "understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs",
+      "summary": "Vitest tests for the import-edge recovery pass in merge-batch-graphs.py, building synthetic file nodes and import edges to verify dropped imports are recovered.",
+      "tags": [
+        "test",
+        "vitest",
+        "merge",
+        "import-recovery"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/__tests__/onboard-builder.test.ts",
+      "type": "file",
+      "name": "onboard-builder.test.ts",
+      "filePath": "understand-anything-plugin/src/__tests__/onboard-builder.test.ts",
+      "summary": "Vitest unit tests for the onboard-builder module, verifying generation of onboarding guides from a knowledge graph.",
+      "tags": [
+        "test",
+        "vitest",
+        "onboard-builder"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs",
+      "type": "file",
+      "name": "worktree-redirect.test.mjs",
+      "filePath": "understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs",
+      "summary": "Vitest tests verifying worktree path-redirect resolution logic used when agents run in isolated git worktrees.",
+      "tags": [
+        "test",
+        "vitest",
+        "worktree"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/diff-analyzer.ts",
+      "type": "file",
+      "name": "diff-analyzer.ts",
+      "filePath": "understand-anything-plugin/src/diff-analyzer.ts",
+      "summary": "Skill source module for /understand-diff that builds diff analysis context from a git diff and a knowledge graph, then formats the analysis output.",
+      "tags": [
+        "diff-analyzer",
+        "skill-source",
+        "formatting",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/extract-structure.mjs:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "understand-anything-plugin/skills/understand/extract-structure.mjs",
+      "lineRange": [
+        49,
+        140
+      ],
+      "summary": "CLI entry point that reads the batch input, runs structural extraction on each file, and writes the results JSON.",
+      "tags": [
+        "entry-point",
+        "cli",
+        "orchestration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/extract-structure.mjs:buildResult",
+      "type": "function",
+      "name": "buildResult",
+      "filePath": "understand-anything-plugin/skills/understand/extract-structure.mjs",
+      "lineRange": [
+        146,
+        304
+      ],
+      "summary": "Core extraction routine that parses a single file with tree-sitter or specialized parsers and builds its structural result (functions, classes, exports, sub-file sections).",
+      "tags": [
+        "structural-extraction",
+        "tree-sitter",
+        "parser"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:normalize_node_id",
+      "type": "function",
+      "name": "normalize_node_id",
+      "filePath": "understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "lineRange": [
+        178,
+        221
+      ],
+      "summary": "Repairs and canonicalizes malformed node IDs (missing prefixes, project-name pollution) to the standard type-prefixed format.",
+      "tags": [
+        "normalization",
+        "node-id",
+        "merge"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:production_candidates",
+      "type": "function",
+      "name": "production_candidates",
+      "filePath": "understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "lineRange": [
+        340,
+        506
+      ],
+      "summary": "Derives candidate production-file paths for a given test file across many language and directory naming conventions.",
+      "tags": [
+        "test-linking",
+        "path-convention",
+        "heuristics"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:link_tests",
+      "type": "function",
+      "name": "link_tests",
+      "filePath": "understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "lineRange": [
+        556,
+        719
+      ],
+      "summary": "Canonicalizes tested_by edge direction, pairs tests to production files by convention, and tags tested production nodes.",
+      "tags": [
+        "test-linking",
+        "edges",
+        "merge"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:merge_and_normalize",
+      "type": "function",
+      "name": "merge_and_normalize",
+      "filePath": "understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "lineRange": [
+        724,
+        908
+      ],
+      "summary": "Loads all batch fragments, normalizes node IDs/types/complexity, deduplicates, and assembles the unified node and edge sets.",
+      "tags": [
+        "merge",
+        "normalization",
+        "deduplication"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:recover_imports_from_scan",
+      "type": "function",
+      "name": "recover_imports_from_scan",
+      "filePath": "understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "lineRange": [
+        913,
+        998
+      ],
+      "summary": "Recovers import edges that file-analyzer agents dropped by cross-referencing the deterministic scan import map.",
+      "tags": [
+        "import-recovery",
+        "merge",
+        "safety-net"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "lineRange": [
+        1003,
+        1160
+      ],
+      "summary": "CLI entry point orchestrating the full merge: load, normalize, link tests, recover imports, and write the final knowledge graph.",
+      "tags": [
+        "entry-point",
+        "cli",
+        "orchestration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/merge-subdomain-graphs.py:merge_graphs",
+      "type": "function",
+      "name": "merge_graphs",
+      "filePath": "understand-anything-plugin/skills/understand/merge-subdomain-graphs.py",
+      "lineRange": [
+        52,
+        232
+      ],
+      "summary": "Merges multiple subdomain graph fragments, deduplicating shared nodes and edges into a single domain graph.",
+      "tags": [
+        "merge",
+        "domain-graph",
+        "deduplication"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/merge-subdomain-graphs.py:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "understand-anything-plugin/skills/understand/merge-subdomain-graphs.py",
+      "lineRange": [
+        235,
+        304
+      ],
+      "summary": "CLI entry point that loads subdomain graphs and writes the merged domain graph.",
+      "tags": [
+        "entry-point",
+        "cli",
+        "orchestration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/scan-project.mjs:detectCategory",
+      "type": "function",
+      "name": "detectCategory",
+      "filePath": "understand-anything-plugin/skills/understand/scan-project.mjs",
+      "lineRange": [
+        373,
+        417
+      ],
+      "summary": "Classifies a file into a category (code, config, docs, infra, data, script, markup) based on path and extension.",
+      "tags": [
+        "classification",
+        "file-category",
+        "scanner"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/scan-project.mjs:enumerateViaWalk",
+      "type": "function",
+      "name": "enumerateViaWalk",
+      "filePath": "understand-anything-plugin/skills/understand/scan-project.mjs",
+      "lineRange": [
+        499,
+        544
+      ],
+      "summary": "Enumerates project files via a recursive filesystem walk when git enumeration is unavailable.",
+      "tags": [
+        "scanner",
+        "file-walk",
+        "enumeration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/scan-project.mjs:countLines",
+      "type": "function",
+      "name": "countLines",
+      "filePath": "understand-anything-plugin/skills/understand/scan-project.mjs",
+      "lineRange": [
+        622,
+        639
+      ],
+      "summary": "Counts total lines for a file used in complexity estimation and inventory metrics.",
+      "tags": [
+        "metrics",
+        "line-count",
+        "scanner"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/skills/understand/scan-project.mjs:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "understand-anything-plugin/skills/understand/scan-project.mjs",
+      "lineRange": [
+        645,
+        765
+      ],
+      "summary": "CLI entry point that enumerates files, detects language and category, estimates complexity, counts lines, and writes the project inventory.",
+      "tags": [
+        "entry-point",
+        "cli",
+        "orchestration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:understand-anything-plugin/src/diff-analyzer.ts:buildDiffContext",
+      "type": "function",
+      "name": "buildDiffContext",
+      "filePath": "understand-anything-plugin/src/diff-analyzer.ts",
+      "lineRange": [
+        22,
+        88
+      ],
+      "summary": "Builds diff analysis context by correlating changed files in a git diff with their knowledge-graph nodes and relationships.",
+      "tags": [
+        "diff-analyzer",
+        "context-builder",
+        "graph"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/src/diff-analyzer.ts:formatDiffAnalysis",
+      "type": "function",
+      "name": "formatDiffAnalysis",
+      "filePath": "understand-anything-plugin/src/diff-analyzer.ts",
+      "lineRange": [
+        93,
+        198
+      ],
+      "summary": "Formats the diff analysis context into a human-readable report of affected components and risks.",
+      "tags": [
+        "diff-analyzer",
+        "formatting",
+        "report"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/explain-builder.ts",
+      "type": "file",
+      "name": "explain-builder.ts",
+      "filePath": "understand-anything-plugin/src/explain-builder.ts",
+      "summary": "Builds the explanation context and prompt for the /understand-explain skill by extracting a target node, its children, related nodes, and layer from the knowledge graph.",
+      "tags": [
+        "service",
+        "prompt-builder",
+        "graph-traversal",
+        "skill",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Pure functions that walk the knowledge graph (nodes/edges/layers) and assemble a markdown prompt string."
+    },
+    {
+      "id": "function:understand-anything-plugin/src/explain-builder.ts:buildExplainContext",
+      "type": "function",
+      "name": "buildExplainContext",
+      "filePath": "understand-anything-plugin/src/explain-builder.ts",
+      "lineRange": [
+        22,
+        103
+      ],
+      "summary": "Resolves the target node for a given path and gathers its child nodes, connected/related nodes, relevant edges, and owning layer into an explain context object.",
+      "tags": [
+        "graph-traversal",
+        "context-builder",
+        "lookup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/src/explain-builder.ts:formatExplainPrompt",
+      "type": "function",
+      "name": "formatExplainPrompt",
+      "filePath": "understand-anything-plugin/src/explain-builder.ts",
+      "lineRange": [
+        108,
+        196
+      ],
+      "summary": "Formats an explain context into a markdown prompt describing the target component, its members, related nodes, and edges for the LLM to explain.",
+      "tags": [
+        "prompt-builder",
+        "formatting",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/src/index.ts",
+      "type": "file",
+      "name": "index.ts",
+      "filePath": "understand-anything-plugin/src/index.ts",
+      "summary": "Barrel module re-exporting the public skill-builder APIs (chat, diff, explain, onboarding) from their respective modules.",
+      "tags": [
+        "barrel",
+        "entry-point",
+        "exports"
+      ],
+      "complexity": "simple",
+      "languageNotes": "TypeScript barrel file using re-exports with .js extensions for ESM resolution."
+    },
+    {
+      "id": "file:understand-anything-plugin/src/onboard-builder.ts",
+      "type": "file",
+      "name": "onboard-builder.ts",
+      "filePath": "understand-anything-plugin/src/onboard-builder.ts",
+      "summary": "Generates a markdown onboarding guide for new team members from the knowledge graph, covering project overview, architectural layers, entry points, and key components.",
+      "tags": [
+        "service",
+        "prompt-builder",
+        "documentation",
+        "skill",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:understand-anything-plugin/src/onboard-builder.ts:buildOnboardingGuide",
+      "type": "function",
+      "name": "buildOnboardingGuide",
+      "filePath": "understand-anything-plugin/src/onboard-builder.ts",
+      "lineRange": [
+        7,
+        124
+      ],
+      "summary": "Walks the project metadata, layers, and nodes of the knowledge graph to assemble a structured markdown onboarding guide.",
+      "tags": [
+        "graph-traversal",
+        "documentation",
+        "formatting"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:understand-anything-plugin/vitest.config.ts",
+      "type": "file",
+      "name": "vitest.config.ts",
+      "filePath": "understand-anything-plugin/vitest.config.ts",
+      "summary": "Vitest test runner configuration for the understand-anything plugin package.",
+      "tags": [
+        "config",
+        "test",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:vitest.config.ts",
+      "type": "file",
+      "name": "vitest.config.ts",
+      "filePath": "vitest.config.ts",
+      "summary": "Root Vitest configuration that picks up the repo-level skill tests in tests/skill/.",
+      "tags": [
+        "config",
+        "test",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx:Breadcrumb",
+      "type": "function",
+      "name": "Breadcrumb",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx",
+      "summary": "React component rendering the breadcrumb navigation trail; default export of Breadcrumb.tsx.",
+      "tags": [
+        "component",
+        "navigation",
+        "dashboard"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx:PersonaSelector",
+      "type": "function",
+      "name": "PersonaSelector",
+      "filePath": "understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "summary": "React component for selecting the active persona; default export of PersonaSelector.tsx.",
+      "tags": [
+        "component",
+        "persona",
+        "dashboard"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:understand-anything-plugin/packages/core/src/languages/configs/docker-compose.ts",
+      "type": "file",
+      "name": "docker-compose.ts",
+      "filePath": "understand-anything-plugin/packages/core/src/languages/configs/docker-compose.ts",
+      "summary": "Language configuration for Docker Compose files, declaring file patterns and metadata for the language registry.",
+      "tags": [
+        "language-config",
+        "data-model",
+        "docker-compose"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:scripts/check-graph.mjs",
+      "type": "file",
+      "name": "check-graph.mjs",
+      "filePath": "scripts/check-graph.mjs",
+      "summary": "Deterministic, zero-token CI guard for the repo's committed self-knowledge graph: schema-validates knowledge-graph.json and domain-graph.json (blocking) and detects structural staleness against committed fingerprints (advisory, or blocking under --strict).",
+      "tags": [
+        "ci-cd",
+        "validation",
+        "script",
+        "build-system",
+        "entry-point"
+      ],
+      "complexity": "complex",
+      "languageNotes": "ESM script that loads @understand-anything/core from the built dist via dynamic pathToFileURL imports rather than a project-relative source import, keeping it decoupled from the TypeScript build graph."
+    },
+    {
+      "id": "function:scripts/check-graph.mjs:loadCore",
+      "type": "function",
+      "name": "loadCore",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        54,
+        66
+      ],
+      "summary": "Dynamically imports @understand-anything/core and its schema module from the built dist directory, exiting with a CI error if the package has not been built.",
+      "tags": [
+        "utility",
+        "dynamic-import",
+        "bootstrap"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:scripts/check-graph.mjs:validateOne",
+      "type": "function",
+      "name": "validateOne",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        68,
+        93
+      ],
+      "summary": "Schema-validates a single graph JSON file by name, parsing it and running validateGraph, emitting CI errors on missing files, parse failures, or validation errors.",
+      "tags": [
+        "validation",
+        "schema",
+        "ci-cd"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:scripts/check-graph.mjs:trackedSourceFiles",
+      "type": "function",
+      "name": "trackedSourceFiles",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        95,
+        107
+      ],
+      "summary": "Returns the list of git-tracked source files (filtered by graph-relevant extensions and the ignore filter) using git ls-files.",
+      "tags": [
+        "utility",
+        "git",
+        "file-discovery"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:scripts/check-graph.mjs:checkStaleness",
+      "type": "function",
+      "name": "checkStaleness",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        109,
+        168
+      ],
+      "summary": "Rebuilds structural fingerprints for the current source tree and compares them against the committed fingerprints to detect added, removed, or structurally changed files, reporting drift as a warning (or error under --strict).",
+      "tags": [
+        "validation",
+        "staleness-check",
+        "ci-cd",
+        "fingerprinting"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:scripts/check-graph.mjs:checkDomainSync",
+      "type": "function",
+      "name": "checkDomainSync",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        175,
+        215
+      ],
+      "summary": "Verifies the committed domain-graph.json was generated from the same knowledge graph revision by comparing source hashes, emitting an error when the domain graph is out of sync.",
+      "tags": [
+        "validation",
+        "staleness-check",
+        "ci-cd"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:scripts/check-graph.mjs:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "scripts/check-graph.mjs",
+      "lineRange": [
+        217,
+        239
+      ],
+      "summary": "Entry point orchestrating the guard: loads core, validates both graph files, runs staleness and domain-sync checks, and exits non-zero on any blocking error.",
+      "tags": [
+        "entry-point",
+        "orchestration",
+        "ci-cd"
+      ],
+      "complexity": "moderate"
+    }
+  ],
+  "edges": [
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/django.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/react.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/python.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/typescript.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/plugin-discovery.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/plugin-discovery.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/batch.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/c.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/cpp.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/csharp.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/css.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/csv.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/dart.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/dockerfile.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/env.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/github-actions.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/go.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/graphql.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/html.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/batch.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/c.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/cpp.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/csharp.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/css.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/csv.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/dart.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/dockerfile.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/env.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/github-actions.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/go.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/graphql.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/html.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/java.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/javascript.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/jenkinsfile.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/json-config.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/json-schema.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/kotlin.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/kubernetes.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/lua.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/makefile.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/markdown.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/openapi.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/php.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/plaintext.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/powershell.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/protobuf.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/python.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/restructuredtext.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/ruby.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/rust.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/shell.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/sql.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/swift.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/terraform.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/toml.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/typescript.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/xml.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/yaml.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/java.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/javascript.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/jenkinsfile.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/json-config.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/json-schema.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/kotlin.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/kubernetes.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/lua.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/makefile.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/markdown.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/openapi.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/php.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/plaintext.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/powershell.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/protobuf.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/python.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/restructuredtext.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/ruby.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/rust.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/shell.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/sql.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/swift.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/terraform.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/toml.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/typescript.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/xml.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/yaml.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/django.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/express.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/fastapi.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/flask.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/gin.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/django.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/express.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/fastapi.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/flask.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/gin.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/nextjs.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/rails.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/react.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/spring.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/frameworks/vue.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/nextjs.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/rails.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/react.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/spring.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/frameworks/vue.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/languages/framework-registry.ts:FrameworkRegistry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/languages/framework-registry.ts:FrameworkRegistry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/languages/language-registry.ts:LanguageRegistry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/languages/language-registry.ts:LanguageRegistry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/discovery.ts:parsePluginConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/discovery.ts:parsePluginConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/discovery.ts:serializePluginConfig",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/discovery.ts:serializePluginConfig",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cpp-extractor.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cpp-extractor.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/dart-extractor.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/dart-extractor.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/java-extractor.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/java-extractor.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/kotlin-extractor.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/kotlin-extractor.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/rust-extractor.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/rust-extractor.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts:traverse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts:traverse",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts:findChildren",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts:findChildren",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts:CppExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts:CppExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts:CSharpExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts:CSharpExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts:DartExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts:DartExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts:GoExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts:GoExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts:JavaExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts:JavaExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts:KotlinExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts:KotlinExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts:PhpExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts:PhpExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts:PythonExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts:PythonExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts:RubyExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts:RubyExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts:RustExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts:RustExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts:TypeScriptExtractor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts:TypeScriptExtractor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts:TreeSitterPlugin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts:TreeSitterPlugin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx:useOverviewGraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx:useLayerDetailTopology",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx:useLayerDetailGraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx:GraphViewInner",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx:TourFitView",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/themes/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx:KeyboardShortcutsHelp",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx:KeyboardShortcutsHelp",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx:computeLayout",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx:KnowledgeGraphViewInner",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx:KnowledgeGraphViewInner",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx:computeLayout",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx:LayerClusterNode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx:LayerClusterNode",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx:getLayerColor",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx:LayerLegend",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx:LayerLegend",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx:getLayerColor",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx:getLayerColor",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx:LearnPanel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx:LearnPanel",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx:MobileBottomNav",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx:MobileBottomNav",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx:MobileDrawer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx:MobileDrawer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx:MobileLayout",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx:MobileLayout",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx:NodeInfo",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx:NodeInfo",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx:KnowledgeNodeDetails",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx:DomainNodeDetails",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx:NodeTooltip",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx:NodeTooltip",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx:OnboardingOverlay",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx:OnboardingOverlay",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/App.tsx:Dashboard",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/App.tsx:DashboardContent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/App.tsx:dataUrl",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/App.tsx:resolveInitialToken",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/themes/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx:CodeViewer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx:CodeViewer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx:fallbackLanguage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx:ContainerNodeComponent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx:ContainerNodeComponent",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx:getLayerColor",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx:CustomNodeComponent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx:DiffToggle",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx:DiffToggle",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx:DomainClusterNode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx:buildDomainOverview",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx:buildDomainDetail",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx:DomainGraphViewInner",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx:DomainGraphViewInner",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx:buildDomainOverview",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx:DomainGraphViewInner",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx:buildDomainDetail",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx:ExportMenu",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx:ExportMenu",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx:downloadBlob",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx:ExportMenu",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx:downloadBlob",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx:buildFileTree",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx:FileTreeRow",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx:FileExplorer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx:FileExplorer",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx:FileExplorer",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx:buildFileTree",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx:FilterPanel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx:FilterPanel",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx:FlowNode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx:PathFinderModal",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx:PathFinderModal",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx:useI18n",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx:PortalNode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx:getLayerColor",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx:ProjectOverview",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx:ProjectOverview",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx:useI18n",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx:SearchBar",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx:SearchBar",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx:useI18n",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx:StepNode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx:ThemePicker",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx:ThemePicker",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/themes/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx:useI18n",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx:TokenGate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx:TokenGate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx:buildCopyText",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx:WarningBanner",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx:WarningBanner",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx:useI18n",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx:I18nProvider",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx:useI18n",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx:I18nProvider",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts:useIsMobile",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts:useIsMobile",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts:useKeyboardShortcuts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts:formatShortcutKey",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts:useKeyboardShortcuts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts:formatShortcutKey",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/main.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/main.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/index.css",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/store.ts:buildGraphIndexes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/store.ts:navigateTourToLayer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/store.ts:layerResetIfChanged",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/edgeAggregation.test.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/edgeAggregation.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/elk-layout.test.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/elk-layout.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/filters.test.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/filters.test.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/filters.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/layerStats.test.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/layerStats.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:aggregateLayerEdges",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:computePortals",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:findCrossLayerFileNodes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:aggregateContainerEdges",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:aggregateLayerEdges",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:computePortals",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:findCrossLayerFileNodes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts:aggregateContainerEdges",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts:repairElkInput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts:applyElkLayout",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts:repairElkInput",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts:applyElkLayout",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/filters.ts:filterNodes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/filters.ts:filterEdges",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/filters.ts:filterNodes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/filters.ts:filterEdges",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts:computeLayerStats",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts:computeLayerStats",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:applyDagreLayout",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:applyForceLayout",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:nodesToElkInput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:mergeElkPositions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:applyDagreLayout",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:applyForceLayout",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:nodesToElkInput",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/layout.ts:mergeElkPositions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/domain-normalize.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/domain-normalize.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/domain-persistence.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/domain-persistence.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/domain-types.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/domain-types.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/fingerprint.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/fingerprint.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/fingerprint.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/typescript.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/layer-detector.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/layer-detector.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/layer-detector.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/plugin-registry.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/plugin-registry.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/plugin-registry.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/plugin-registry.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/schema.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/schema.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/schema.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/search.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/search.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/search.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/search.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/search.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/staleness.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/staleness.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/tour-generator.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/tour-generator.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/tour-generator.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts:GraphBuilder",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts:GraphBuilder",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:detectLanguageConcepts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:detectLanguageConcepts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:buildLanguageLessonPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:buildLanguageLessonPrompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:parseLanguageLessonResponse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:parseLanguageLessonResponse",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:buildLanguageLessonPrompt",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts:detectLanguageConcepts",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:detectLayers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:detectLayers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:buildLayerDetectionPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:buildLayerDetectionPrompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:parseLayerDetectionResponse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:parseLayerDetectionResponse",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:applyLLMLayers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts:applyLLMLayers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeNodeId",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeNodeId",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeComplexity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeComplexity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeBatchOutput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeBatchOutput",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeBatchOutput",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeNodeId",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeBatchOutput",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts:normalizeComplexity",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts:buildTourGenerationPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts:buildTourGenerationPrompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts:parseTourGenerationResponse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts:parseTourGenerationResponse",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts:generateHeuristicTour",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts:generateHeuristicTour",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/change-classifier.ts:classifyUpdate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/change-classifier.ts:classifyUpdate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/change-classifier.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/change-classifier.ts:detectDirectoryChanges",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/change-classifier.ts:classifyUpdate",
+      "target": "function:understand-anything-plugin/packages/core/src/change-classifier.ts:detectDirectoryChanges",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/search.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/embedding-search.ts:cosineSimilarity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/embedding-search.ts:cosineSimilarity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/embedding-search.ts:SemanticSearchEngine",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/embedding-search.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/embedding-search.ts:SemanticSearchEngine",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:understand-anything-plugin/packages/core/src/embedding-search.ts:SemanticSearchEngine",
+      "target": "function:understand-anything-plugin/packages/core/src/embedding-search.ts:cosineSimilarity",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:extractFileFingerprint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:compareFingerprints",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:buildFingerprintStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:analyzeChanges",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:extractFileFingerprint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:compareFingerprints",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:buildFingerprintStore",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/fingerprint.ts:analyzeChanges",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/persistence/index.ts:sanitiseFilePaths",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/persistence/index.ts:loadGraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/persistence/index.ts:loadDomainGraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/persistence/index.ts:loadGraph",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/persistence/index.ts:loadDomainGraph",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/persistence/index.ts:loadGraph",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:validateGraph",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/persistence/index.ts:loadDomainGraph",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:validateGraph",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/persistence.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/persistence.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/persistence.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/persistence/persistence.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts:DockerfileParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts:DockerfileParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts:EnvParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts:EnvParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts:GraphQLParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts:GraphQLParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts:registerAllParsers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts:registerAllParsers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts:registerAllParsers",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/registry.ts:PluginRegistry",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts:stripJsoncSyntax",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts:JSONConfigParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts:stripJsoncSyntax",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts:JSONConfigParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts:MakefileParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts:MakefileParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts:MarkdownParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts:MarkdownParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts:ProtobufParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts:ProtobufParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts:ShellParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts:ShellParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts:SQLParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts:SQLParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts:TerraformParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts:TerraformParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts:TOMLParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts:TOMLParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts:YAMLConfigParser",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts:YAMLConfigParser",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/registry.ts:PluginRegistry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/plugins/registry.ts:PluginRegistry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "class:understand-anything-plugin/packages/core/src/plugins/registry.ts:PluginRegistry",
+      "target": "class:understand-anything-plugin/packages/core/src/languages/language-registry.ts:LanguageRegistry",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:sanitizeGraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:autoFixGraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:normalizeGraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:validateGraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:sanitizeGraph",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:autoFixGraph",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:normalizeGraph",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/schema.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:validateGraph",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/schema.ts:validateGraph",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:sanitizeGraph",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/schema.ts:validateGraph",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:normalizeGraph",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/schema.ts:validateGraph",
+      "target": "function:understand-anything-plugin/packages/core/src/schema.ts:autoFixGraph",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/search.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/search.ts:SearchEngine",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/search.ts",
+      "target": "class:understand-anything-plugin/packages/core/src/search.ts:SearchEngine",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/search.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/staleness.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/staleness.ts:getChangedFiles",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/staleness.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/staleness.ts:mergeGraphUpdate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/staleness.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/staleness.ts:getChangedFiles",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/staleness.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/staleness.ts:mergeGraphUpdate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/staleness.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/types.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/types.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/types.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/locales/en.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/locales/ja.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/locales/ko.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/locales/ru.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/locales/zh.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/locales/index.ts:getLocale",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/locales/index.ts:resolveLocaleKey",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/locales/index.ts:getLocale",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/locales/index.ts:resolveLocaleKey",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/ignore-filter.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/ignore-filter.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/ignore-filter.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/ignore-filter.ts:createIgnoreFilter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/ignore-filter.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/ignore-filter.ts:createIgnoreFilter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/ignore-generator.ts:detectDirectories",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/ignore-generator.ts:generateStarterIgnoreFile",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/ignore-generator.ts:generateStarterIgnoreFile",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/core/src/ignore-generator.ts:generateStarterIgnoreFile",
+      "target": "function:understand-anything-plugin/packages/core/src/ignore-generator.ts:detectDirectories",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/ignore-filter.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/ignore-generator.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/themes/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/themes/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/themes/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx:ThemeProvider",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx:useTheme",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx:loadFromLocalStorage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx:ThemeProvider",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx:useTheme",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/presets.ts:getPreset",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/presets.ts:getAccent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/presets.ts:getPreset",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/presets.ts:getAccent",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts:applyTheme",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts:deriveFromAccent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts:applyTheme",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts:applyTheme",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/presets.ts:getPreset",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts:applyTheme",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/presets.ts:getAccent",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx:ThemeProvider",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts:applyTheme",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx:ThemeProvider",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/themes/presets.ts:getPreset",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/containers.test.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/louvain.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "target": "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/containers.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/containers.ts:deriveContainers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/containers.ts:deriveContainers",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/containers.ts:groupByFolder",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/containers.ts:shouldFallbackToCommunity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/containers.ts:commonPrefix",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/louvain.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/louvain.ts:detectCommunities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/utils/louvain.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/louvain.ts:detectCommunities",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/packages/dashboard/src/utils/containers.ts:deriveContainers",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/utils/louvain.ts:detectCommunities",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/src/__tests__/context-builder.test.ts",
+      "target": "file:understand-anything-plugin/src/context-builder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/src/understand-chat.ts",
+      "target": "file:understand-anything-plugin/src/context-builder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/src/context-builder.ts",
+      "target": "function:understand-anything-plugin/src/context-builder.ts:buildChatContext",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/src/context-builder.ts",
+      "target": "function:understand-anything-plugin/src/context-builder.ts:formatContextForPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/src/context-builder.ts",
+      "target": "function:understand-anything-plugin/src/context-builder.ts:buildChatContext",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/src/context-builder.ts",
+      "target": "function:understand-anything-plugin/src/context-builder.ts:formatContextForPrompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/src/understand-chat.ts",
+      "target": "function:understand-anything-plugin/src/understand-chat.ts:buildChatPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/src/understand-chat.ts",
+      "target": "function:understand-anything-plugin/src/understand-chat.ts:buildChatPrompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/src/understand-chat.ts:buildChatPrompt",
+      "target": "function:understand-anything-plugin/src/context-builder.ts:buildChatContext",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:understand-anything-plugin/src/understand-chat.ts:buildChatPrompt",
+      "target": "function:understand-anything-plugin/src/context-builder.ts:formatContextForPrompt",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/src/context-builder.ts",
+      "target": "file:understand-anything-plugin/src/__tests__/context-builder.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "pipeline:.github/workflows/ci.yml",
+      "target": "step:.github/workflows/ci.yml:ci",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "pipeline:.github/workflows/deploy-homepage.yml",
+      "target": "step:.github/workflows/deploy-homepage.yml:build",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "pipeline:.github/workflows/deploy-homepage.yml",
+      "target": "step:.github/workflows/deploy-homepage.yml:deploy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "step:.github/workflows/deploy-homepage.yml:deploy",
+      "target": "step:.github/workflows/deploy-homepage.yml:build",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Show-Usage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Resolve-Platform",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Prompt-Platform",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Clone-Or-Update",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Remove-Reparse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:New-Junction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Link-Skills",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Unlink-Skills",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Link-Plugin-Root",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Cmd-Install",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Cmd-Uninstall",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.ps1",
+      "target": "function:install.ps1:Cmd-Update",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:platforms_table",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:resolve_platform",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:prompt_platform",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:list_skills",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:link_skills",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:unlink_skills",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:cmd_install",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:cmd_uninstall",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:usage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:install.sh",
+      "target": "function:install.sh:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "config:package.json",
+      "target": "config:tsconfig.json",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:pnpm-workspace.yaml",
+      "target": "config:package.json",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CONTRIBUTING.md",
+      "target": "document:README.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CONTRIBUTING.md",
+      "target": "document:CODE_OF_CONDUCT.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "document:CONTRIBUTING.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "file:install.sh",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "file:install.ps1",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:READMEs/README.es-ES.md",
+      "target": "document:README.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:READMEs/README.ja-JP.md",
+      "target": "document:README.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:READMEs/README.ko-KR.md",
+      "target": "document:README.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:READMEs/README.ru-RU.md",
+      "target": "document:README.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:READMEs/README.tr-TR.md",
+      "target": "document:README.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:READMEs/README.zh-CN.md",
+      "target": "document:README.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:READMEs/README.zh-TW.md",
+      "target": "document:README.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/plans/2026-03-14-phase2-implementation.md",
+      "target": "document:docs/superpowers/plans/2026-03-14-phase1-implementation.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/plans/2026-03-14-phase3-implementation.md",
+      "target": "document:docs/superpowers/plans/2026-03-14-phase2-implementation.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/plans/2026-03-14-phase4-implementation.md",
+      "target": "document:docs/superpowers/plans/2026-03-14-phase3-implementation.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/plans/2026-03-25-dashboard-robustness-impl.md",
+      "target": "document:docs/superpowers/plans/2026-03-25-dashboard-robustness-plan.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/plans/2026-03-29-homepage-update-impl.md",
+      "target": "document:docs/superpowers/plans/2026-03-15-homepage-implementation.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/plans/2026-04-15-language-extractors-impl.md",
+      "target": "document:docs/superpowers/plans/2026-03-21-language-agnostic-plan.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/plans/2026-04-09-understand-knowledge.md",
+      "target": "document:docs/superpowers/plans/2026-04-01-business-domain-knowledge-impl.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/plans/2026-05-24-semantic-batching-and-output-chunking-impl.md",
+      "target": "document:docs/superpowers/plans/2026-03-27-token-reduction-impl.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/plans/2026-05-03-graph-layout-scaling.md",
+      "target": "document:docs/superpowers/plans/2026-03-25-dashboard-robustness-impl.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/specs/2026-03-29-homepage-update-design.md",
+      "target": "document:docs/superpowers/specs/2026-03-15-homepage-design.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/specs/2026-06-03-language-auto-detection-design.md",
+      "target": "document:docs/superpowers/specs/2026-03-21-language-agnostic-design.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/specs/2026-04-09-understand-knowledge-design.md",
+      "target": "document:docs/superpowers/specs/2026-04-01-business-domain-knowledge-design.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/specs/2026-05-24-semantic-batching-and-output-chunking-design.md",
+      "target": "document:docs/superpowers/specs/2026-03-27-token-reduction-design.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/specs/2026-03-18-multi-platform-simple-design.md",
+      "target": "document:docs/superpowers/specs/2026-03-14-understand-anything-design.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/specs/2026-03-28-understand-anything-extension-design.md",
+      "target": "document:docs/superpowers/specs/2026-03-14-understand-anything-design.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/superpowers/specs/2026-03-21-language-agnostic-design.md",
+      "target": "document:docs/superpowers/specs/2026-03-14-understand-anything-design.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:homepage/README.md",
+      "target": "config:homepage/package.json",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:homepage/tsconfig.json",
+      "target": "config:homepage/package.json",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:understand-anything-plugin/agents/project-scanner.md",
+      "target": "document:understand-anything-plugin/agents/file-analyzer.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:understand-anything-plugin/agents/file-analyzer.md",
+      "target": "document:understand-anything-plugin/agents/architecture-analyzer.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:understand-anything-plugin/agents/file-analyzer.md",
+      "target": "document:understand-anything-plugin/agents/assemble-reviewer.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:understand-anything-plugin/agents/assemble-reviewer.md",
+      "target": "document:understand-anything-plugin/agents/graph-reviewer.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:understand-anything-plugin/agents/architecture-analyzer.md",
+      "target": "document:understand-anything-plugin/agents/tour-builder.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:understand-anything-plugin/agents/article-analyzer.md",
+      "target": "document:understand-anything-plugin/agents/file-analyzer.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:understand-anything-plugin/agents/domain-analyzer.md",
+      "target": "document:understand-anything-plugin/agents/project-scanner.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:understand-anything-plugin/agents/knowledge-graph-guide.md",
+      "target": "document:understand-anything-plugin/agents/graph-reviewer.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:understand-anything-plugin/packages/dashboard/tsconfig.json",
+      "target": "config:understand-anything-plugin/packages/dashboard/tsconfig.app.json",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:understand-anything-plugin/packages/dashboard/tsconfig.app.json",
+      "target": "file:understand-anything-plugin/packages/dashboard/index.html",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:.claude-plugin/marketplace.json",
+      "target": "config:.claude-plugin/plugin.json",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:homepage/src/pages/index.astro",
+      "target": "file:homepage/src/layouts/Layout.astro",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:homepage/src/pages/index.astro",
+      "target": "file:homepage/src/components/Nav.astro",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:homepage/src/pages/index.astro",
+      "target": "file:homepage/src/components/Hero.astro",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:homepage/src/pages/index.astro",
+      "target": "file:homepage/src/components/Problem.astro",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:homepage/src/pages/index.astro",
+      "target": "file:homepage/src/components/Showcase.astro",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:homepage/src/pages/index.astro",
+      "target": "file:homepage/src/components/CommunityVideo.astro",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:homepage/src/pages/index.astro",
+      "target": "file:homepage/src/components/Features.astro",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:homepage/src/pages/index.astro",
+      "target": "file:homepage/src/components/Install.astro",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:homepage/src/pages/index.astro",
+      "target": "file:homepage/src/components/Footer.astro",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:homepage/src/layouts/Layout.astro",
+      "target": "file:homepage/src/styles/global.css",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:homepage/astro.config.mjs",
+      "target": "file:homepage/src/pages/index.astro",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:scripts/generate-large-graph.mjs",
+      "target": "function:scripts/generate-large-graph.mjs:generateNodes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/generate-large-graph.mjs",
+      "target": "function:scripts/generate-large-graph.mjs:generateEdges",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/generate-large-graph.mjs",
+      "target": "function:scripts/generate-large-graph.mjs:generateLayers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/generate-large-graph.mjs",
+      "target": "function:scripts/generate-large-graph.mjs:generateTour",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/generate-large-graph.mjs",
+      "target": "function:scripts/generate-large-graph.mjs:injectTier1",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/generate-large-graph.mjs",
+      "target": "function:scripts/generate-large-graph.mjs:injectTier2Node",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/generate-large-graph.mjs",
+      "target": "function:scripts/generate-large-graph.mjs:injectTier2Edge",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/generate-large-graph.mjs",
+      "target": "function:scripts/generate-large-graph.mjs:applyMessy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:scripts/generate-large-graph.mjs:applyMessy",
+      "target": "function:scripts/generate-large-graph.mjs:injectTier1",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:scripts/generate-large-graph.mjs:applyMessy",
+      "target": "function:scripts/generate-large-graph.mjs:injectTier2Node",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:scripts/generate-large-graph.mjs:applyMessy",
+      "target": "function:scripts/generate-large-graph.mjs:injectTier2Edge",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:tests/skill/understand/test_compute_batches.test.mjs",
+      "target": "function:tests/skill/understand/test_compute_batches.test.mjs:runScript",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_compute_batches.test.mjs",
+      "target": "function:tests/skill/understand/test_compute_batches.test.mjs:setupProject",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_extract_import_map.test.mjs",
+      "target": "function:tests/skill/understand/test_extract_import_map.test.mjs:setupTree",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_extract_import_map.test.mjs",
+      "target": "function:tests/skill/understand/test_extract_import_map.test.mjs:runScript",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_merge_batch_graphs.py",
+      "target": "class:tests/skill/understand/test_merge_batch_graphs.py:IsTestPathTests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_merge_batch_graphs.py",
+      "target": "class:tests/skill/understand/test_merge_batch_graphs.py:ProductionCandidatesTests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_merge_batch_graphs.py",
+      "target": "class:tests/skill/understand/test_merge_batch_graphs.py:LinkTestsTests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_merge_batch_graphs.py",
+      "target": "class:tests/skill/understand/test_merge_batch_graphs.py:MergeIntegrationTests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_merge_batch_graphs.py",
+      "target": "class:tests/skill/understand/test_merge_batch_graphs.py:NormalizeDirectionTests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_merge_batch_graphs.py",
+      "target": "class:tests/skill/understand/test_merge_batch_graphs.py:MergeEdgeDirectionTests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_merge_batch_graphs.py",
+      "target": "class:tests/skill/understand/test_merge_batch_graphs.py:TestMultiPart",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_merge_batch_graphs.py",
+      "target": "class:tests/skill/understand/test_merge_batch_graphs.py:TestUnrecognizedBatchFilename",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_scan_project.test.mjs",
+      "target": "function:tests/skill/understand/test_scan_project.test.mjs:setupTree",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:tests/skill/understand/test_scan_project.test.mjs",
+      "target": "function:tests/skill/understand/test_scan_project.test.mjs:runScript",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.test.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:buildFileAnalysisPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:buildProjectSummaryPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:extractJson",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:parseFileAnalysisResponse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:parseProjectSummaryResponse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:buildFileAnalysisPrompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:buildProjectSummaryPrompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:parseFileAnalysisResponse",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+      "target": "function:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts:parseProjectSummaryResponse",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "target": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs:makeGraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "target": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs:aggregateBefore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "target": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs:aggregateAfter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+      "target": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs:bench",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs",
+      "target": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs:makeGraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs",
+      "target": "function:understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs:fillDims",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/vite.config.ts:readSourceFile",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/vite.config.ts:normalizeGraphPath",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/vite.config.ts:graphFilePathSet",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/vite.config.ts",
+      "target": "function:understand-anything-plugin/packages/dashboard/vite.config.ts:detectLanguage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "config:understand-anything-plugin/packages/core/tsconfig.json",
+      "target": "file:understand-anything-plugin/packages/core/src/index.ts",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:understand-anything-plugin/packages/core/package.json",
+      "target": "file:understand-anything-plugin/packages/core/src/index.ts",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:understand-anything-plugin/hooks/hooks.json",
+      "target": "document:understand-anything-plugin/hooks/auto-update-prompt.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:understand-anything-plugin/packages/tree-sitter-dart-wasm/package.json",
+      "target": "file:understand-anything-plugin/packages/tree-sitter-dart-wasm/tree-sitter-dart.wasm",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:understand-anything-plugin/packages/tree-sitter-dart-wasm/BUILD.md",
+      "target": "file:understand-anything-plugin/packages/tree-sitter-dart-wasm/tree-sitter-dart.wasm",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "service:understand-anything-plugin/packages/core/src/languages/configs/docker-compose.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/index.ts",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "target": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:scan_file_tree",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "target": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:detect_entry_points",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "target": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:extract_file_signatures",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "target": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:extract_metadata",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "target": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:_truncate_to_fit",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+      "target": "function:understand-anything-plugin/skills/understand-domain/extract-domain-context.py:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py",
+      "target": "function:understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py:merge",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py",
+      "target": "function:understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "target": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:detect_format",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "target": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:extract_first_paragraph",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "target": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:parse_index",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "target": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:parse_log",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "target": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:build_name_to_stem_map",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "target": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:resolve_wikilink",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "target": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:parse_wiki",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+      "target": "function:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/build-fingerprints.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/build-fingerprints.mjs:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/compute-batches.mjs:extractExports",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/compute-batches.mjs:buildNonCodeBatches",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/compute-batches.mjs:runLouvain",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/compute-batches.mjs:mergeSmallBatches",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/compute-batches.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/compute-batches.mjs:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveTsJsImport",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolvePythonImport",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveGoImport",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveRustImport",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolvePhpImport",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveImport",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveTsJsImport",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolvePythonImport",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveGoImport",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolveRustImport",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-import-map.mjs:resolvePhpImport",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-structure.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-structure.mjs:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-structure.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-structure.mjs:buildResult",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-structure.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/extract-structure.mjs:buildResult",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "target": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:normalize_node_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "target": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:production_candidates",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "target": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:link_tests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "target": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:merge_and_normalize",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "target": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:recover_imports_from_scan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+      "target": "function:understand-anything-plugin/skills/understand/merge-batch-graphs.py:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/merge-subdomain-graphs.py",
+      "target": "function:understand-anything-plugin/skills/understand/merge-subdomain-graphs.py:merge_graphs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/merge-subdomain-graphs.py",
+      "target": "function:understand-anything-plugin/skills/understand/merge-subdomain-graphs.py:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/scan-project.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/scan-project.mjs:detectCategory",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/scan-project.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/scan-project.mjs:enumerateViaWalk",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/scan-project.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/scan-project.mjs:countLines",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/scan-project.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/scan-project.mjs:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/scan-project.mjs",
+      "target": "function:understand-anything-plugin/skills/understand/scan-project.mjs:detectCategory",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/src/diff-analyzer.ts",
+      "target": "function:understand-anything-plugin/src/diff-analyzer.ts:buildDiffContext",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/src/diff-analyzer.ts",
+      "target": "function:understand-anything-plugin/src/diff-analyzer.ts:formatDiffAnalysis",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/src/diff-analyzer.ts",
+      "target": "function:understand-anything-plugin/src/diff-analyzer.ts:buildDiffContext",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/src/diff-analyzer.ts",
+      "target": "function:understand-anything-plugin/src/diff-analyzer.ts:formatDiffAnalysis",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/src/__tests__/diff-analyzer.test.ts",
+      "target": "file:understand-anything-plugin/src/diff-analyzer.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/src/__tests__/explain-builder.test.ts",
+      "target": "file:understand-anything-plugin/src/explain-builder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/src/__tests__/extract-structure.test.mjs",
+      "target": "file:understand-anything-plugin/skills/understand/extract-structure.mjs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/src/__tests__/onboard-builder.test.ts",
+      "target": "file:understand-anything-plugin/src/onboard-builder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/src/diff-analyzer.ts",
+      "target": "file:understand-anything-plugin/src/__tests__/diff-analyzer.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/skills/understand/extract-structure.mjs",
+      "target": "file:understand-anything-plugin/src/__tests__/extract-structure.test.mjs",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/src/explain-builder.ts",
+      "target": "function:understand-anything-plugin/src/explain-builder.ts:buildExplainContext",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/src/explain-builder.ts",
+      "target": "function:understand-anything-plugin/src/explain-builder.ts:buildExplainContext",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/src/explain-builder.ts",
+      "target": "function:understand-anything-plugin/src/explain-builder.ts:formatExplainPrompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/src/explain-builder.ts",
+      "target": "function:understand-anything-plugin/src/explain-builder.ts:formatExplainPrompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/src/onboard-builder.ts",
+      "target": "function:understand-anything-plugin/src/onboard-builder.ts:buildOnboardingGuide",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/src/onboard-builder.ts",
+      "target": "function:understand-anything-plugin/src/onboard-builder.ts:buildOnboardingGuide",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:understand-anything-plugin/src/index.ts",
+      "target": "file:understand-anything-plugin/src/explain-builder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/src/index.ts",
+      "target": "file:understand-anything-plugin/src/onboard-builder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:understand-anything-plugin/src/explain-builder.ts",
+      "target": "file:understand-anything-plugin/src/__tests__/explain-builder.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/src/onboard-builder.ts",
+      "target": "file:understand-anything-plugin/src/__tests__/onboard-builder.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx:Breadcrumb",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx:Breadcrumb",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx:PersonaSelector",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+      "target": "function:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx:PersonaSelector",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+      "target": "file:understand-anything-plugin/packages/core/src/languages/configs/docker-compose.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:scripts/check-graph.mjs",
+      "target": "function:scripts/check-graph.mjs:loadCore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/check-graph.mjs",
+      "target": "function:scripts/check-graph.mjs:validateOne",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/check-graph.mjs",
+      "target": "function:scripts/check-graph.mjs:trackedSourceFiles",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/check-graph.mjs",
+      "target": "function:scripts/check-graph.mjs:checkStaleness",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/check-graph.mjs",
+      "target": "function:scripts/check-graph.mjs:checkDomainSync",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:scripts/check-graph.mjs",
+      "target": "function:scripts/check-graph.mjs:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:scripts/check-graph.mjs:main",
+      "target": "function:scripts/check-graph.mjs:loadCore",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:scripts/check-graph.mjs:main",
+      "target": "function:scripts/check-graph.mjs:validateOne",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:scripts/check-graph.mjs:main",
+      "target": "function:scripts/check-graph.mjs:checkStaleness",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:scripts/check-graph.mjs:main",
+      "target": "function:scripts/check-graph.mjs:checkDomainSync",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:scripts/check-graph.mjs:checkStaleness",
+      "target": "function:scripts/check-graph.mjs:trackedSourceFiles",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    }
+  ],
+  "layers": [
+    {
+      "id": "layer:skill-runtime",
+      "name": "Skill Runtime",
+      "description": "TypeScript logic backing the slash-command skills (src/ and root tests/): understand-chat, understand-diff, understand-explain, understand-onboard, and the context builder.",
+      "nodeIds": [
+        "file:understand-anything-plugin/src/__tests__/context-builder.test.ts",
+        "file:understand-anything-plugin/src/context-builder.ts",
+        "file:understand-anything-plugin/src/understand-chat.ts",
+        "file:tests/skill/understand/test_compute_batches.test.mjs",
+        "file:tests/skill/understand/test_extract_import_map.test.mjs",
+        "file:tests/skill/understand/test_merge_batch_graphs.py",
+        "file:tests/skill/understand/test_scan_project.test.mjs",
+        "file:understand-anything-plugin/src/__tests__/diff-analyzer.test.ts",
+        "file:understand-anything-plugin/src/__tests__/explain-builder.test.ts",
+        "file:understand-anything-plugin/src/__tests__/extract-structure.test.mjs",
+        "file:understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs",
+        "file:understand-anything-plugin/src/__tests__/onboard-builder.test.ts",
+        "file:understand-anything-plugin/src/__tests__/worktree-redirect.test.mjs",
+        "file:understand-anything-plugin/src/diff-analyzer.ts",
+        "file:understand-anything-plugin/src/explain-builder.ts",
+        "file:understand-anything-plugin/src/index.ts",
+        "file:understand-anything-plugin/src/onboard-builder.ts"
+      ]
+    },
+    {
+      "id": "layer:core-engine",
+      "name": "Core Analysis Engine",
+      "description": "Shared static-analysis engine in packages/core: tree-sitter extractors, language and framework registries, graph builder, layer detector, LLM analyzer, schema, search, and persistence.",
+      "nodeIds": [
+        "file:understand-anything-plugin/packages/core/src/__tests__/framework-registry.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/plugin-discovery.test.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/batch.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/c.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/cpp.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/csharp.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/css.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/csv.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/dart.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/dockerfile.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/env.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/github-actions.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/go.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/graphql.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/html.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/index.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/java.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/javascript.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/jenkinsfile.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/json-config.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/json-schema.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/kotlin.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/kubernetes.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/lua.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/makefile.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/markdown.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/openapi.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/php.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/plaintext.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/powershell.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/protobuf.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/python.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/restructuredtext.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/ruby.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/rust.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/shell.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/sql.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/swift.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/terraform.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/toml.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/typescript.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/xml.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/yaml.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/framework-registry.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/django.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/express.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/fastapi.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/flask.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/gin.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/index.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/nextjs.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/rails.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/react.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/spring.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/frameworks/vue.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/language-registry.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/types.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/discovery.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cpp-extractor.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/dart-extractor.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/go-extractor.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/java-extractor.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/kotlin-extractor.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/php-extractor.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/python-extractor.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/ruby-extractor.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/rust-extractor.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/dart-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/go-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/index.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/java-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/kotlin-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/php-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/python-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/ruby-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/rust-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/domain-normalize.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/domain-persistence.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/domain-types.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/embedding-search.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/fingerprint.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/language-lesson.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/layer-detector.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/parsers.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/plugin-registry.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/schema.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/search.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/staleness.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/tour-generator.test.ts",
+        "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.test.ts",
+        "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+        "file:understand-anything-plugin/packages/core/src/analyzer/language-lesson.ts",
+        "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+        "file:understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts",
+        "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+        "file:understand-anything-plugin/packages/core/src/change-classifier.ts",
+        "file:understand-anything-plugin/packages/core/src/embedding-search.ts",
+        "file:understand-anything-plugin/packages/core/src/fingerprint.ts",
+        "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+        "file:understand-anything-plugin/packages/core/src/persistence/persistence.test.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/dockerfile-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/env-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/graphql-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/index.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/json-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/makefile-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/markdown-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/protobuf-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/shell-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/sql-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/terraform-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/toml-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/parsers/yaml-parser.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+        "file:understand-anything-plugin/packages/core/src/schema.ts",
+        "file:understand-anything-plugin/packages/core/src/search.ts",
+        "file:understand-anything-plugin/packages/core/src/staleness.ts",
+        "file:understand-anything-plugin/packages/core/src/types.test.ts",
+        "file:understand-anything-plugin/packages/core/src/types.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts",
+        "file:understand-anything-plugin/packages/core/src/__tests__/ignore-generator.test.ts",
+        "file:understand-anything-plugin/packages/core/src/ignore-filter.ts",
+        "file:understand-anything-plugin/packages/core/src/ignore-generator.ts",
+        "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.test.ts",
+        "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts",
+        "file:understand-anything-plugin/packages/core/src/index.ts",
+        "service:understand-anything-plugin/packages/core/src/languages/configs/docker-compose.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/index.ts",
+        "file:understand-anything-plugin/packages/core/vitest.config.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/configs/docker-compose.ts"
+      ]
+    },
+    {
+      "id": "layer:dashboard",
+      "name": "Dashboard UI",
+      "description": "React + TypeScript web dashboard (packages/dashboard): React Flow graph views, components, Zustand store, hooks, themes, locales, and code viewer.",
+      "nodeIds": [
+        "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/KeyboardShortcutsHelp.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/KnowledgeGraphView.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/LayerClusterNode.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/LayerLegend.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/LearnPanel.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/MobileBottomNav.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/MobileDrawer.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/MobileLayout.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/NodeInfo.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/NodeTooltip.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/OnboardingOverlay.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/Breadcrumb.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/ContainerNode.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/CustomNode.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/DiffToggle.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/DomainClusterNode.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/DomainGraphView.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/ExportMenu.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/FileExplorer.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/FilterPanel.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/FlowNode.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/PathFinderModal.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/PersonaSelector.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/PortalNode.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/ProjectOverview.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/SearchBar.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/StepNode.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/ThemePicker.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/TokenGate.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/components/WarningBanner.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/contexts/I18nContext.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/hooks/useIsMobile.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/hooks/useKeyboardShortcuts.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/main.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/store.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/themes/index.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/edgeAggregation.test.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/elk-layout.test.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/filters.test.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/layerStats.test.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/edgeAggregation.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/filters.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/layerStats.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/layout.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/locales/en.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/locales/index.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/locales/ja.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/locales/ko.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/locales/ru.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/locales/zh-TW.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/locales/zh.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/themes/ThemeContext.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/themes/presets.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/themes/theme-engine.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/themes/types.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/containers.test.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/containers.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/louvain.ts",
+        "file:understand-anything-plugin/packages/dashboard/index.html",
+        "file:understand-anything-plugin/packages/dashboard/scripts/benchmark-aggregations.mjs",
+        "file:understand-anything-plugin/packages/dashboard/scripts/benchmark-layout.mjs",
+        "file:understand-anything-plugin/packages/dashboard/src/index.css",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/__tests__/smoke.test.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/layout.worker.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/vite-env.d.ts",
+        "file:understand-anything-plugin/packages/dashboard/vite.config.demo.ts",
+        "file:understand-anything-plugin/packages/dashboard/vite.config.ts"
+      ]
+    },
+    {
+      "id": "layer:skill-definitions",
+      "name": "Skill & Agent Definitions",
+      "description": "Markdown prompt definitions that drive the plugin: skill specs, agent definitions (project-scanner, file-analyzer, architecture-analyzer, etc.), and auto-update hooks.",
+      "nodeIds": [
+        "document:understand-anything-plugin/agents/architecture-analyzer.md",
+        "document:understand-anything-plugin/agents/article-analyzer.md",
+        "document:understand-anything-plugin/agents/assemble-reviewer.md",
+        "document:understand-anything-plugin/agents/domain-analyzer.md",
+        "document:understand-anything-plugin/agents/file-analyzer.md",
+        "document:understand-anything-plugin/agents/graph-reviewer.md",
+        "document:understand-anything-plugin/agents/knowledge-graph-guide.md",
+        "document:understand-anything-plugin/agents/project-scanner.md",
+        "document:understand-anything-plugin/agents/tour-builder.md",
+        "document:understand-anything-plugin/skills/understand/frameworks/django.md",
+        "document:understand-anything-plugin/skills/understand/frameworks/express.md",
+        "document:understand-anything-plugin/skills/understand/frameworks/fastapi.md",
+        "document:understand-anything-plugin/skills/understand/frameworks/flask.md",
+        "document:understand-anything-plugin/skills/understand/frameworks/gin.md",
+        "document:understand-anything-plugin/skills/understand/frameworks/nextjs.md",
+        "document:understand-anything-plugin/skills/understand/frameworks/rails.md",
+        "document:understand-anything-plugin/skills/understand/frameworks/react.md",
+        "document:understand-anything-plugin/skills/understand/frameworks/spring.md",
+        "document:understand-anything-plugin/skills/understand/frameworks/vue.md",
+        "document:understand-anything-plugin/skills/understand/languages/cpp.md",
+        "document:understand-anything-plugin/skills/understand/languages/csharp.md",
+        "document:understand-anything-plugin/skills/understand/languages/css.md",
+        "document:understand-anything-plugin/skills/understand/languages/dockerfile.md",
+        "document:understand-anything-plugin/skills/understand/languages/go.md",
+        "document:understand-anything-plugin/skills/understand/languages/graphql.md",
+        "document:understand-anything-plugin/skills/understand/languages/html.md",
+        "document:understand-anything-plugin/skills/understand/languages/java.md",
+        "document:understand-anything-plugin/skills/understand/languages/javascript.md",
+        "document:understand-anything-plugin/skills/understand/languages/json.md",
+        "document:understand-anything-plugin/skills/understand/languages/kotlin.md",
+        "document:understand-anything-plugin/skills/understand/languages/markdown.md",
+        "document:understand-anything-plugin/skills/understand/languages/php.md",
+        "document:understand-anything-plugin/skills/understand/languages/protobuf.md",
+        "document:understand-anything-plugin/skills/understand/languages/python.md",
+        "document:understand-anything-plugin/skills/understand/languages/ruby.md",
+        "document:understand-anything-plugin/skills/understand/languages/rust.md",
+        "document:understand-anything-plugin/skills/understand/languages/shell.md",
+        "document:understand-anything-plugin/skills/understand/languages/sql.md",
+        "document:understand-anything-plugin/skills/understand/languages/swift.md",
+        "document:understand-anything-plugin/skills/understand/languages/terraform.md",
+        "document:understand-anything-plugin/skills/understand/languages/typescript.md",
+        "document:understand-anything-plugin/skills/understand/languages/yaml.md",
+        "document:understand-anything-plugin/skills/understand/locales/en.md",
+        "document:understand-anything-plugin/skills/understand/locales/ja.md",
+        "document:understand-anything-plugin/skills/understand/locales/ko.md",
+        "document:understand-anything-plugin/skills/understand/locales/ru.md",
+        "document:understand-anything-plugin/skills/understand/locales/zh-TW.md",
+        "document:understand-anything-plugin/skills/understand/locales/zh.md",
+        "document:understand-anything-plugin/hooks/auto-update-prompt.md",
+        "config:understand-anything-plugin/hooks/hooks.json",
+        "document:understand-anything-plugin/skills/understand-chat/SKILL.md",
+        "document:understand-anything-plugin/skills/understand-dashboard/SKILL.md",
+        "document:understand-anything-plugin/skills/understand-diff/SKILL.md",
+        "file:understand-anything-plugin/skills/understand-domain/extract-domain-context.py",
+        "document:understand-anything-plugin/skills/understand-domain/SKILL.md",
+        "document:understand-anything-plugin/skills/understand-explain/SKILL.md",
+        "file:understand-anything-plugin/skills/understand-knowledge/merge-knowledge-graph.py",
+        "file:understand-anything-plugin/skills/understand-knowledge/parse-knowledge-base.py",
+        "document:understand-anything-plugin/skills/understand-knowledge/SKILL.md",
+        "document:understand-anything-plugin/skills/understand-onboard/SKILL.md",
+        "file:understand-anything-plugin/skills/understand/build-fingerprints.mjs",
+        "file:understand-anything-plugin/skills/understand/compute-batches.mjs",
+        "file:understand-anything-plugin/skills/understand/extract-import-map.mjs",
+        "document:understand-anything-plugin/skills/understand/SKILL.md",
+        "file:understand-anything-plugin/skills/understand/extract-structure.mjs",
+        "file:understand-anything-plugin/skills/understand/generate-ignore.mjs",
+        "file:understand-anything-plugin/skills/understand/merge-batch-graphs.py",
+        "file:understand-anything-plugin/skills/understand/merge-subdomain-graphs.py",
+        "file:understand-anything-plugin/skills/understand/scan-project.mjs"
+      ]
+    },
+    {
+      "id": "layer:documentation",
+      "name": "Documentation",
+      "description": "Human-facing project documentation: design specs and plans under docs/, translated READMEs, and root guides (README, CONTRIBUTING, SECURITY, CLAUDE).",
+      "nodeIds": [
+        "document:CLAUDE.md",
+        "document:CODE_OF_CONDUCT.md",
+        "document:CONTRIBUTING.md",
+        "document:README.md",
+        "document:SECURITY.md",
+        "document:READMEs/README.es-ES.md",
+        "document:READMEs/README.ja-JP.md",
+        "document:READMEs/README.ko-KR.md",
+        "document:READMEs/README.ru-RU.md",
+        "document:READMEs/README.tr-TR.md",
+        "document:READMEs/README.zh-CN.md",
+        "document:READMEs/README.zh-TW.md",
+        "document:docs/superpowers/plans/2026-03-14-phase1-implementation.md",
+        "document:docs/superpowers/plans/2026-03-14-phase2-implementation.md",
+        "document:docs/superpowers/plans/2026-03-14-phase3-implementation.md",
+        "document:docs/superpowers/plans/2026-03-14-phase4-implementation.md",
+        "document:docs/superpowers/plans/2026-03-15-homepage-implementation.md",
+        "document:docs/superpowers/plans/2026-03-18-multi-platform-simple-implementation.md",
+        "document:docs/superpowers/plans/2026-03-21-language-agnostic-plan.md",
+        "document:docs/superpowers/plans/2026-03-25-dashboard-robustness-impl.md",
+        "document:docs/superpowers/plans/2026-03-25-dashboard-robustness-plan.md",
+        "document:docs/superpowers/plans/2026-03-26-theme-system-implementation.md",
+        "document:docs/superpowers/plans/2026-03-27-token-reduction-impl.md",
+        "document:docs/superpowers/plans/2026-03-28-understand-anything-extension-impl.md",
+        "document:docs/superpowers/plans/2026-03-29-homepage-update-impl.md",
+        "document:docs/superpowers/plans/2026-04-01-business-domain-knowledge-impl.md",
+        "document:docs/superpowers/plans/2026-04-09-understand-knowledge.md",
+        "document:docs/superpowers/plans/2026-04-10-understandignore-impl.md",
+        "document:docs/superpowers/plans/2026-04-15-language-extractors-impl.md",
+        "document:docs/superpowers/plans/2026-05-03-graph-layout-scaling.md",
+        "document:docs/superpowers/plans/2026-05-24-semantic-batching-and-output-chunking-impl.md",
+        "document:docs/superpowers/plans/2026-06-03-language-auto-detection.md",
+        "document:docs/superpowers/specs/2026-03-14-understand-anything-design.md",
+        "document:docs/superpowers/specs/2026-03-15-homepage-design.md",
+        "document:docs/superpowers/specs/2026-03-18-multi-platform-simple-design.md",
+        "document:docs/superpowers/specs/2026-03-21-language-agnostic-design.md",
+        "document:docs/superpowers/specs/2026-03-26-theme-system-design.md",
+        "document:docs/superpowers/specs/2026-03-27-token-reduction-design.md",
+        "document:docs/superpowers/specs/2026-03-28-understand-anything-extension-design.md",
+        "document:docs/superpowers/specs/2026-03-29-homepage-update-design.md",
+        "document:docs/superpowers/specs/2026-04-01-business-domain-knowledge-design.md",
+        "document:docs/superpowers/specs/2026-04-09-understand-knowledge-design.md",
+        "document:docs/superpowers/specs/2026-04-10-understandignore-design.md",
+        "document:docs/superpowers/specs/2026-05-03-graph-layout-scaling-design.md",
+        "document:docs/superpowers/specs/2026-05-24-semantic-batching-and-output-chunking-design.md",
+        "document:docs/superpowers/specs/2026-06-03-language-auto-detection-design.md",
+        "document:understand-anything-plugin/packages/tree-sitter-dart-wasm/BUILD.md"
+      ]
+    },
+    {
+      "id": "layer:homepage",
+      "name": "Marketing Homepage",
+      "description": "Astro marketing site under homepage/, including pages, components, and its build configuration.",
+      "nodeIds": [
+        "document:homepage/README.md",
+        "config:homepage/package.json",
+        "config:homepage/tsconfig.json",
+        "config:homepage/astro.config.mjs",
+        "file:homepage/public/.gitkeep",
+        "file:homepage/public/CNAME",
+        "file:homepage/src/components/CommunityVideo.astro",
+        "file:homepage/src/components/Features.astro",
+        "file:homepage/src/components/Footer.astro",
+        "file:homepage/src/components/Hero.astro",
+        "file:homepage/src/components/Install.astro",
+        "file:homepage/src/components/Nav.astro",
+        "file:homepage/src/components/Problem.astro",
+        "file:homepage/src/components/Showcase.astro",
+        "file:homepage/src/layouts/Layout.astro",
+        "file:homepage/src/pages/index.astro",
+        "file:homepage/src/styles/global.css"
+      ]
+    },
+    {
+      "id": "layer:config",
+      "name": "Configuration & Tooling",
+      "description": "Monorepo and per-package configuration: pnpm workspace, tsconfig, ESLint, Vitest/Vite configs, plugin manifests, install scripts, and build tooling.",
+      "nodeIds": [
+        "file:install.ps1",
+        "file:install.sh",
+        "config:package.json",
+        "config:pnpm-workspace.yaml",
+        "config:tsconfig.json",
+        "config:tests/skill/understand/fixtures/scan-result-3-cliques.json",
+        "config:tests/skill/understand/fixtures/scan-result-large-community.json",
+        "config:tests/skill/understand/fixtures/scan-result-merge-respects-non-mergeable.json",
+        "config:tests/skill/understand/fixtures/scan-result-non-code.json",
+        "config:tests/skill/understand/fixtures/scan-result-singletons.json",
+        "config:understand-anything-plugin/package.json",
+        "config:understand-anything-plugin/pnpm-workspace.yaml",
+        "config:understand-anything-plugin/tsconfig.json",
+        "config:understand-anything-plugin/packages/dashboard/package.json",
+        "config:understand-anything-plugin/packages/dashboard/tsconfig.app.json",
+        "config:understand-anything-plugin/packages/dashboard/tsconfig.json",
+        "config:.claude-plugin/marketplace.json",
+        "config:.claude-plugin/plugin.json",
+        "config:.copilot-plugin/plugin.json",
+        "config:.cursor-plugin/plugin.json",
+        "config:.npmrc",
+        "config:eslint.config.mjs",
+        "file:scripts/generate-large-graph.mjs",
+        "config:understand-anything-plugin/.claude-plugin/plugin.json",
+        "config:understand-anything-plugin/packages/core/package.json",
+        "config:understand-anything-plugin/packages/core/tsconfig.json",
+        "config:understand-anything-plugin/packages/dashboard/public/knowledge-graph.json",
+        "config:understand-anything-plugin/packages/tree-sitter-dart-wasm/package.json",
+        "file:understand-anything-plugin/packages/tree-sitter-dart-wasm/tree-sitter-dart.wasm",
+        "file:understand-anything-plugin/vitest.config.ts",
+        "file:vitest.config.ts",
+        "file:scripts/check-graph.mjs"
+      ]
+    },
+    {
+      "id": "layer:ci-cd",
+      "name": "CI/CD",
+      "description": "GitHub Actions workflows and issue templates that build, test, and deploy the project and homepage.",
+      "nodeIds": [
+        "pipeline:.github/workflows/ci.yml",
+        "step:.github/workflows/ci.yml:ci",
+        "pipeline:.github/workflows/deploy-homepage.yml",
+        "step:.github/workflows/deploy-homepage.yml:build",
+        "step:.github/workflows/deploy-homepage.yml:deploy",
+        "config:.github/ISSUE_TEMPLATE/bug_report.yml",
+        "config:.github/ISSUE_TEMPLATE/config.yml",
+        "config:.github/ISSUE_TEMPLATE/feature_request.yml",
+        "config:.github/ISSUE_TEMPLATE/question.yml",
+        "document:.github/PULL_REQUEST_TEMPLATE.md"
+      ]
+    }
+  ],
+  "tour": [
+    {
+      "order": 1,
+      "title": "Project Overview",
+      "description": "Start with the README to understand what Understand Anything is: an open-source tool that combines LLM intelligence with static analysis to turn any codebase or knowledge base into an interactive knowledge graph you can explore, search, and question. The README walks from the project's purpose through quick-start installation across Claude Code, Codex, Cursor, Copilot, and Gemini CLI, then into the `/understand` pipeline, the dashboard, and the graph schema. Read this first to get the mental model the rest of the tour fills in with real code.",
+      "nodeIds": [
+        "document:README.md"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "The /understand Pipeline",
+      "description": "The conceptual entry point of the whole project is the `/understand` skill definition, not a single binary. This SKILL.md documents the full multi-phase agent pipeline that scans a codebase and assembles an interactive knowledge graph. It is the orchestration contract that the README describes prose-first and that the following steps trace stage by stage through real agents and engine code.",
+      "nodeIds": [
+        "document:understand-anything-plugin/skills/understand/SKILL.md"
+      ]
+    },
+    {
+      "order": 3,
+      "title": "Pipeline Stages: Scan, Analyze, Architect, Tour",
+      "description": "Each phase of the `/understand` pipeline is a markdown agent definition acting as a prompt-driven worker. The project-scanner produces a file inventory of languages and frameworks; the file-analyzer extracts structural nodes and edges per file via tree-sitter plus LLM analysis; the architecture-analyzer groups files into logical layers; and the tour-builder designs the pedagogical walkthrough. Reading these together shows how the system decomposes 'understand this repo' into staged, reviewable steps.",
+      "nodeIds": [
+        "document:understand-anything-plugin/agents/project-scanner.md",
+        "document:understand-anything-plugin/agents/file-analyzer.md",
+        "document:understand-anything-plugin/agents/architecture-analyzer.md",
+        "document:understand-anything-plugin/agents/tour-builder.md"
+      ]
+    },
+    {
+      "order": 4,
+      "title": "Core Type System",
+      "description": "Now move from prompts into the analysis engine. These two files are the most depended-upon in the entire codebase (fan-in 49 and 57): `types.ts` defines the graph nodes, edges, and fingerprints the whole engine produces, while the languages `types.ts` declares the Zod schemas for language and framework configuration. Almost everything else in packages/core imports from here, so this is the shared vocabulary every later step builds on.",
+      "nodeIds": [
+        "file:understand-anything-plugin/packages/core/src/types.ts",
+        "file:understand-anything-plugin/packages/core/src/languages/types.ts"
+      ],
+      "languageLesson": "These modules use Zod to define runtime schemas and then derive static TypeScript types from them (z.infer). One declaration produces both compile-time types and runtime validation, eliminating drift between the two."
+    },
+    {
+      "order": 5,
+      "title": "Tree-sitter Extraction Layer",
+      "description": "Building on the type system from Step 4, the extractor layer is how static analysis actually reads source code. The `base-extractor` provides shared tree-sitter AST traversal helpers (traverse, findChild, getStringValue), and `types.ts` defines the LanguageExtractor interface that every per-language extractor implements. This is the 'static analysis' half of the README's hybrid promise — turning raw syntax trees into structured facts.",
+      "nodeIds": [
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/base-extractor.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/types.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts"
+      ],
+      "languageLesson": "The project uses web-tree-sitter (a WASM build) rather than native tree-sitter bindings, because native bindings fail on darwin/arm64 with Node 24. The same WASM parser runs everywhere the plugin is installed."
+    },
+    {
+      "order": 6,
+      "title": "Plugin Registry & Tree-sitter Orchestration",
+      "description": "The registry maps languages and file extensions to the right analysis plugin and delegates file analysis, import resolution, and call-graph extraction. The tree-sitter plugin loads grammars and dispatches each parsed file to the appropriate extractor from Step 5. Together they are the dispatch hub that lets one engine handle TypeScript, Python, GraphQL, and more without the caller knowing the language.",
+      "nodeIds": [
+        "file:understand-anything-plugin/packages/core/src/plugins/registry.ts",
+        "file:understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts"
+      ]
+    },
+    {
+      "order": 7,
+      "title": "Graph Builder & LLM Analyzer",
+      "description": "This is where extracted facts become a knowledge graph. The GraphBuilder accumulates files, functions, classes, and non-code chunks into deduplicated nodes and edges, while the llm-analyzer builds the prompts that add semantic summaries and relationships on top of the raw structure. Together they realize the README's 'LLM intelligence + static analysis' fusion that the type system from Step 4 models.",
+      "nodeIds": [
+        "file:understand-anything-plugin/packages/core/src/analyzer/graph-builder.ts",
+        "file:understand-anything-plugin/packages/core/src/analyzer/llm-analyzer.ts"
+      ]
+    },
+    {
+      "order": 8,
+      "title": "Layers, Tours & Graph Schema",
+      "description": "Once a graph exists, these modules give it structure and pedagogy. The layer-detector groups files into architectural layers (the same layers powering this tour), the tour-generator builds guided walkthroughs, and `schema.ts` defines the Zod validation pipeline that every graph must pass before the dashboard will render it. This closes the loop between the architecture-analyzer and tour-builder agents from Step 3 and their actual engine implementations.",
+      "nodeIds": [
+        "file:understand-anything-plugin/packages/core/src/analyzer/layer-detector.ts",
+        "file:understand-anything-plugin/packages/core/src/analyzer/tour-generator.ts",
+        "file:understand-anything-plugin/packages/core/src/schema.ts"
+      ]
+    },
+    {
+      "order": 9,
+      "title": "Persistence & Search",
+      "description": "The persistence layer reads and writes the knowledge graph, project metadata, and fingerprints to the project's `.understand-anything` directory, sanitizing absolute paths to project-relative form so graphs are portable and shareable. The Fuse.js-backed search engine indexes graph nodes for the fuzzy, type-filtered search the README highlights. These supporting modules turn an in-memory graph into a durable, queryable artifact.",
+      "nodeIds": [
+        "file:understand-anything-plugin/packages/core/src/persistence/index.ts",
+        "file:understand-anything-plugin/packages/core/src/search.ts"
+      ]
+    },
+    {
+      "order": 10,
+      "title": "Dashboard Entry & State",
+      "description": "Now cross into the visualization layer. `main.tsx` mounts the root App, which bootstraps the token gate, fetches and validates the saved graph from Step 9, and wires the graph-first layout. The Zustand `store.ts` (fan-in 24) is the dashboard's central state — graph data, filters, selection, and layer navigation — that nearly every component reads from. This is the runtime that renders the graph the engine produced.",
+      "nodeIds": [
+        "file:understand-anything-plugin/packages/dashboard/src/main.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/App.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/store.ts"
+      ],
+      "languageLesson": "The dashboard must only import from core's browser-safe subpath exports (./search, ./types, ./schema), never the main entry point, which pulls in Node.js modules that would break in the browser bundle."
+    },
+    {
+      "order": 11,
+      "title": "Graph Rendering & Code Viewer",
+      "description": "These tightly-coupled components (a cluster the analysis flagged with 8 internal edges) turn graph state into an interactive picture. GraphView builds overview and per-layer topologies with React Flow, the elk-layout and layout utilities compute node positions, and the CodeViewer slides up to show token-gated source with syntax highlighting when a file node is clicked. This is the explorable dashboard the README promises.",
+      "nodeIds": [
+        "file:understand-anything-plugin/packages/dashboard/src/components/GraphView.tsx",
+        "file:understand-anything-plugin/packages/dashboard/src/utils/elk-layout.ts",
+        "file:understand-anything-plugin/packages/dashboard/src/components/CodeViewer.tsx"
+      ]
+    },
+    {
+      "order": 12,
+      "title": "Plugin Packaging & CI",
+      "description": "Finish where distribution lives. The root monorepo manifest pins pnpm and defines the build/test/lint scripts, the marketplace manifest declares the installable plugin entry the README's install steps consume, and the CI workflow runs lint, build, and test across the core and skill packages on every push. Together they explain how this multi-platform plugin gets validated and shipped to Claude Code, Cursor, Copilot, and the rest.",
+      "nodeIds": [
+        "config:package.json",
+        "config:.claude-plugin/marketplace.json",
+        "pipeline:.github/workflows/ci.yml"
+      ],
+      "languageLesson": "GitHub Actions workflows use `on` triggers to fire on pull requests and pushes, and `steps` to run lint, build, and test sequentially. Pinning the package manager via the root manifest's packageManager field keeps every CI run and contributor on the same pnpm version."
+    }
+  ]
+}

--- a/.understand-anything/meta.json
+++ b/.understand-anything/meta.json
@@ -1,0 +1,6 @@
+{
+  "lastAnalyzedAt": "2026-06-24T15:31:31.138Z",
+  "gitCommitHash": "dee750facc588fc860744f8c6061a150e6852d9f",
+  "version": "1.0.0",
+  "analyzedFiles": 400
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,14 @@ An open-source tool combining LLM intelligence + static analysis to produce inte
 ## Scripts
 - `scripts/generate-large-graph.mjs` — Generates a fake knowledge graph for performance testing (e.g. large-graph layout). Writes to `.understand-anything/knowledge-graph.json`. Usage: `node scripts/generate-large-graph.mjs [nodeCount]` (default: 3000 nodes). Not part of the production pipeline.
 
+## Self-Knowledge Graph (Dogfooding)
+This repo eats its own dog food: it keeps a committed Understand Anything graph of itself under `.understand-anything/`.
+- **Committed artifacts:** `knowledge-graph.json` (structural), `domain-graph.json` (business-flow view), `meta.json`, `fingerprints.json`, `config.json`, `.understandignore`. Per the README's *Share the Graph with Your Team* guidance, only `intermediate/`, `diff-overlay.json`, `tmp/`, and `.trash-*/` are gitignored (local scratch).
+- **Freshness:** `config.json` has `"autoUpdate": true`. The plugin's bundled hooks (`understand-anything-plugin/hooks/hooks.json`) drive `hooks/auto-update-prompt.md` — a post-commit (PostToolUse on `git commit`) trigger and a SessionStart staleness check — to incrementally patch the graph (zero LLM tokens when changes are cosmetic). The graph is regenerated only for committers who have the plugin installed; otherwise re-run `/understand` before a release.
+- **The domain graph is NOT auto-refreshed.** The hook patches only `knowledge-graph.json` (+ `meta.json`, `fingerprints.json`); `domain-graph.json` is derived from the knowledge graph and has no incremental path. **Every commit that meaningfully changes structure should regenerate both: run `/understand` (or let the hook run), then `/understand-domain`, and commit the refreshed `domain-graph.json`.** Cosmetic commits need neither.
+- **CI guard:** `scripts/check-graph.mjs` (wired into `.github/workflows/ci.yml`) is deterministic and spends zero LLM tokens. It (a) schema-validates both committed graphs (**blocking**), (b) warns when the source tree has drifted structurally from `fingerprints.json` (**advisory**), and (c) warns when `domain-graph.json`'s `project.gitCommitHash` no longer matches `meta.json`'s — i.e. the domain view is behind the knowledge graph (**advisory**). Pass `--strict` to make the advisory checks blocking. Regeneration itself is an LLM task and deliberately stays off the PR path — handled by the local post-commit hook or a manual run.
+- **Regenerate manually:** `/understand --full` (then `/understand-domain` to refresh the domain view). View with `/understand-dashboard`.
+
 ## Versioning
 When pushing to remote, bump the version in **all five** of these files (keep them in sync):
 - `understand-anything-plugin/package.json` → `"version"` field

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,17 @@ Then open a Pull Request on GitHub with:
 - Link to related issues (if any)
 - Screenshots (for UI changes)
 
+### 6. Keep the Knowledge Graph Fresh
+
+This repo dogfoods Understand Anything: a committed graph of itself lives in `.understand-anything/` (`knowledge-graph.json`, `domain-graph.json`, `meta.json`, `fingerprints.json`, `config.json`). It powers onboarding and the live demo, so keep it in sync with your code changes.
+
+- **Every meaningful commit should refresh the graph.** If your commit adds/removes files, functions, classes, or imports (a *structural* change), regenerate before opening the PR; cosmetic-only commits (formatting, comments, internal logic) need nothing.
+- **Auto-update is enabled** (`.understand-anything/config.json` → `"autoUpdate": true`). If you have the plugin installed, a post-commit hook incrementally patches **`knowledge-graph.json`** after structural changes — zero tokens on cosmetic commits. No plugin? Re-run `/understand` (incremental) or `/understand --full` manually.
+- **The domain graph is not auto-refreshed — do it yourself.** The hook only touches the knowledge graph. After a structural change, also run **`/understand-domain`** and commit the refreshed `domain-graph.json`, so the business-flow view tracks the knowledge graph on every meaningful commit.
+- **CI tells you if you forgot.** `scripts/check-graph.mjs` (in CI) schema-validates both graphs and posts an advisory warning when the source tree has drifted from `fingerprints.json` or when the domain graph is behind the knowledge graph. Heed the warning and regenerate.
+- **Don't hand-edit** the JSON artifacts; regenerate them. Only `.understand-anything/intermediate/`, `tmp/`, `.trash-*/`, and `diff-overlay.json` are local scratch (gitignored) — everything else is committed.
+- See the README's *Share the Graph with Your Team* section for the rationale and git-lfs guidance for large graphs.
+
 ## 🧪 Testing Guidelines
 
 ### Writing Tests

--- a/scripts/check-graph.mjs
+++ b/scripts/check-graph.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * check-graph.mjs — deterministic CI guard for this repo's committed
+ * self-knowledge graph. Spends ZERO LLM tokens.
+ *
+ * Two checks:
+ *   1. SCHEMA (blocking)   — validateGraph() on knowledge-graph.json and
+ *                            domain-graph.json. Catches corruption / bad
+ *                            hand-edits. Exits non-zero on a fatal error.
+ *   2. STALENESS (advisory)— rebuilds structural fingerprints for the current
+ *                            source tree and compares against the committed
+ *                            fingerprints.json (same logic as the auto-update
+ *                            hook's Phase 1). If a source file was added,
+ *                            removed, or structurally changed without the graph
+ *                            being refreshed, it prints a ::warning:: telling
+ *                            the author to run /understand. Non-blocking by
+ *                            default (a stale graph is behind, not broken).
+ *
+ * Flags:
+ *   --strict   treat staleness as an error too (exit non-zero)
+ *
+ * Usage: node scripts/check-graph.mjs [--strict]
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve, extname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const UA_DIR = resolve(REPO_ROOT, ".understand-anything");
+const STRICT = process.argv.includes("--strict");
+
+// Source extensions that carry graph-relevant structure — mirrors the
+// auto-update hook's source filter (hooks/auto-update-prompt.md Phase 0).
+const SOURCE_EXTS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".py", ".go", ".rs",
+  ".java", ".rb", ".cpp", ".c", ".h", ".cs", ".swift", ".kt", ".php",
+]);
+
+const CORE_DIST = resolve(
+  REPO_ROOT,
+  "understand-anything-plugin/packages/core/dist",
+);
+
+function ghError(msg) {
+  console.error(`::error::${msg}`);
+}
+function ghWarning(msg) {
+  console.log(`::warning::${msg}`);
+}
+
+async function loadCore() {
+  const index = pathToFileURL(resolve(CORE_DIST, "index.js")).href;
+  const schema = pathToFileURL(resolve(CORE_DIST, "schema.js")).href;
+  if (!existsSync(resolve(CORE_DIST, "index.js"))) {
+    ghError(
+      "@understand-anything/core is not built. Run `pnpm --filter @understand-anything/core build` first.",
+    );
+    process.exit(1);
+  }
+  const core = await import(index);
+  const { validateGraph } = await import(schema);
+  return { ...core, validateGraph };
+}
+
+function validateOne(validateGraph, fileName) {
+  const path = resolve(UA_DIR, fileName);
+  if (!existsSync(path)) {
+    ghError(`${fileName} is missing from .understand-anything/.`);
+    return false;
+  }
+  let data;
+  try {
+    data = JSON.parse(readFileSync(path, "utf-8"));
+  } catch (err) {
+    ghError(`${fileName} is not valid JSON: ${err.message}`);
+    return false;
+  }
+  const result = validateGraph(data);
+  if (!result.success) {
+    ghError(
+      `${fileName} failed schema validation: ${result.fatal ?? "see issues below"}`,
+    );
+    for (const issue of result.issues ?? []) {
+      console.error(`    - ${issue.message ?? JSON.stringify(issue)}`);
+    }
+    return false;
+  }
+  console.log(`  ✓ ${fileName} — schema valid`);
+  return true;
+}
+
+function trackedSourceFiles(filter) {
+  const out = execFileSync("git", ["ls-files"], {
+    cwd: REPO_ROOT,
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .filter((p) => SOURCE_EXTS.has(extname(p)))
+    .filter((p) => !filter.isIgnored(p));
+}
+
+async function checkStaleness(core) {
+  const fpPath = resolve(UA_DIR, "fingerprints.json");
+  if (!existsSync(fpPath)) {
+    ghWarning(
+      "fingerprints.json is missing — cannot run a staleness check. Run `/understand` to baseline.",
+    );
+    return STRICT ? false : true;
+  }
+
+  const store = core.loadFingerprints(REPO_ROOT);
+  if (!store || !store.files) {
+    ghWarning("fingerprints.json could not be loaded; skipping staleness check.");
+    return STRICT ? false : true;
+  }
+
+  // Build a tree-sitter registry that mirrors build-fingerprints.mjs so the
+  // comparison uses the same structural extraction as the committed baseline.
+  const tsConfigs = core.builtinLanguageConfigs.filter((c) => c.treeSitter);
+  const tsPlugin = new core.TreeSitterPlugin(tsConfigs);
+  await tsPlugin.init();
+  const registry = new core.PluginRegistry();
+  registry.register(tsPlugin);
+  core.registerAllParsers(registry);
+
+  const filter = core.createIgnoreFilter(REPO_ROOT);
+  const currentSource = trackedSourceFiles(filter);
+  const storedSource = Object.keys(store.files).filter((p) =>
+    SOURCE_EXTS.has(extname(p)),
+  );
+  const candidates = [...new Set([...currentSource, ...storedSource])];
+
+  const analysis = core.analyzeChanges(REPO_ROOT, candidates, store, registry);
+  const drift = [
+    ...analysis.newFiles.map((f) => `+ ${f} (new)`),
+    ...analysis.deletedFiles.map((f) => `- ${f} (deleted)`),
+    ...analysis.structurallyChangedFiles.map((f) => `~ ${f} (structural)`),
+  ];
+
+  if (drift.length === 0) {
+    console.log(
+      `  ✓ graph is in sync — ${candidates.length} source files checked, no structural drift`,
+    );
+    return true;
+  }
+
+  const lines = [
+    `Knowledge graph is stale: ${drift.length} source file(s) changed structurally since the committed graph was generated.`,
+    ...drift.slice(0, 25).map((d) => `    ${d}`),
+    drift.length > 25 ? `    …and ${drift.length - 25} more` : "",
+    "Run `/understand` (incremental) — or `/understand --full` — and commit the refreshed .understand-anything/ graph.",
+  ].filter(Boolean);
+  const msg = lines.join("\n");
+
+  if (STRICT) {
+    ghError(msg);
+    return false;
+  }
+  ghWarning(msg);
+  return true;
+}
+
+// The domain graph is DERIVED from the knowledge graph and is NOT refreshed by
+// the auto-update hook (which only patches the knowledge graph). So it can drift
+// even when the knowledge graph is current. Both files stamp the commit they were
+// generated against — knowledge graph via meta.json, domain graph via
+// project.gitCommitHash — so a mismatch is a cheap, deterministic staleness signal.
+function checkDomainSync() {
+  const domainPath = resolve(UA_DIR, "domain-graph.json");
+  const metaPath = resolve(UA_DIR, "meta.json");
+  if (!existsSync(domainPath)) {
+    console.log("  · no domain-graph.json — skipping domain sync check");
+    return true;
+  }
+  if (!existsSync(metaPath)) {
+    ghWarning(
+      "meta.json is missing — cannot verify the domain graph is in sync with the knowledge graph.",
+    );
+    return STRICT ? false : true;
+  }
+  let metaHash, domainHash;
+  try {
+    metaHash = JSON.parse(readFileSync(metaPath, "utf-8")).gitCommitHash;
+    domainHash = JSON.parse(readFileSync(domainPath, "utf-8"))?.project?.gitCommitHash;
+  } catch (err) {
+    ghWarning(`Could not read commit hashes for the domain sync check: ${err.message}`);
+    return STRICT ? false : true;
+  }
+
+  if (domainHash && metaHash && domainHash !== metaHash) {
+    const msg = [
+      "Domain graph is out of sync with the knowledge graph:",
+      `    domain-graph.json was generated at ${domainHash.slice(0, 8)}, knowledge graph at ${metaHash.slice(0, 8)}.`,
+      "The auto-update hook refreshes only the knowledge graph — re-run `/understand-domain` and commit the refreshed domain-graph.json.",
+    ].join("\n");
+    if (STRICT) {
+      ghError(msg);
+      return false;
+    }
+    ghWarning(msg);
+    return true;
+  }
+
+  console.log(
+    `  ✓ domain-graph.json in sync with the knowledge graph (${(metaHash ?? "").slice(0, 8)})`,
+  );
+  return true;
+}
+
+async function main() {
+  const core = await loadCore();
+
+  console.log("[check-graph] Schema validation (blocking):");
+  const kgOk = validateOne(core.validateGraph, "knowledge-graph.json");
+  const dgOk = validateOne(core.validateGraph, "domain-graph.json");
+  const schemaOk = kgOk && dgOk;
+
+  console.log("[check-graph] Staleness check (advisory unless --strict):");
+  const freshOk = await checkStaleness(core);
+
+  console.log("[check-graph] Domain sync check (advisory unless --strict):");
+  const domainOk = checkDomainSync();
+
+  if (!schemaOk) {
+    ghError("Graph schema validation failed — see errors above.");
+    process.exit(1);
+  }
+  if (!freshOk || !domainOk) {
+    process.exit(1);
+  }
+  console.log("[check-graph] OK");
+}
+
+main().catch((err) => {
+  ghError(`check-graph crashed: ${err.stack ?? err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What & why

Closes #508 — "eat your own dog food." Runs the plugin on this repo and commits the result, so the repo carries a live, maintained knowledge graph of its own architecture. Useful for onboarding, PR-review context, and as a real-world example of the tool.

## Committed artifacts (`.understand-anything/`)
- **`knowledge-graph.json`** — structural graph: 674 nodes, 960 edges, 8 architectural layers, 12-step guided tour (includes this PR's own `scripts/check-graph.mjs`)
- **`domain-graph.json`** — business-flow view: 7 domains, 12 flows, 45 steps, version-matched to the knowledge graph via `project.gitCommitHash`
- **`meta.json`**, **`fingerprints.json`** — analysis baseline + structural fingerprints (400 files) for incremental updates
- **`config.json`** — `{ "autoUpdate": true }`
- **`.understandignore`** — analysis scope

Per the README's *Share the Graph with Your Team* guidance, `.gitignore` is scoped to drop only the pipeline's local scratch (`intermediate/`, `tmp/`, `.trash-*/`, `diff-overlay.json`) and track the rest.

## Keeping it fresh
- **Auto-update enabled** (`config.json`). The plugin's bundled hooks fire the incremental auto-update on commit (+ a staleness check at session start), spending zero LLM tokens on cosmetic changes. The hook refreshes **only** `knowledge-graph.json`.
- **The domain graph is not auto-refreshed** (it's derived from the knowledge graph, no incremental path). Every commit that meaningfully changes structure should run `/understand` (or let the hook run) **and** `/understand-domain`, then commit the refreshed `domain-graph.json`. Documented in CLAUDE.md and CONTRIBUTING.md.

## CI guard — `scripts/check-graph.mjs` (wired into `ci.yml`)
Deterministic, zero LLM tokens:
- schema-validates **both** committed graphs (**blocking**),
- rebuilds structural fingerprints for the current source tree, warns on drift from `fingerprints.json` (**advisory**),
- warns when `domain-graph.json`'s `project.gitCommitHash` no longer matches `meta.json` — i.e. the domain view is behind the knowledge graph (**advisory**).

`--strict` makes the advisory checks blocking. Reuses core's `validateGraph`, `buildFingerprintStore`/`analyzeChanges`, and `createIgnoreFilter`, mirroring the auto-update hook's deterministic Phase 1. Graph **regeneration** is an LLM task and deliberately stays off the PR path.

This PR practices what it documents: after adding `check-graph.mjs`, the graph and domain view were regenerated to include it, so the guard runs clean (`✓ schema · ✓ in sync · ✓ domain in sync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
