### PR TITLE
fix: make /understand discoverable in Claude Code VS Code extension

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,5 +14,7 @@
     "architecture",
     "onboarding",
     "dashboard"
-  ]
+  ],
+  "skills": "./understand-anything-plugin/skills/",
+  "agents": "./understand-anything-plugin/agents/"
 }

--- a/understand-anything-plugin/.claude-plugin/plugin.json
+++ b/understand-anything-plugin/.claude-plugin/plugin.json
@@ -14,5 +14,7 @@
     "architecture",
     "onboarding",
     "dashboard"
-  ]
+  ],
+  "skills": "./skills/",
+  "agents": "./agents/"
 }


### PR DESCRIPTION
## Summary

Fixes #505

The `/understand` command was available when installed through the Claude Code CLI but was not discoverable in the Claude Code VS Code extension.

## Root Cause

The Claude plugin manifests were missing explicit `skills` and `agents` entries.

While the CLI can discover skills through directory scanning, the VS Code extension relies on manifest-based discovery. Without these entries, the extension could not locate and register the `/understand` skill.

## Changes

* Added `skills` and `agents` entries to `.claude-plugin/plugin.json`
* Added `skills` and `agents` entries to `understand-anything-plugin/.claude-plugin/plugin.json`

## Verification

* Rebuilt `@understand-anything/core`
* Rebuilt `@understand-anything/skill`
* Verified successful builds
* Confirmed the manifest paths correctly expose skill and agent directories for extension discovery

This change is backward compatible and does not alter existing CLI behavior.
