### PR TITLE
fix(cpp): extract templated and include-guarded declarations from C/C++ headers

### DIFF
--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -256,7 +256,7 @@ Using the script's structural data and file categories, create edges:
 |---|---|---|---|
 | `contains` | File contains a function or class node you created (use for ALL function/class nodes) | `1.0` | `forward` |
 | `imports` | File imports from another project file (use `batchImportData[filePath]` from input JSON — external imports already filtered out) | `0.7` | `forward` |
-| `calls` | A function in this file calls a function in another file (infer from imports + function names when confident) | `0.8` | `forward` |
+| `calls` | A function in this file calls a function in another file. **Primary source: the `callGraph` array in the script output** (deterministic `{caller, callee, lineNumber}` pairs) — do not ignore it. For each entry whose `callee` resolves to a function/method of a file in `batchImportData[filePath]` or `neighborMap`, emit a `calls` edge (this file → that file). Skip callees that are standard-library/external symbols (e.g. `std::…`, `printf`, `typeid`) — they can't become project edges. Also infer from imports + function names when confident. | `0.8` | `forward` |
 | `inherits` | A class extends another class in the project | `0.9` | `forward` |
 | `implements` | A class implements an interface in the project | `0.9` | `forward` |
 | `exports` | File exports a function or class node you created (only for exported items — use IN ADDITION to `contains`, not instead of it) | `0.8` | `forward` |

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cpp-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/cpp-extractor.test.ts
@@ -693,4 +693,135 @@ int main() {
       parser.delete();
     });
   });
