### PR TITLE
fix: recognize batch-existing.json in incremental merge (graph no longer collapses to changed files)

### DIFF
--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -1013,12 +1013,15 @@ def main() -> None:
         sys.exit(1)
 
     # Discover batch files, sorted by numeric index (not lexicographic)
-    batch_files = sorted(
-        intermediate_dir.glob("batch-*.json"),
-        key=lambda p: int(re.search(r"batch-(\d+)", p.stem).group(1))
-        if re.search(r"batch-(\d+)", p.stem)
-        else 0,
-    )
+    def _batch_sort_key(p):
+        # batch-existing.json (the pruned prior graph on incremental updates) must
+        # load FIRST so fresh per-file batches override it during dedup.
+        if p.name == "batch-existing.json":
+            return -1
+        m = re.search(r"batch-(\d+)", p.stem)
+        return int(m.group(1)) if m else 0
+
+    batch_files = sorted(intermediate_dir.glob("batch-*.json"), key=_batch_sort_key)
     if not batch_files:
         print("Error: no batch-*.json files found in intermediate/", file=sys.stderr)
         sys.exit(1)
@@ -1033,6 +1036,14 @@ def main() -> None:
     by_batch = _dd(list)
     unrecognized_batch_files: list[str] = []
     for f in batch_files:
+        # batch-existing.json carries the pruned prior graph on incremental updates
+        # (written by the /understand incremental path, SKILL.md Phase 2). It has no
+        # numeric index, so the strict pattern below would classify it "unrecognized"
+        # and DROP every retained node/edge - collapsing the graph to only the changed
+        # files. Recognize it explicitly so the incremental path actually works.
+        if f.name == "batch-existing.json":
+            by_batch[-1].append((f.name, None))
+            continue
         m = re.match(r"batch-(\d+)(?:-part-(\d+))?\.json", f.name)
         if m:
             by_batch[int(m.group(1))].append((f.name, int(m.group(2)) if m.group(2) else None))


### PR DESCRIPTION
## Problem

The incremental `/understand` path collapses the knowledge graph down to only the changed files.

`skills/understand/SKILL.md` (Phase 2, "Incremental update path") writes the pruned prior graph to `batch-existing.json` and states:

> 4. Run the same merge script - it will combine `batch-existing.json` with the fresh `batch-*.json` files

But `merge-batch-graphs.py` discovers batch files and filters them with:

```python
m = re.match(r"batch-(\d+)(?:-part-(\d+))?\.json", f.name)
```

`batch-existing.json` has no numeric index, so it does not match, is appended to `unrecognized_batch_files`, and is **skipped at load**:

```python
unrecognized_set = set(unrecognized_batch_files)
...
if f.name in unrecognized_set:
    continue
```

Result: on every incremental update, all retained nodes/edges from the prior graph are dropped and the assembled graph shrinks to just the files that changed in that commit. The script prints a generic "unrecognized filenames will be DROPPED" warning, but the file it is dropping is the one the skill's own incremental path is documented to produce.

## Fix

Recognize `batch-existing.json` explicitly and sort it first (`key = -1`) so the fresh per-file batches still override it during dedup (the merge keeps the last occurrence per node id):

- `_batch_sort_key` returns `-1` for `batch-existing.json` so it loads before the numbered batches.
- The grouping loop handles `batch-existing.json` as a valid batch instead of marking it unrecognized.

Minimal change, one file, no behavior change for full analysis or for the existing `batch-<N>.json` / `batch-<N>-part-<K>.json` handling.

## Verification

Standalone repro against the patched script:

- `batch-existing.json` = files `a`, `b`, `c` + an `imports` edge (the retained prior graph)
- `batch-0.json` = changed file `d`

| | assembled nodes | edges |
|---|---|---|
| before | `file:d.py` only (1) | 0 |
| after | `file:a.py, file:b.py, file:c.py, file:d.py` (4) | 1 |

Dedup still works (fresh batch overrides existing for a changed file, because existing loads first).

## Notes

Happy to add a test in whatever harness you prefer for the Python scripts (I didn't see an existing pytest setup alongside the vitest suites - let me know and I'll wire one up).
