### PR TITLE
fix(merge): resolve cross-batch edge endpoints with mismatched node-type prefix

### DIFF
--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -1413,5 +1413,89 @@ class TestUaDirResolution(unittest.TestCase):
         self.assertFalse((self.tmp / ".ua" / "intermediate" / "assembled-graph.json").exists())
 
 
+
+class PrefixResolutionTests(unittest.TestCase):
+    """Cross-batch endpoints whose node-type prefix was guessed wrong.
+
+    A file-analyzer that emits an edge into another batch has to guess the
+    target's node-type prefix; `neighborMap` only resolves code imports, so
+    doc->pipeline and config->code references have no ground truth. Without
+    resolution those edges are dropped silently.
+    """
+
+    @staticmethod
+    def _node(node_id: str, node_type: str, path: str) -> dict[str, Any]:
+        return {
+            "id": node_id,
+            "type": node_type,
+            "name": path.rsplit("/", 1)[-1],
+            "filePath": path,
+            "summary": "",
+            "tags": [],
+            "complexity": "simple",
+        }
+
+    def _merge(self, edges: list[dict[str, Any]]):
+        owner = {
+            "nodes": [
+                self._node("pipeline:wf/a.md", "pipeline", "wf/a.md"),
+                self._node("file:src/x.ts", "file", "src/x.ts"),
+                self._node("file:amb/y.ts", "file", "amb/y.ts"),
+                self._node("config:amb/y.ts", "config", "amb/y.ts"),
+            ],
+            "edges": [],
+        }
+        citer = {
+            "nodes": [self._node("document:docs/d.md", "document", "docs/d.md")],
+            "edges": edges,
+        }
+        return mbg.merge_and_normalize([owner, citer])
+
+    @staticmethod
+    def _edge(target: str, etype: str = "documents") -> dict[str, Any]:
+        return {
+            "source": "document:docs/d.md",
+            "target": target,
+            "type": etype,
+            "direction": "forward",
+            "weight": 0.5,
+        }
+
+    def test_document_prefix_resolves_to_pipeline(self) -> None:
+        assembled, _ = self._merge([self._edge("document:wf/a.md")])
+        targets = [e["target"] for e in assembled["edges"]]
+        self.assertIn("pipeline:wf/a.md", targets)
+
+    def test_config_prefix_resolves_to_file(self) -> None:
+        assembled, _ = self._merge([self._edge("config:src/x.ts", "related")])
+        targets = [e["target"] for e in assembled["edges"]]
+        self.assertIn("file:src/x.ts", targets)
+
+    def test_missing_target_still_dropped(self) -> None:
+        assembled, report = self._merge([self._edge("document:ghost/nope.md")])
+        self.assertEqual(assembled["edges"], [])
+        self.assertIn("ghost/nope.md", "\n".join(report))
+
+    def test_ambiguous_body_still_dropped(self) -> None:
+        """Two nodes share the body `amb/y.ts` — resolution must not guess."""
+        assembled, report = self._merge([self._edge("document:amb/y.ts", "related")])
+        self.assertEqual(assembled["edges"], [])
+        self.assertIn("amb/y.ts", "\n".join(report))
+
+    def test_resolution_reported_as_a_fix(self) -> None:
+        _assembled, report = self._merge(
+            [self._edge("document:wf/a.md"), self._edge("config:src/x.ts", "related")]
+        )
+        self.assertIn(
+            "edge endpoints resolved to correct node-type prefix", "\n".join(report)
+        )
+
+    def test_already_valid_endpoints_untouched(self) -> None:
+        """Edges that resolve today must take an unchanged path."""
+        assembled, _ = self._merge([self._edge("pipeline:wf/a.md")])
+        self.assertEqual(len(assembled["edges"]), 1)
+        self.assertEqual(assembled["edges"][0]["target"], "pipeline:wf/a.md")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -870,6 +870,38 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
 
     # ── Step 6: Deduplicate edges, drop dangling ─────────────────────
     node_ids = set(nodes_by_id.keys())
+
+    # Cross-batch endpoints may carry the wrong node-type prefix. Each
+    # file-analyzer picks the prefix for a target it does not own
+    # (file:/config:/document:/pipeline:/table:/schema:/endpoint:) on its own,
+    # and neighborMap only resolves code imports -- so doc->pipeline and
+    # config->code references are guesses. Left alone, those edges are dropped
+    # below with no signal other than a stderr line.
+    #
+    # Safe by construction: consulted only for IDs already headed for the drop,
+    # and only remaps when exactly one node shares the ID body. Ambiguous cases
+    # (e.g. both `file:x.ts` and `config:x.ts` exist) keep the current
+    # drop-and-report behaviour.
+    _ids_by_body: dict[str, list[str]] = {}
+    for _nid in node_ids:
+        _head, _sep, _body = _nid.partition(":")
+        _k = _body if (_sep and _head in VALID_NODE_PREFIXES) else _nid
+        _ids_by_body.setdefault(_k, []).append(_nid)
+
+    def resolve_prefix(nid: str) -> str | None:
+        """Return the real node ID for `nid`, ignoring its node-type prefix.
+
+        Returns None when unresolvable or ambiguous, so the caller drops the
+        edge exactly as it does today.
+        """
+        if nid in node_ids:
+            return nid
+        _head, _sep, _body = nid.partition(":")
+        _k = _body if (_sep and _head in VALID_NODE_PREFIXES) else nid
+        candidates = _ids_by_body.get(_k, [])
+        return candidates[0] if len(candidates) == 1 else None
+
+    prefix_resolved = 0
     # Direction is part of the dedup key so a `forward` edge does not silently
     # overwrite a `bidirectional` one (or vice versa); they're different
     # semantic relationships that the dashboard renders distinctly.
