### PR TITLE
docs: ignore generated .ua trash directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,11 +282,12 @@ The graph is just JSON — **commit it once, and teammates skip the pipeline**. 
 
 > **Example:** [GoogleCloudPlatform/microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo) — Go / Java / Python / Node reference with a committed graph.
 
-**What to commit:** everything in `.ua/` *except* `intermediate/` and `diff-overlay.json` (those are local scratch). (Legacy projects use `.understand-anything/` — substitute that directory name below if it's the one present.)
+**What to commit:** everything in `.ua/` *except* `intermediate/`, `diff-overlay.json`, and `.trash-*/` (those are local scratch). (Legacy projects use `.understand-anything/` — substitute that directory name below if it's the one present.)
 
 ```gitignore
 .ua/intermediate/
 .ua/diff-overlay.json
+.ua/.trash-*/
 ```
 
 **Keep it fresh:** enable `/understand --auto-update` — a post-commit hook incrementally patches the graph so each commit lands with a matching graph. Or re-run `/understand` manually before releases.

--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -266,11 +266,12 @@ El grafo es solo JSON — **confírmalo una vez y tus compañeros se saltan el p
 
 > **Ejemplo:** [GoogleCloudPlatform/microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo) — referencia políglota (Go / Java / Python / Node) con el grafo ya confirmado.
 
-**Qué confirmar:** todo lo que hay en `.ua/` *excepto* `intermediate/` y `diff-overlay.json` (archivos temporales locales). (Los proyectos heredados usan `.understand-anything/`: sustituye ese nombre de directorio abajo si es el que está presente.)
+**Qué confirmar:** todo lo que hay en `.ua/` *excepto* `intermediate/`, `diff-overlay.json` y `.trash-*/` (archivos temporales locales). (Los proyectos heredados usan `.understand-anything/`: sustituye ese nombre de directorio abajo si es el que está presente.)
 
 ```gitignore
 .ua/intermediate/
 .ua/diff-overlay.json
+.ua/.trash-*/
 ```
 
 **Mantenlo al día:** activa `/understand --auto-update` — un hook post-commit parchea el grafo de forma incremental, así cada commit llega con su grafo correspondiente. O vuelve a ejecutar `/understand` manualmente antes de cada release.

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -267,11 +267,12 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 > **例：** [GoogleCloudPlatform/microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo) —— コミット済みのグラフを含む Go / Java / Python / Node のリファレンスプロジェクト。
 
-**コミット対象：** `.ua/` 内のすべてのファイル。ただし `intermediate/` と `diff-overlay.json` は除きます（これらはローカルの一時ファイルです）。（レガシープロジェクトは `.understand-anything/` を使用します。そのディレクトリが存在する場合は、以下のディレクトリ名をそれに置き換えてください。）
+**コミット対象：** `.ua/` 内のすべてのファイル。ただし `intermediate/`、`diff-overlay.json`、`.trash-*/` は除きます（これらはローカルの一時ファイルです）。（レガシープロジェクトは `.understand-anything/` を使用します。そのディレクトリが存在する場合は、以下のディレクトリ名をそれに置き換えてください。）
 
 ```gitignore
 .ua/intermediate/
 .ua/diff-overlay.json
+.ua/.trash-*/
 ```
 
 **最新状態を保つ：** `/understand --auto-update` を有効にすると、post-commit フックがグラフを増分的に更新し、各コミットに対応するグラフが揃います。またはリリース前に `/understand` を手動で再実行します。

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -266,11 +266,12 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 > **예시:** [GoogleCloudPlatform/microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo) — 커밋된 그래프를 포함한 Go / Java / Python / Node 레퍼런스 프로젝트.
 
-**커밋할 대상:** `.ua/` 내부의 모든 파일. 단, `intermediate/` 와 `diff-overlay.json` 은 제외합니다 (이들은 로컬 임시 파일입니다). (레거시 프로젝트는 `.understand-anything/` 를 사용합니다. 해당 디렉터리가 있는 경우 아래의 디렉터리 이름을 그것으로 바꾸세요.)
+**커밋할 대상:** `.ua/` 내부의 모든 파일. 단, `intermediate/`, `diff-overlay.json`, `.trash-*/` 는 제외합니다 (이들은 로컬 임시 파일입니다). (레거시 프로젝트는 `.understand-anything/` 를 사용합니다. 해당 디렉터리가 있는 경우 아래의 디렉터리 이름을 그것으로 바꾸세요.)
 
 ```gitignore
 .ua/intermediate/
 .ua/diff-overlay.json
+.ua/.trash-*/
 ```
 
 **최신 상태 유지:** `/understand --auto-update` 를 활성화하면 post-commit 훅이 그래프를 증분 업데이트하여 각 커밋마다 일치하는 그래프가 유지됩니다. 또는 릴리스 전에 `/understand` 를 수동으로 다시 실행하세요.

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -267,11 +267,12 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 > **Пример:** [GoogleCloudPlatform/microservices-demo (форк)](https://github.com/GoogleCloudPlatform/microservices-demo) — мультиязыковой проект (Go / Java / Python / Node) с уже зафиксированным графом.
 
-**Что коммитить:** всё содержимое `.ua/`, *кроме* `intermediate/` и `diff-overlay.json` (это локальные временные файлы). (Устаревшие проекты используют `.understand-anything/` — подставьте это имя каталога ниже, если присутствует именно он.)
+**Что коммитить:** всё содержимое `.ua/`, *кроме* `intermediate/`, `diff-overlay.json` и `.trash-*/` (это локальные временные файлы). (Устаревшие проекты используют `.understand-anything/` — подставьте это имя каталога ниже, если присутствует именно он.)
 
 ```gitignore
 .ua/intermediate/
 .ua/diff-overlay.json
+.ua/.trash-*/
 ```
 
 **Держите граф в актуальном состоянии:** включите `/understand --auto-update` — post-commit хук будет инкрементально обновлять граф, так что каждый коммит сопровождается соответствующим графом. Либо запускайте `/understand` вручную перед релизами.

--- a/READMEs/README.tr-TR.md
+++ b/READMEs/README.tr-TR.md
@@ -267,11 +267,12 @@ Graf yalnızca bir JSON dosyasıdır — **bir kez commit'leyin, ekip arkadaşla
 
 > **Örnek:** [GoogleCloudPlatform/microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo) — commit'lenmiş grafı içeren Go / Java / Python / Node çok dilli referans projesi.
 
-**Neyi commit'leyin:** `.ua/` içindeki her şey, *ancak* `intermediate/` ve `diff-overlay.json` hariç (bunlar yerel geçici dosyalardır). (Eski projeler `.understand-anything/` kullanır — mevcut olan buysa aşağıdaki dizin adını onunla değiştirin.)
+**Neyi commit'leyin:** `.ua/` içindeki her şey, *ancak* `intermediate/`, `diff-overlay.json` ve `.trash-*/` hariç (bunlar yerel geçici dosyalardır). (Eski projeler `.understand-anything/` kullanır — mevcut olan buysa aşağıdaki dizin adını onunla değiştirin.)
 
 ```gitignore
 .ua/intermediate/
 .ua/diff-overlay.json
+.ua/.trash-*/
 ```
 
 **Güncel tutun:** `/understand --auto-update` etkinleştirin — bir post-commit kancası grafı artımlı olarak yamalar, böylece her commit eşleşen bir grafla birlikte gelir. Veya sürümden önce `/understand` komutunu elle yeniden çalıştırın.

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -266,11 +266,12 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 > **示例：** [GoogleCloudPlatform/microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo) —— 包含已提交图谱的 Go / Java / Python / Node 多语言参考项目。
 
-**需要提交的内容：** `.ua/` 下的全部文件，*除了* `intermediate/` 和 `diff-overlay.json`（这些是本地临时文件）。（旧项目使用 `.understand-anything/`——如果存在的是该目录，请将下方的目录名替换为它。）
+**需要提交的内容：** `.ua/` 下的全部文件，*除了* `intermediate/`、`diff-overlay.json` 和 `.trash-*/`（这些是本地临时文件）。（旧项目使用 `.understand-anything/`——如果存在的是该目录，请将下方的目录名替换为它。）
 
 ```gitignore
 .ua/intermediate/
 .ua/diff-overlay.json
+.ua/.trash-*/
 ```
 
 **保持最新：** 启用 `/understand --auto-update` —— 一个 post-commit 钩子会增量更新图谱，每次提交都能得到匹配的图谱版本。也可以在发布前手动重跑 `/understand`。

--- a/READMEs/README.zh-TW.md
+++ b/READMEs/README.zh-TW.md
@@ -266,11 +266,12 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 > **範例：** [GoogleCloudPlatform/microservices-demo](https://github.com/GoogleCloudPlatform/microservices-demo) —— 包含已提交圖譜的 Go / Java / Python / Node 多語言參考專案。
 
-**需要提交的內容：** `.ua/` 底下的全部檔案，*除了* `intermediate/` 與 `diff-overlay.json`（這些是本機暫存檔）。（舊專案使用 `.understand-anything/`——如果存在的是該目錄，請將下方的目錄名稱替換為它。）
+**需要提交的內容：** `.ua/` 底下的全部檔案，*除了* `intermediate/`、`diff-overlay.json` 與 `.trash-*/`（這些是本機暫存檔）。（舊專案使用 `.understand-anything/`——如果存在的是該目錄，請將下方的目錄名稱替換為它。）
 
 ```gitignore
 .ua/intermediate/
 .ua/diff-overlay.json
+.ua/.trash-*/
 ```
 
 **保持最新：** 啟用 `/understand --auto-update` —— 一個 post-commit 掛鉤會增量更新圖譜，讓每次提交都有對應的圖譜版本。也可以在發布前手動重跑 `/understand`。


### PR DESCRIPTION
## Summary

- document `.ua/.trash-*/` as local scratch data
- add the missing ignore rule to the main README and all seven translations
- keep the legacy `.understand-anything/` substitution guidance intact

## Root cause

The `/understand` cleanup flow moves temporary directories to `.ua/.trash-<timestamp>/`, but the “Share the Graph with Your Team” examples only ignored `intermediate/` and `diff-overlay.json`. Following the documented example could therefore stage generated trash directories.

## Impact

Users can copy the documented ignore block without accidentally committing `.trash-*` directories. Runtime behavior is unchanged.

## Validation

- `git diff --check`
- verified all eight README variants contain the three expected ignore rules
- independently tested with `git check-ignore` that `.ua/.trash-123/` is ignored while `.ua/knowledge-graph.json` remains trackable
- independently tested the equivalent legacy `.understand-anything/` substitution
