### PR TITLE
update outdated vitest devDependency from ^3.1.0 to ^3.2.0 to fix CVE-2026-47429

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "globals": "^17.6.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.0.0",
-    "vitest": "^3.1.0"
+    "vitest": "^3.2.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/understand-anything-plugin/package.json
+++ b/understand-anything-plugin/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "node -e \"console.log('skill tests live at <repo-root>/tests/skill — run via root \\`pnpm test\\`')\""
+    "test": "node -e \"console.log('skill tests live at <repo-root>/tests/skill — run via root \`pnpm test\`')\""
   },
   "dependencies": {
     "@understand-anything/core": "workspace:*",
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.7.0",
-    "vitest": "^3.1.0"
+    "vitest": "^3.2.0"
   }
 }

--- a/understand-anything-plugin/packages/core/package.json
+++ b/understand-anything-plugin/packages/core/package.json
@@ -34,7 +34,7 @@
     "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "3.2.4",
     "typescript": "^5.7.0",
-    "vitest": "^3.1.0"
+    "vitest": "^3.2.0"
   },
   "dependencies": {
     "@tree-sitter-grammars/tree-sitter-kotlin": "1.1.0",

--- a/understand-anything-plugin/packages/dashboard/package.json
+++ b/understand-anything-plugin/packages/dashboard/package.json
@@ -38,6 +38,6 @@
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.4.2",
-    "vitest": "^3.1.0"
+    "vitest": "^3.2.0"
   }
 }


### PR DESCRIPTION
Updates vitest across all 4 package.json files to address the UI-server arbitrary file read/execute vulnerability (CVE-2026-47429). This resolves false-alarm security scan warnings without functional changes since vitest is a devDependency only.

Fixes #533

## Summary

<!-- One or two sentences on what this PR changes and why. -->

## Linked issue(s)

<!-- e.g. Closes #123, Refs #456. Leave empty if there's no tracking issue. -->

## How I tested this

<!-- Concrete steps. "Ran the test suite" is fine; "Ran /understand on a 3k-file
Swift repo and verified the dashboard shows non-empty edges" is better. -->

- [ ] `pnpm lint`
- [ ] `pnpm --filter @understand-anything/core test`
- [ ] `pnpm test`
- [ ] Manual smoke test (describe above)

## Versioning

<!-- If this PR ships a user-visible behavior change, bump the version in ALL
five manifests per CLAUDE.md. If it's docs/tests/internal-only, leave them
alone and the maintainer will bump on merge. -->

- [ ] Version bumped in all five manifests, OR
- [ ] N/A — internal/docs-only change