@@ -880,6 +912,17 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
         etype = edge.get("type", "")
         direction = normalize_direction(edge.get("direction"))
         edge["direction"] = direction
+
+        if src not in node_ids or tgt not in node_ids:
+            resolved_src = resolve_prefix(src)
+            resolved_tgt = resolve_prefix(tgt)
+            if resolved_src is not None and resolved_tgt is not None:
+                if resolved_src != src:
+                    edge["source"] = src = resolved_src
+                    prefix_resolved += 1
+                if resolved_tgt != tgt:
+                    edge["target"] = tgt = resolved_tgt
+                    prefix_resolved += 1
 
         if src not in node_ids or tgt not in node_ids:
             missing = []
@@ -909,6 +952,8 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
             fixed_lines.append(f"  {count:>4} × complexity {pattern}")
     if edges_rewritten:
         fixed_lines.append(f"  {edges_rewritten:>4} × edge references rewritten after ID normalization")
+    if prefix_resolved:
+        fixed_lines.append(f"  {prefix_resolved:>4} × edge endpoints resolved to correct node-type prefix")
     if duplicate_count:
         fixed_lines.append(f"  {duplicate_count:>4} × duplicate node IDs removed (kept last)")
     if tested_by_swapped:
@@ -922,6 +967,7 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
             sum(id_fix_patterns.values())
             + sum(complexity_fix_patterns.values())
             + edges_rewritten
+            + prefix_resolved
             + duplicate_count
             + tested_by_swapped
             + tested_by_dropped


### PR DESCRIPTION
Fixes #628

## Problem

`merge-batch-graphs.py` silently drops cross-batch edges whose endpoint carries the wrong node-type prefix.

Each `file-analyzer` subagent picks the ID prefix for a node it owns (`file:` / `config:` / `document:` / `pipeline:` / `table:` / `schema:` / `endpoint:`). When batch A emits an edge pointing at a file that batch B classified, A has to **guess** that prefix — `batchImportData` and `neighborMap` only resolve project-internal *code imports*, so doc→pipeline, doc→config and config→code references have no ground truth.

Step 6 then compares IDs by exact equality and drops anything that doesn't match:

```python
if src not in node_ids or tgt not in node_ids:
    unfixable.append(f"Edge {src} → {tgt} ({etype}): dropped, missing ...")
    continue
```

Code files almost always end up as `file:`, so the loss lands entirely on the non-code node types — which is where the most valuable semantic edges live (`documents`, `triggers`, `configures`, `depends_on`).

The failure is quiet: the drop only reaches stderr, and the only consumer of that stderr in the pipeline is the optional Phase 3 `assemble-reviewer` LLM agent. Runs that skip it (or that don't read its output closely) lose the edges with no visible signal — the final graph just has fewer relationships than it should.

### Real-world impact

On a 205-file project (Next.js CRM + 46 SQL migrations + 17 n8n workflow docs + docs tree), a single `/understand` run had **25 edges** about to be dropped this way. **21 of them** were `documents` edges from `README.md` / `CLAUDE.md` / two other root docs → `pipeline:n8n-workflows/*.md` — the batch that owned the docs guessed `document:`, the batch that owned the workflow files chose `pipeline:`. That is the entire "which document describes which automation" map, gone.

The remaining 4 were `file:` vs `config:` (`next.config.ts`, a large JSON data file). Exactly **one** of the 26 reported drops was legitimate (a path referenced in a doc that no longer exists on disk).

## Fix

Before dropping, try to resolve the endpoint ignoring its prefix.

- Consulted **only** for IDs already headed for the drop — edges that resolve today take an unchanged path.
- Remaps **only** when exactly one node shares the ID body. If both `file:x.ts` and `config:x.ts` exist, the ID stays ambiguous and the edge is dropped and reported exactly as it is today.
- Therefore it cannot corrupt an edge that currently works; the worst case is the existing behaviour.

The count surfaces in the existing "Fixed" report section:

```
Fixed (25 corrections):
    25 × edge endpoints resolved to correct node-type prefix
```

## Tests

Adds `PrefixResolutionTests` to `tests/skill/understand/test_merge_batch_graphs.py` — six cases through `merge_and_normalize`, covering both the recovery and the guardrails:

| Edge target | Graph contains | Expected |
|---|---|---|
| `document:wf/a.md` | `pipeline:wf/a.md` | resolved |
| `config:src/x.ts` | `file:src/x.ts` | resolved |
| `document:ghost/nope.md` | — | **still dropped** |
| `document:amb/y.ts` | `file:amb/y.ts` **and** `config:amb/y.ts` | **still dropped** (ambiguous) |
| two resolvable edges | — | reported under "Fixed" |
| `pipeline:wf/a.md` (already valid) | `pipeline:wf/a.md` | untouched |

```
$ python -m unittest tests.skill.understand.test_merge_batch_graphs
Ran 86 tests in 0.61s
OK

$ python -m unittest tests.skill.understand.test_merge_subdomain_graphs
Ran 6 tests in 0.00s
OK
```

The diff is additive only (+130 / −0); no existing test changed.

Also run against the real 205-file project described above: 511 nodes, 1011 edges, 25 endpoints resolved, 1 legitimate drop remaining, and the resulting graph passes the Phase 6 inline validator with 0 issues.

## Notes

- No new dependencies, no signature changes, no behavioural change for graphs that currently merge cleanly.
- `VALID_NODE_PREFIXES` is reused for the prefix test rather than hardcoding a second list, so new node types are picked up automatically.
- An alternative fix would be to have `compute-batches.mjs` publish an authoritative `path → nodeType` map to every batch, so analyzers never have to guess. That's a bigger change; this one is the safety net regardless of whether that lands.
