### PR TITLE
fix: preserve real prefix when middle ID segment is a reserved word

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
@@ -512,6 +512,49 @@ describe("normalizeBatchOutput", () => {
     expect(result.edges[0].target).toBe("file:src/foo.ts");
     expect(result.stats.danglingEdgesDropped).toBe(0);
   });
+
+  it("repairs an edge endpoint with a chain of reserved-word prefixes", () => {
+    // Regression: an edge endpoint "service:endpoint:file:src/foo.ts" carries
+    // more than one reserved prefix before the real "file" prefix. Normalizing
+    // the full id for each candidate type can't collapse the run, so the repair
+    // must normalize from the candidate prefix segment to resolve it to the
+    // canonical node "file:src/foo.ts" rather than drop the edge.
+    const result = normalizeBatchOutput({
+      nodes: [
+        {
+          id: "file:src/foo.ts",
+          type: "file",
+          name: "foo.ts",
+          filePath: "src/foo.ts",
+          summary: "Target",
+          tags: [],
+          complexity: "simple",
+        },
+        {
+          id: "file:src/bar.ts",
+          type: "file",
+          name: "bar.ts",
+          filePath: "src/bar.ts",
+          summary: "Source",
+          tags: [],
+          complexity: "simple",
+        },
+      ],
+      edges: [
+        {
+          source: "file:src/bar.ts",
+          target: "service:endpoint:file:src/foo.ts",
+          type: "imports",
+          direction: "forward",
+          weight: 0.7,
+        },
+      ],
+    });
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].target).toBe("file:src/foo.ts");
+    expect(result.stats.danglingEdgesDropped).toBe(0);
+  });
 });
 
 describe("normalizeBatchOutput integration", () => {

--- a/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
@@ -555,6 +555,54 @@ describe("normalizeBatchOutput", () => {
     expect(result.edges[0].target).toBe("file:src/foo.ts");
     expect(result.stats.danglingEdgesDropped).toBe(0);
   });
+
+  it("drops a missing canonical endpoint instead of rewiring it to a same-named node", () => {
+    // Regression: an edge endpoint "func:src/a.ts:formatDate" is a canonical
+    // multi-part ID whose node is missing, while a DIFFERENT function
+    // "func:formatDate" exists. The reserved-prefix peeling must not strip the
+    // real "func" prefix and normalize the bare suffix "src/a.ts:formatDate"
+    // back to "func:formatDate" — that silently rewires the edge to an
+    // unrelated function. The edge must be dropped as dangling instead.
+    const result = normalizeBatchOutput({
+      nodes: [
+        {
+          id: "func:formatDate",
+          type: "function",
+          name: "formatDate",
+          summary: "A different formatDate",
+          tags: [],
+          complexity: "simple",
+        },
+        {
+          id: "file:src/a.ts",
+          type: "file",
+          name: "a.ts",
+          filePath: "src/a.ts",
+          summary: "Source",
+          tags: [],
+          complexity: "simple",
+        },
+      ],
+      edges: [
+        {
+          source: "file:src/a.ts",
+          target: "func:src/a.ts:formatDate",
+          type: "calls",
+          direction: "forward",
+          weight: 0.7,
+        },
+      ],
+    });
+
+    expect(result.edges).toHaveLength(0);
+    expect(result.stats.danglingEdgesDropped).toBe(1);
+    expect(result.stats.droppedEdges[0]).toEqual({
+      source: "file:src/a.ts",
+      target: "func:src/a.ts:formatDate",
+      type: "calls",
+      reason: "missing-target",
+    });
+  });
 });
 
 describe("normalizeBatchOutput integration", () => {

--- a/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
@@ -47,6 +47,22 @@ describe("normalizeNodeId", () => {
     expect(normalizeNodeId(once, { type: "endpoint" })).toBe(once);
   });
 
+  it("strips a project-name prefix that collides with a reserved word", () => {
+    // Regression: when the project name is itself a reserved word ("service")
+    // and the node's real prefix follows ("file"), the spurious outer prefix
+    // must be dropped so the canonical "file:src/foo.ts" form is used — not
+    // left as "service:file:src/foo.ts", which would dangle edges that
+    // reference the canonical ID.
+    expect(
+      normalizeNodeId("service:file:src/foo.ts", { type: "file" }),
+    ).toBe("file:src/foo.ts");
+  });
+
+  it("is idempotent when a reserved-word project prefix is stripped", () => {
+    const once = normalizeNodeId("service:file:src/foo.ts", { type: "file" });
+    expect(normalizeNodeId(once, { type: "file" })).toBe(once);
+  });
+
   it("strips project-name prefix when valid prefix follows", () => {
     expect(
       normalizeNodeId("my-project:file:src/foo.ts", { type: "file" }),

--- a/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
@@ -31,6 +31,22 @@ describe("normalizeNodeId", () => {
     ).toBe("file:src/foo.ts");
   });
 
+  it("keeps a real prefix when a different reserved word is a middle segment", () => {
+    // Regression: "endpoint:service:x" is a valid prefix followed by a real
+    // path segment that happens to be a reserved word. The outer "endpoint"
+    // prefix must be preserved, not dropped in favour of "service".
+    expect(
+      normalizeNodeId("endpoint:service:getUser", { type: "endpoint" }),
+    ).toBe("endpoint:service:getUser");
+  });
+
+  it("is idempotent for IDs whose middle segment is a reserved word", () => {
+    const once = normalizeNodeId("endpoint:service:getUser", {
+      type: "endpoint",
+    });
+    expect(normalizeNodeId(once, { type: "endpoint" })).toBe(once);
+  });
+
   it("strips project-name prefix when valid prefix follows", () => {
     expect(
       normalizeNodeId("my-project:file:src/foo.ts", { type: "file" }),

--- a/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
@@ -470,6 +470,48 @@ describe("normalizeBatchOutput", () => {
     expect(result.edges[0].source).toBe("file:src/bare.ts");
     expect(result.edges[0].target).toBe("file:src/target.ts");
   });
+
+  it("repairs an edge endpoint whose project prefix collides with a reserved word", () => {
+    // Regression: an edge endpoint "service:file:src/foo.ts" refers to the
+    // canonical node "file:src/foo.ts", but inferTypeFromId reads the spurious
+    // reserved-word project prefix "service" as the type. The fallback must
+    // still resolve it to the existing node rather than drop the edge.
+    const result = normalizeBatchOutput({
+      nodes: [
+        {
+          id: "file:src/foo.ts",
+          type: "file",
+          name: "foo.ts",
+          filePath: "src/foo.ts",
+          summary: "Target",
+          tags: [],
+          complexity: "simple",
+        },
+        {
+          id: "file:src/bar.ts",
+          type: "file",
+          name: "bar.ts",
+          filePath: "src/bar.ts",
+          summary: "Source",
+          tags: [],
+          complexity: "simple",
+        },
+      ],
+      edges: [
+        {
+          source: "file:src/bar.ts",
+          target: "service:file:src/foo.ts",
+          type: "imports",
+          direction: "forward",
+          weight: 0.7,
+        },
+      ],
+    });
+
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].target).toBe("file:src/foo.ts");
+    expect(result.stats.danglingEdgesDropped).toBe(0);
+  });
 });
 
 describe("normalizeBatchOutput integration", () => {

--- a/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/normalize-graph.test.ts
@@ -58,6 +58,33 @@ describe("normalizeNodeId", () => {
     ).toBe("file:src/foo.ts");
   });
 
+  it("collapses a chain of reserved-word prefixes down to the expected one", () => {
+    // Regression: a file node emitted as "service:endpoint:file:src/foo.ts"
+    // carries TWO spurious reserved-word segments before its real prefix.
+    // Collapsing only when the immediate inner segment is the expected prefix
+    // stops at "service", leaving the ID uncanonical, so every canonical edge
+    // pointing at "file:src/foo.ts" dangles. The chain must collapse whole.
+    expect(
+      normalizeNodeId("service:endpoint:file:src/foo.ts", { type: "file" }),
+    ).toBe("file:src/foo.ts");
+  });
+
+  it("is idempotent when a reserved-prefix chain is collapsed", () => {
+    const once = normalizeNodeId("service:endpoint:file:src/foo.ts", {
+      type: "file",
+    });
+    expect(normalizeNodeId(once, { type: "file" })).toBe(once);
+  });
+
+  it("keeps a real prefix even when the expected prefix appears later as a path segment", () => {
+    // The guard for the case above must not over-collapse: an endpoint node
+    // legitimately named "endpoint:file:handler" has "file" as a real middle
+    // segment, not a spurious prefix, so the outer "endpoint" stays.
+    expect(
+      normalizeNodeId("endpoint:file:handler", { type: "endpoint" }),
+    ).toBe("endpoint:file:handler");
+  });
+
   it("is idempotent when a reserved-word project prefix is stripped", () => {
     const once = normalizeNodeId("service:file:src/foo.ts", { type: "file" });
     expect(normalizeNodeId(once, { type: "file" })).toBe(once);

--- a/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
+++ b/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
@@ -212,6 +212,40 @@ function inferTypeFromId(id: string): string {
 }
 
 /**
+ * Best-effort repair of an edge endpoint that matches no node ID.
+ *
+ * Tries the prefix-inferred type first (preserving the common case), then
+ * each subsequent leading reserved-word segment as a candidate type. This
+ * recovers a reserved-word project prefix — e.g. an edge endpoint
+ * `service:file:src/foo.ts` pointing at the canonical node `file:src/foo.ts`,
+ * where `inferTypeFromId` would treat the spurious `service` as the type and
+ * fail to strip it, leaving the edge dangling. Returns the original id
+ * unchanged when nothing resolves to an existing node.
+ */
+function resolveEdgeEndpoint(id: string, validNodeIds: Set<string>): string {
+  const candidateTypes: string[] = [inferTypeFromId(id)];
+
+  // Add each leading valid-prefix segment's type as an additional candidate,
+  // so a spurious outer reserved word can be skipped in favour of the real one.
+  let rest = id;
+  while (true) {
+    const colonIdx = rest.indexOf(":");
+    if (colonIdx <= 0) break;
+    const segment = rest.slice(0, colonIdx);
+    if (!(segment in PREFIX_TO_TYPE)) break;
+    const type = PREFIX_TO_TYPE[segment];
+    if (!candidateTypes.includes(type)) candidateTypes.push(type);
+    rest = rest.slice(colonIdx + 1);
+  }
+
+  for (const type of candidateTypes) {
+    const normalized = normalizeNodeId(id, { type });
+    if (validNodeIds.has(normalized)) return normalized;
+  }
+  return id;
+}
+
+/**
  * Normalizes a merged batch output: fixes node IDs and numeric complexity,
  * rewrites edge references, deduplicates nodes and edges, and drops dangling edges.
  *
@@ -300,18 +334,14 @@ export function normalizeBatchOutput(data: {
     let newSource = idMap.get(oldSource) ?? oldSource;
     let newTarget = idMap.get(oldTarget) ?? oldTarget;
 
-    // Fallback: if endpoint not found in idMap, normalize it directly
-    // (handles cross-variant malformed IDs between nodes and edges).
-    // Try the edge's implied type first (from prefix), then fall back to "file".
+    // Fallback: if an endpoint isn't found in idMap, repair it directly
+    // (handles cross-variant malformed IDs between nodes and edges, including
+    // reserved-word project prefixes that inferTypeFromId alone can't resolve).
     if (!validNodeIds.has(newSource)) {
-      const inferredType = inferTypeFromId(newSource);
-      const normalized = normalizeNodeId(newSource, { type: inferredType });
-      if (validNodeIds.has(normalized)) newSource = normalized;
+      newSource = resolveEdgeEndpoint(newSource, validNodeIds);
     }
     if (!validNodeIds.has(newTarget)) {
-      const inferredType = inferTypeFromId(newTarget);
-      const normalized = normalizeNodeId(newTarget, { type: inferredType });
-      if (validNodeIds.has(normalized)) newTarget = normalized;
+      newTarget = resolveEdgeEndpoint(newTarget, validNodeIds);
     }
 
     if (newSource !== oldSource || newTarget !== oldTarget) {

--- a/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
+++ b/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
@@ -211,6 +211,12 @@ function inferTypeFromId(id: string): string {
   return "file";
 }
 
+/** True when an ID begins with a valid `prefix:` segment (e.g. "file:src/x.ts"). */
+function startsWithValidPrefix(id: string): boolean {
+  const colonIdx = id.indexOf(":");
+  return colonIdx > 0 && id.slice(0, colonIdx) in PREFIX_TO_TYPE;
+}
+
 /**
  * Best-effort repair of an edge endpoint that matches no node ID.
  *
@@ -225,6 +231,14 @@ function inferTypeFromId(id: string): string {
  * `stripToValidPrefix` can't collapse the run for the `file` candidate and
  * every full-id attempt would otherwise leave the edge dangling. Returns the
  * original id unchanged when nothing resolves to an existing node.
+ *
+ * A leading reserved word is only peeled when what remains is itself a
+ * canonical `prefix:path` id — that is the signature of a spurious outer
+ * prefix sitting in front of the real id. When the remainder is a bare path,
+ * the peeled segment was the endpoint's own prefix (e.g. `func` in
+ * `func:src/a.ts:formatDate`), and reinterpreting the suffix would silently
+ * rewire the edge to a different same-named node (`func:formatDate`) instead
+ * of dropping the missing endpoint as dangling.
  */
 function resolveEdgeEndpoint(id: string, validNodeIds: Set<string>): string {
   // Each candidate pairs a node type with the id suffix to normalize from.
@@ -241,6 +255,10 @@ function resolveEdgeEndpoint(id: string, validNodeIds: Set<string>): string {
     const segment = rest.slice(0, colonIdx);
     if (!(segment in PREFIX_TO_TYPE)) break;
     rest = rest.slice(colonIdx + 1);
+    // Only strip `segment` as a spurious outer prefix when the remainder is
+    // still a canonical prefixed id. Otherwise `segment` was the real prefix
+    // and the bare suffix must not be reinterpreted as another node.
+    if (!startsWithValidPrefix(rest)) break;
     const type = PREFIX_TO_TYPE[segment];
     if (!candidates.some((c) => c.type === type && c.fromId === rest)) {
       candidates.push({ type, fromId: rest });

--- a/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
+++ b/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
@@ -214,32 +214,41 @@ function inferTypeFromId(id: string): string {
 /**
  * Best-effort repair of an edge endpoint that matches no node ID.
  *
- * Tries the prefix-inferred type first (preserving the common case), then
- * each subsequent leading reserved-word segment as a candidate type. This
- * recovers a reserved-word project prefix — e.g. an edge endpoint
- * `service:file:src/foo.ts` pointing at the canonical node `file:src/foo.ts`,
- * where `inferTypeFromId` would treat the spurious `service` as the type and
- * fail to strip it, leaving the edge dangling. Returns the original id
- * unchanged when nothing resolves to an existing node.
+ * Tries the prefix-inferred type against the full id first (preserving the
+ * common case), then peels each leading reserved-word segment and normalizes
+ * from the suffix that begins at it. This recovers a reserved-word project
+ * prefix — e.g. an edge endpoint `service:file:src/foo.ts` pointing at the
+ * canonical node `file:src/foo.ts`, where `inferTypeFromId` would treat the
+ * spurious `service` as the type and fail to strip it. Normalizing from the
+ * candidate segment (rather than always from the full id) also handles a
+ * *chain* of reserved prefixes, e.g. `service:endpoint:file:src/foo.ts`, where
+ * `stripToValidPrefix` can't collapse the run for the `file` candidate and
+ * every full-id attempt would otherwise leave the edge dangling. Returns the
+ * original id unchanged when nothing resolves to an existing node.
  */
 function resolveEdgeEndpoint(id: string, validNodeIds: Set<string>): string {
-  const candidateTypes: string[] = [inferTypeFromId(id)];
+  // Each candidate pairs a node type with the id suffix to normalize from.
+  // The first preserves the common case (inferred type, full id); each peeled
+  // segment then offers its real prefix and the substring that starts there.
+  const candidates: { type: string; fromId: string }[] = [
+    { type: inferTypeFromId(id), fromId: id },
+  ];
 
-  // Add each leading valid-prefix segment's type as an additional candidate,
-  // so a spurious outer reserved word can be skipped in favour of the real one.
   let rest = id;
   while (true) {
     const colonIdx = rest.indexOf(":");
     if (colonIdx <= 0) break;
     const segment = rest.slice(0, colonIdx);
     if (!(segment in PREFIX_TO_TYPE)) break;
-    const type = PREFIX_TO_TYPE[segment];
-    if (!candidateTypes.includes(type)) candidateTypes.push(type);
     rest = rest.slice(colonIdx + 1);
+    const type = PREFIX_TO_TYPE[segment];
+    if (!candidates.some((c) => c.type === type && c.fromId === rest)) {
+      candidates.push({ type, fromId: rest });
+    }
   }
 
-  for (const type of candidateTypes) {
-    const normalized = normalizeNodeId(id, { type });
+  for (const { type, fromId } of candidates) {
+    const normalized = normalizeNodeId(fromId, { type });
     if (validNodeIds.has(normalized)) return normalized;
   }
   return id;

--- a/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
+++ b/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
@@ -38,10 +38,13 @@ function stripToValidPrefix(id: string): { prefix: string | null; path: string }
 
     const segment = remaining.slice(0, colonIdx);
     if (VALID_PREFIXES.has(segment)) {
-      // Check for double valid prefix (e.g., "file:file:src/foo.ts")
+      // Check for a true duplicate prefix (e.g., "file:file:src/foo.ts").
+      // Only collapse when the next segment is the SAME prefix — a different
+      // reserved word in the middle (e.g. "endpoint:service:x") is a real
+      // path segment, not a duplicate, and must not be stripped.
       const rest = remaining.slice(colonIdx + 1);
       const innerColonIdx = rest.indexOf(":");
-      if (innerColonIdx > 0 && VALID_PREFIXES.has(rest.slice(0, innerColonIdx))) {
+      if (innerColonIdx > 0 && rest.slice(0, innerColonIdx) === segment) {
         // Double-prefixed — skip the outer, recurse on inner
         remaining = rest;
         continue;

--- a/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
+++ b/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
@@ -27,8 +27,17 @@ const TYPE_TO_PREFIX: Record<string, string> = {
 /**
  * Strips all non-valid prefixes from an ID, returning the bare path
  * and the first valid prefix found (if any).
+ *
+ * `expectedPrefix` is the canonical prefix for the node's declared type
+ * (e.g. "file" for a file node). It disambiguates a reserved word that
+ * appears before the expected prefix — a spurious project-name prefix that
+ * happens to collide with a reserved word — from a reserved word that is a
+ * legitimate middle path segment.
  */
-function stripToValidPrefix(id: string): { prefix: string | null; path: string } {
+function stripToValidPrefix(
+  id: string,
+  expectedPrefix?: string,
+): { prefix: string | null; path: string } {
   let remaining = id;
 
   // Peel off colon-separated segments until we find a valid prefix or run out
@@ -38,14 +47,22 @@ function stripToValidPrefix(id: string): { prefix: string | null; path: string }
 
     const segment = remaining.slice(0, colonIdx);
     if (VALID_PREFIXES.has(segment)) {
-      // Check for a true duplicate prefix (e.g., "file:file:src/foo.ts").
-      // Only collapse when the next segment is the SAME prefix — a different
-      // reserved word in the middle (e.g. "endpoint:service:x") is a real
-      // path segment, not a duplicate, and must not be stripped.
+      // Collapse the outer prefix only when the next segment is either:
+      //   - the SAME reserved word — a true duplicate ("file:file:src/foo.ts"), or
+      //   - the node's expected prefix — a spurious project-name prefix that
+      //     collides with a reserved word ("service:file:src/foo.ts" for a file
+      //     node), which must resolve to the canonical "file:src/foo.ts".
+      // A different reserved word that is NOT the expected prefix
+      // ("endpoint:service:x" for an endpoint node) is a real path segment and
+      // must be preserved.
       const rest = remaining.slice(colonIdx + 1);
       const innerColonIdx = rest.indexOf(":");
-      if (innerColonIdx > 0 && rest.slice(0, innerColonIdx) === segment) {
-        // Double-prefixed — skip the outer, recurse on inner
+      const innerSegment = innerColonIdx > 0 ? rest.slice(0, innerColonIdx) : "";
+      if (
+        innerColonIdx > 0 &&
+        (innerSegment === segment || innerSegment === expectedPrefix)
+      ) {
+        // Skip the outer prefix, recurse on the inner one
         remaining = rest;
         continue;
       }
@@ -72,7 +89,7 @@ export function normalizeNodeId(
   if (!trimmed) return trimmed;
 
   const expectedPrefix = TYPE_TO_PREFIX[node.type];
-  const { prefix, path } = stripToValidPrefix(trimmed);
+  const { prefix, path } = stripToValidPrefix(trimmed, expectedPrefix);
 
   if (prefix) {
     // For step nodes with filePath, reconstruct as step:flowSlug:filePath:stepSlug.

--- a/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
+++ b/understand-anything-plugin/packages/core/src/analyzer/normalize-graph.ts
@@ -34,6 +34,24 @@ const TYPE_TO_PREFIX: Record<string, string> = {
  * happens to collide with a reserved word — from a reserved word that is a
  * legitimate middle path segment.
  */
+/**
+ * True when `prefix` appears inside the leading run of reserved-word segments
+ * of `id`. Scanning stops at the first segment that is not a reserved word, so
+ * a match means the run really is a chain of prefixes rather than ordinary path
+ * text that happens to contain the word.
+ */
+function chainContainsPrefix(id: string, prefix: string): boolean {
+  let rest = id;
+  while (true) {
+    const colonIdx = rest.indexOf(":");
+    if (colonIdx <= 0) return false;
+    const segment = rest.slice(0, colonIdx);
+    if (segment === prefix) return true;
+    if (!VALID_PREFIXES.has(segment)) return false;
+    rest = rest.slice(colonIdx + 1);
+  }
+}
+
 function stripToValidPrefix(
   id: string,
   expectedPrefix?: string,
@@ -60,7 +78,19 @@ function stripToValidPrefix(
       const innerSegment = innerColonIdx > 0 ? rest.slice(0, innerColonIdx) : "";
       if (
         innerColonIdx > 0 &&
-        (innerSegment === segment || innerSegment === expectedPrefix)
+        (innerSegment === segment ||
+          innerSegment === expectedPrefix ||
+          // A RUN of reserved words can sit in front of the real prefix
+          // ("service:endpoint:file:src/foo.ts" for a file node). Checking only
+          // the immediate inner segment stops at "service" and leaves the ID
+          // uncanonical, which dangles every edge pointing at the canonical
+          // form. Keep peeling while the expected prefix is still ahead in the
+          // run. Guarded on the outer segment not already BEING the expected
+          // prefix, so a real prefix followed by a reserved-word path segment
+          // ("endpoint:file:handler" for an endpoint node) is never stripped.
+          (expectedPrefix !== undefined &&
+            segment !== expectedPrefix &&
+            chainContainsPrefix(rest, expectedPrefix)))
       ) {
         // Skip the outer prefix, recurse on the inner one
         remaining = rest;


### PR DESCRIPTION
## Problem

`stripToValidPrefix` in `analyzer/normalize-graph.ts` collapses any node ID whose **second** segment happens to be a valid prefix, treating it as a double-prefix duplicate. This corrupts IDs where a reserved word legitimately appears as a middle path segment.

For example, `endpoint:service:getUser` is parsed as:
- outer segment `endpoint` (valid prefix) ✓
- next segment `service` (also a valid prefix) → wrongly assumed to be a duplicate prefix

…so the real `endpoint` prefix is dropped and the function returns `{ prefix: "service", path: "getUser" }`, yielding `service:getUser`. This:

- **changes the node type** (endpoint → service),
- **breaks edge references** that point at the original ID, and
- **violates idempotency** — normalizing an already-normalized ID mutates it.

## Fix

Only collapse a **true same-prefix duplicate** (e.g. `file:file:src/foo.ts`) by requiring the inner segment to equal the outer prefix:

```ts
// before
if (innerColonIdx > 0 && VALID_PREFIXES.has(rest.slice(0, innerColonIdx))) {

// after
if (innerColonIdx > 0 && rest.slice(0, innerColonIdx) === segment) {
```

A different reserved word in the middle is a legitimate path segment and is preserved. The genuine `file:file:...` double-prefix case still collapses as before.

## Tests

Added two regression tests to `normalize-graph.test.ts`:
- `endpoint:service:getUser` is preserved unchanged (was previously corrupted to `service:getUser`).
- normalization is idempotent for IDs with a reserved-word middle segment.

`pnpm --filter @understand-anything/core test` — **755 passing** (including the existing `file:file:` double-prefix test, which still passes).