+
+  // ---- Include guards & templates ----
+  //
+  // Regression: real C/C++ headers wrap their contents in an `#ifndef … #endif`
+  // include guard (a `preproc_ifdef` node) and frequently declare templated
+  // classes/functions (`template_declaration` nodes). Neither was traversed, so
+  // guard-wrapped and/or templated declarations were silently dropped — leaving
+  // most header files with zero extracted symbols.
+
+  describe("extractStructure - include guards and templates", () => {
+    it("extracts declarations wrapped in an #ifndef include guard", () => {
+      const { tree, parser, root } = parse(`
+#ifndef FOO_H
+#define FOO_H
+class Foo {
+public:
+    void bar();
+};
+void freeFn() {}
+#endif
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes.map((c) => c.name)).toContain("Foo");
+      expect(result.classes[0].methods).toContain("bar");
+      expect(result.functions.map((f) => f.name)).toContain("freeFn");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a top-level templated class", () => {
+      const { tree, parser, root } = parse(`
+template <typename T>
+class Vec {
+public:
+    void push(T item);
+    T pop();
+};
+`);
+      const result = extractor.extractStructure(root);
+
+      const vec = result.classes.find((c) => c.name === "Vec");
+      expect(vec).toBeDefined();
+      expect(vec!.methods).toContain("push");
+      expect(vec!.methods).toContain("pop");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a templated class nested in a namespace", () => {
+      const { tree, parser, root } = parse(`
+namespace util {
+template <class T>
+class Queue {
+public:
+    void enqueue(T item);
+    T dequeue();
+};
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.classes.map((c) => c.name)).toContain("Queue");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a templated member method (definition inside a class)", () => {
+      const { tree, parser, root } = parse(`
+class Logger {
+public:
+    void plain();
+    template <typename T>
+    void log(T msg) {}
+};
+`);
+      const result = extractor.extractStructure(root);
+
+      // The templated method must appear in both the class method list and
+      // the flat functions list (with a body it is a function_definition).
+      expect(result.classes[0].methods).toContain("log");
+      expect(result.functions.map((f) => f.name)).toContain("log");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("extracts a top-level templated free function", () => {
+      const { tree, parser, root } = parse(`
+template <typename T>
+T identity(T x) {
+    return x;
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.functions.map((f) => f.name)).toContain("identity");
+
+      tree.delete();
+      parser.delete();
+    });
+
+    it("combines include guard + namespace + templates (real-header shape)", () => {
+      const { tree, parser, root } = parse(`
+#ifndef QUEUE_H
+#define QUEUE_H
+namespace util {
+template <class T>
+class Queue {
+public:
+    void enqueue(T item);
+    template <typename U>
+    void emplace(U&& u) {}
+};
+}
+#endif
+`);
+      const result = extractor.extractStructure(root);
+
+      const q = result.classes.find((c) => c.name === "Queue");
+      expect(q).toBeDefined();
+      expect(q!.methods).toContain("enqueue");
+      expect(q!.methods).toContain("emplace");
+
+      tree.delete();
+      parser.delete();
+    });
+  });
 });

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/cpp-extractor.ts
@@ -239,6 +239,37 @@ export class CppExtractor implements LanguageExtractor {
           break;
         }
 
+        case "preproc_ifdef":
+        case "preproc_if":
+        case "preproc_else":
+        case "preproc_elif": {
+          // Include guards (`#ifndef __X_H__ … #endif`) and other preprocessor
+          // conditionals wrap their contents in a preproc_* node. tree-sitter nests the
+          // guarded declarations as children of this node, so recurse into it — otherwise
+          // every header that uses an include guard yields zero symbols.
+          this.walkTopLevel(node, functions, classes, imports, exports, methodsByClass);
+          break;
+        }
+
+        case "template_declaration": {
+          // `template <...> class/struct/void foo(...)` parses as a template_declaration
+          // wrapping the underlying entity. Unwrap and dispatch to the existing extractors
+          // so templated classes, structs, and functions are captured (not skipped).
+          const tClass = findChild(node, "class_specifier");
+          if (tClass) {
+            this.extractClassOrStruct(tClass, "class", classes, functions, exports);
+          }
+          const tStruct = findChild(node, "struct_specifier");
+          if (tStruct) {
+            this.extractClassOrStruct(tStruct, "struct", classes, functions, exports);
+          }
+          const tFunc = findChild(node, "function_definition");
+          if (tFunc) {
+            this.extractFunctionDef(tFunc, functions, exports, methodsByClass);
+          }
+          break;
+        }
+
         case "declaration": {
           // A top-level ";" terminated statement — could be a class/struct with a trailing ;
           // e.g., `class Foo { ... };` parses the class_specifier as a child of a
@@ -346,8 +377,21 @@ export class CppExtractor implements LanguageExtractor {
           continue;
         }
 
-        if (member.type === "field_declaration") {
-          const declNode = member.childForFieldName("declarator");
+        // Unwrap templated members: `template <...> void f();` (declaration) and
+        // `template <...> void f() { … }` (definition) parse as a template_declaration
+        // wrapping a field_declaration/declaration or a function_definition. Without this,
+        // template methods (e.g. variadic `logf`) are silently dropped from the class.
+        let em = member;
+        if (member.type === "template_declaration") {
+          const inner =
+            findChild(member, "function_definition") ||
+            findChild(member, "field_declaration") ||
+            findChild(member, "declaration");
+          if (inner) em = inner;
+        }
+
+        if (em.type === "field_declaration" || em.type === "declaration") {
+          const declNode = em.childForFieldName("declarator");
           if (declNode && declNode.type === "function_declarator") {
             // Method declaration (no body)
             const info = extractFuncDeclName(declNode);
@@ -356,7 +400,7 @@ export class CppExtractor implements LanguageExtractor {
               if (currentAccess === "public") {
                 exports.push({
                   name: info.name,
-                  lineNumber: member.startPosition.row + 1,
+                  lineNumber: em.startPosition.row + 1,
                 });
               }
             }
@@ -369,9 +413,9 @@ export class CppExtractor implements LanguageExtractor {
           }
         }
 
-        if (member.type === "function_definition") {
+        if (em.type === "function_definition") {
           // Inline method definition
-          const funcDecl = member.childForFieldName("declarator");
+          const funcDecl = em.childForFieldName("declarator");
           if (funcDecl && funcDecl.type === "function_declarator") {
             const info = extractFuncDeclName(funcDecl);
             if (info) {
@@ -382,17 +426,17 @@ export class CppExtractor implements LanguageExtractor {
               functions.push({
                 name: info.name,
                 lineRange: [
-                  member.startPosition.row + 1,
-                  member.endPosition.row + 1,
+                  em.startPosition.row + 1,
+                  em.endPosition.row + 1,
                 ],
                 params: extractParams(paramsNode),
-                returnType: extractReturnType(member),
+                returnType: extractReturnType(em),
               });
 
               if (currentAccess === "public") {
                 exports.push({
                   name: info.name,
-                  lineNumber: member.startPosition.row + 1,
+                  lineNumber: em.startPosition.row + 1,
                 });
               }
             }


### PR DESCRIPTION
## Problem

The C/C++ extractor produced **empty structural output for most real headers**. Two root causes in `walkTopLevel` (`packages/core/src/plugins/extractors/cpp-extractor.ts`), which only descended into `namespace` bodies:

1. **Include guards.** A conventional header wraps its contents in
   `#ifndef __X_H__ / #define __X_H__ / … / #endif`, which tree-sitter parses as a
   `preproc_ifdef` node. The walker never entered it, so **every header using an
   include guard yielded zero symbols** (classes, functions, includes — all lost).
2. **Templates.** `template <…> class/struct/function` parses as a
   `template_declaration` wrapping the entity — at file/namespace scope **and** as a
   class member. None of these were unwrapped, so all templated classes, structs,
   free functions, and templated member methods were dropped.

Because these two patterns are near-universal in real C++ headers (include guards especially), the extractor’s deterministic output for a typical header-heavy C++ project was effectively empty, forcing the downstream LLM pass to reconstruct everything from raw source.

## Fix

- **Recurse into `preproc_ifdef` / `preproc_if` / `preproc_else` / `preproc_elif`** blocks in `walkTopLevel`, so guard-wrapped declarations (and their `#include`s) are traversed.
- **Unwrap `template_declaration`** to its inner `class_specifier` / `struct_specifier` / `function_definition`, both at top level and inside class member lists.

A useful side effect: because `resolveImports` shares the same walker, header→header `#include` edges (previously hidden inside guards) now resolve too.

### Companion change (`agents/file-analyzer.md`)
The extraction script already emits a deterministic `callGraph` (`{caller, callee, lineNumber}`), but the `calls`-edge instruction only said “infer from imports + function names”, so the call graph went unused. The instruction now makes `callGraph` the primary source for `calls` edges (resolving each callee against imported/neighbor files, skipping std/external symbols).

## Before / After (real C++ headers)

| Header | Before | After |
|---|---|---|
| `Queue.h` (`template<class T> class Queue`) | *(no symbols)* | `Queue` + `enqueue`/`dequeue`/`size`/`clear`/… |
| `SequentialUnorderedMap.h` (template) | *(no symbols)* | class + 12 methods |
| `Uuid.h` (guarded, non-template) | *(no symbols)* | `Uuid` + 12 functions |
| `Logger.h` (guarded; variadic template methods) | *(no symbols)* | `Logger` + `log`/`logf` methods |

## Tests

Adds 6 regression tests to `cpp-extractor.test.ts`:
- declarations inside an `#ifndef` include guard,
- top-level templated class,
- templated class nested in a namespace,
- templated member method (definition inside a class),
- top-level templated free function,
- combined real-header shape (guard + namespace + templates).

Full core suite: **759/759 passing** (`pnpm --filter @understand-anything/core test`), including the new tests.

## Known limitation (out of scope)

Free (non-member) **function *prototypes*** at file/namespace scope — e.g. `void freeFn();` declared in a header with the body in a `.cpp` — are still not emitted as nodes from the header (only the `.cpp` *definition* creates the node). Class **method** declarations *are* captured. This is a pre-existing, separate limitation from the guard/template bugs fixed here and is comparatively rare in class-centric C++ codebases; left for a follow-up to keep this change focused.

## Notes

- No changes to the tree-sitter grammar; grammars ship prebuilt binaries.
- `.h`→language mapping was intentionally left unchanged (`.h` is ambiguous C vs C++, and `CppExtractor` already handles both language ids with the same grammar, so it does not affect extraction).