### PR TITLE
feat: add CodeBuddy platform support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,10 @@ An open-source tool combining LLM intelligence + static analysis to produce inte
 `packages/viewer` serves a committed graph without Claude Code, via `npx <release-asset-url>`. Update it when (a) the dashboard UI changes — the tarball embeds the built `dist/` — or (b) the `vite.config.ts` dev-server middleware changes, which `bin/viewer.mjs` deliberately mirrors. On every release, repack (`pack:release` script) and re-upload the tarball to the GitHub release as `understand-anything-viewer.tgz` — exactly that name, the READMEs' `releases/latest/download/` URL depends on it.
 
 ## Versioning
-When pushing to remote, bump the version in **all six** of these files (keep them in sync):
+When pushing to remote, bump the version in **all seven** of these files (keep them in sync):
 - `understand-anything-plugin/package.json` → `"version"` field
 - `understand-anything-plugin/.claude-plugin/plugin.json` → `"version"` field
+- `understand-anything-plugin/.codebuddy-plugin/plugin.json` → `"version"` field
 - `understand-anything-plugin/packages/viewer/package.json` → `"version"` field
 - `.claude-plugin/plugin.json` → `"version"` field
 - `.cursor-plugin/plugin.json` → `"version"` field

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Understand-Anything works across multiple AI coding platforms.
 ```
 
 
-### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae / Nanobot / Kiro)
+### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae / Nanobot / Kiro / CodeBuddy)
 
 
 **macOS / Linux:**
@@ -217,7 +217,7 @@ The installer clones the repo to `~/.understand-anything/repo` and creates the r
 
 > **Note on invoking skills:** the invocation prefix differs per platform. Most platforms use slash commands (`/understand`), but **Codex uses `$` instead** — type `$understand`, not `/understand`. If neither prefix is recognized on your platform, just ask in plain language: *"Use the understand skill to analyze this project."*
 
-- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`
+- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`, `codebuddy`
 - Update later: `./install.sh --update`
 - Uninstall: `./install.sh --uninstall <platform>`
 
@@ -251,6 +251,24 @@ After installation:
 
 For personal skills (available across all projects), run the `install.sh` above with the `kiro` platform.
 
+### CodeBuddy
+
+CodeBuddy IDE and CodeBuddy Code auto-discover the plugin via `.codebuddy-plugin/plugin.json` (bundled inside `understand-anything-plugin/`) when this repo is cloned. No manual installation needed — just clone and open in CodeBuddy.
+
+Alternatively, install for personal use (available across all projects) with the one-liner:
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/install.sh | bash -s codebuddy
+```
+
+**Windows (PowerShell):**
+```powershell
+.\install.ps1 codebuddy
+```
+
+After installation, restart CodeBuddy and run `/understand` to analyze your project.
+
 ### Platform Compatibility
 
 | Platform | Status | Install Method |
@@ -272,6 +290,7 @@ For personal skills (available across all projects), run the `install.sh` above 
 | Trae | ✅ Supported | `install.sh trae` |
 | Nanobot | ✅ Supported | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ Supported | `install.sh kiro` |
+| CodeBuddy | ✅ Supported | `install.sh codebuddy` |
 
 
 ---

--- a/READMEs/README.es-ES.md
+++ b/READMEs/README.es-ES.md
@@ -185,7 +185,7 @@ Understand-Anything funciona en múltiples plataformas de codificación con IA.
 /plugin install understand-anything
 ```
 
-### Instalación de una línea (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro)
+### Instalación de una línea (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro / CodeBuddy)
 
 **macOS / Linux:**
 ```bash
@@ -203,7 +203,7 @@ El instalador clona el repositorio en `~/.understand-anything/repo` y crea los e
 
 > **Nota sobre cómo invocar las skills:** el prefijo de invocación varía según la plataforma. La mayoría usa comandos con barra (`/understand`), pero **Codex usa `$`** — escribe `$understand`, no `/understand`. Si ningún prefijo funciona, pídelo en lenguaje natural: *«Usa la skill understand para analizar este proyecto»*.
 
-- Valores soportados de `<platform>`: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `nanobot`, `kiro`
+- Valores soportados de `<platform>`: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `nanobot`, `kiro`, `codebuddy`
 - Actualizar más adelante: `./install.sh --update`
 - Desinstalar: `./install.sh --uninstall <platform>`
 
@@ -237,6 +237,24 @@ Tras la instalación:
 
 Para habilidades personales (disponibles en todos los proyectos), ejecuta el `install.sh` de arriba con la plataforma `kiro`.
 
+### CodeBuddy
+
+CodeBuddy IDE y CodeBuddy Code detectan automáticamente el plugin a través de `.codebuddy-plugin/plugin.json` (incluido dentro de `understand-anything-plugin/`) cuando se clona este repositorio. No requiere instalación manual: simplemente clona y abre en CodeBuddy.
+
+Alternativamente, instálalo para uso personal (disponible en todos los proyectos) con la instalación de una línea:
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/install.sh | bash -s codebuddy
+```
+
+**Windows (PowerShell):**
+```powershell
+.\install.ps1 codebuddy
+```
+
+Tras la instalación, reinicia CodeBuddy y ejecuta `/understand` para analizar tu proyecto.
+
 ### Compatibilidad de Plataformas
 
 | Plataforma | Estado | Método de Instalación |
@@ -257,6 +275,7 @@ Para habilidades personales (disponibles en todos los proyectos), ejecuta el `in
 | KIMI CLI | ✅ Soportado | `install.sh kimi` |
 | Nanobot | ✅ Soportado | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ Soportado | `install.sh kiro` |
+| CodeBuddy | ✅ Soportado | `install.sh codebuddy` |
 
 ---
 

--- a/READMEs/README.ja-JP.md
+++ b/READMEs/README.ja-JP.md
@@ -197,7 +197,7 @@ Understand-Anythingは複数のAIコーディングプラットフォームで�
 /plugin install understand-anything
 ```
 
-### ワンラインインストール（Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae / Nanobot / Kiro）
+### ワンラインインストール（Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae / Nanobot / Kiro / CodeBuddy）
 
 **macOS / Linux：**
 ```bash
@@ -215,7 +215,7 @@ iwr -useb https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/i
 
 > **スキルの呼び出し方について：** 呼び出しのプレフィックスはプラットフォームごとに異なります。多くのプラットフォームはスラッシュコマンド（`/understand`）を使いますが、**Codexは`$`を使います** — `/understand`ではなく`$understand`と入力してください。どちらのプレフィックスも認識されない場合は、*「understandスキルを使ってこのプロジェクトを分析して」*のように自然言語で依頼できます。
 
-- サポートされる `<platform>` 値：`gemini`、`codex`、`opencode`、`pi`、`openclaw`、`antigravity`、`vibe`、`vscode`、`hermes`、`cline`、`kimi`、`trae`、`nanobot`、`kiro`
+- サポートされる `<platform>` 値：`gemini`、`codex`、`opencode`、`pi`、`openclaw`、`antigravity`、`vibe`、`vscode`、`hermes`、`cline`、`kimi`、`trae`、`nanobot`、`kiro`、`codebuddy`
 - 後で更新：`./install.sh --update`
 - アンインストール：`./install.sh --uninstall <platform>`
 
@@ -249,6 +249,24 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 全プロジェクトで使用するパーソナルスキルとして導入したい場合は、上記の `install.sh` を `kiro` プラットフォームで実行してください。
 
+### CodeBuddy
+
+CodeBuddy IDE と CodeBuddy Code は、このリポジトリをクローンすると `understand-anything-plugin/` 内に同梱されている `.codebuddy-plugin/plugin.json` を通じてプラグインを自動検出します。手動インストールは不要です — クローンして CodeBuddy で開くだけです。
+
+または、すべてのプロジェクトで使用できるパーソナルスキルとして、ワンラインインストールで導入することもできます：
+
+**macOS / Linux：**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/install.sh | bash -s codebuddy
+```
+
+**Windows（PowerShell）：**
+```powershell
+.\install.ps1 codebuddy
+```
+
+インストール後、CodeBuddy を再起動して `/understand` を実行するとプロジェクトを分析できます。
+
 ### プラットフォーム互換性
 
 | プラットフォーム | ステータス | インストール方法 |
@@ -270,6 +288,7 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 | Trae | ✅ サポート | `install.sh trae` |
 | Nanobot | ✅ サポート | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ サポート | `install.sh kiro` |
+| CodeBuddy | ✅ サポート | `install.sh codebuddy` |
 
 ---
 

--- a/READMEs/README.ko-KR.md
+++ b/READMEs/README.ko-KR.md
@@ -185,7 +185,7 @@ Understand-Anything은 다양한 AI 코딩 플랫폼에서 사용할 수 있습�
 /plugin install understand-anything
 ```
 
-### 한 줄 설치 (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro)
+### 한 줄 설치 (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro / CodeBuddy)
 
 **macOS / Linux:**
 ```bash
@@ -203,7 +203,7 @@ iwr -useb https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/i
 
 > **스킬 호출 방식 안내:** 호출 접두사는 플랫폼마다 다릅니다. 대부분의 플랫폼은 슬래시 명령(`/understand`)을 사용하지만, **Codex는 `$`를 사용합니다** — `/understand`가 아니라 `$understand`를 입력하세요. 두 접두사 모두 인식되지 않으면 *"understand 스킬로 이 프로젝트를 분석해 줘"* 처럼 자연어로 요청하면 됩니다.
 
-- 지원되는 `<platform>` 값: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `nanobot`, `kiro`
+- 지원되는 `<platform>` 값: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `nanobot`, `kiro`, `codebuddy`
 - 이후 업데이트: `./install.sh --update`
 - 제거: `./install.sh --uninstall <platform>`
 
@@ -237,6 +237,24 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 모든 프로젝트에서 사용하는 개인 스킬로 설치하려면 위 `install.sh`를 `kiro` 플랫폼으로 실행하세요.
 
+### CodeBuddy
+
+이 저장소를 클론하면 CodeBuddy IDE와 CodeBuddy Code가 `understand-anything-plugin/`에 번들된 `.codebuddy-plugin/plugin.json`을 통해 플러그인을 자동으로 인식합니다. 수동 설치가 필요 없습니다. 클론 후 CodeBuddy에서 열기만 하면 됩니다.
+
+또는 모든 프로젝트에서 사용할 수 있는 개인 스킬로 한 줄 설치를 사용할 수도 있습니다:
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/install.sh | bash -s codebuddy
+```
+
+**Windows (PowerShell):**
+```powershell
+.\install.ps1 codebuddy
+```
+
+설치 후 CodeBuddy를 재시작하고 `/understand`를 실행하여 프로젝트를 분석하세요.
+
 ### 플랫폼 호환성
 
 | 플랫폼 | 상태 | 설치 방법 |
@@ -257,6 +275,7 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 | KIMI CLI | ✅ 지원 | `install.sh kimi` |
 | Nanobot | ✅ 지원 | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ 지원 | `install.sh kiro` |
+| CodeBuddy | ✅ 지원 | `install.sh codebuddy` |
 
 ---
 

--- a/READMEs/README.ru-RU.md
+++ b/READMEs/README.ru-RU.md
@@ -186,7 +186,7 @@ Understand-Anything работает с несколькими платформ�
 /plugin install understand-anything
 ```
 
-### Установка одной командой (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro)
+### Установка одной командой (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro / CodeBuddy)
 
 **macOS / Linux:**
 ```bash
@@ -204,7 +204,7 @@ iwr -useb https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/i
 
 > **Как вызывать skills:** префикс вызова зависит от платформы. Большинство платформ используют слэш-команды (`/understand`), но **Codex использует `$`** — вводите `$understand`, а не `/understand`. Если ни один префикс не распознаётся, просто попросите обычным языком: *«Используй skill understand, чтобы проанализировать этот проект»*.
 
-- Поддерживаемые значения `<platform>`: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `nanobot`, `kiro`
+- Поддерживаемые значения `<platform>`: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `nanobot`, `kiro`, `codebuddy`
 - Обновление: `./install.sh --update`
 - Удаление: `./install.sh --uninstall <platform>`
 
@@ -238,6 +238,24 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 Для персональных skills (доступных во всех проектах) запустите `install.sh` выше с платформой `kiro`.
 
+### CodeBuddy
+
+CodeBuddy IDE и CodeBuddy Code автоматически обнаруживают плагин через `.codebuddy-plugin/plugin.json` (встроен в `understand-anything-plugin/`) при клонировании этого репозитория. Ручная установка не требуется — просто склонируйте и откройте в CodeBuddy.
+
+Либо установите для личного использования (доступно во всех проектах) одной командой:
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/install.sh | bash -s codebuddy
+```
+
+**Windows (PowerShell):**
+```powershell
+.\install.ps1 codebuddy
+```
+
+После установки перезапустите CodeBuddy и выполните `/understand` для анализа вашего проекта.
+
 ### Совместимость с платформами
 
 | Платформа | Статус | Способ установки |
@@ -258,6 +276,7 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 | KIMI CLI | ✅ Поддерживается | `install.sh kimi` |
 | Nanobot | ✅ Поддерживается | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ Поддерживается | `install.sh kiro` |
+| CodeBuddy | ✅ Поддерживается | `install.sh codebuddy` |
 
 ---
 

--- a/READMEs/README.tr-TR.md
+++ b/READMEs/README.tr-TR.md
@@ -186,7 +186,7 @@ Understand-Anything birden fazla AI kodlama platformunda çalışır.
 /plugin install understand-anything
 ```
 
-### Tek satırlık kurulum (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro)
+### Tek satırlık kurulum (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro / CodeBuddy)
 
 **macOS / Linux:**
 ```bash
@@ -204,7 +204,7 @@ Kurulum betiği depoyu `~/.understand-anything/repo` dizinine klonlar ve seçile
 
 > **Skill çağırma hakkında not:** Çağırma öneki platforma göre değişir. Çoğu platform eğik çizgi komutları (`/understand`) kullanır, ancak **Codex `$` kullanır** — `/understand` değil, `$understand` yaz. İki önek de tanınmıyorsa doğal dille iste: *"understand skill'ini kullanarak bu projeyi analiz et."*
 
-- Desteklenen `<platform>` değerleri: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `nanobot`, `kiro`
+- Desteklenen `<platform>` değerleri: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `nanobot`, `kiro`, `codebuddy`
 - Daha sonra güncelle: `./install.sh --update`
 - Kaldır: `./install.sh --uninstall <platform>`
 
@@ -238,6 +238,24 @@ Kurulumdan sonra:
 
 Tüm projelerde kullanmak için kişisel beceri olarak kurmak istersen yukarıdaki `install.sh`'ı `kiro` platformuyla çalıştır.
 
+### CodeBuddy
+
+Bu depo klonlandığında CodeBuddy IDE ve CodeBuddy Code, `understand-anything-plugin/` içine gömülü `.codebuddy-plugin/plugin.json` aracılığıyla eklentiyi otomatik olarak keşfeder. Manuel kurulum gerekmez — sadece klonla ve CodeBuddy'de aç.
+
+Alternatif olarak, kişisel kullanım için (tüm projelerde kullanılabilir) tek satırlık kurulumla da yükleyebilirsin:
+
+**macOS / Linux:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/install.sh | bash -s codebuddy
+```
+
+**Windows (PowerShell):**
+```powershell
+.\install.ps1 codebuddy
+```
+
+Kurulumdan sonra CodeBuddy'yi yeniden başlat ve projeyi analiz etmek için `/understand` komutunu çalıştır.
+
 ### Platform Uyumluluğu
 
 | Platform | Durum | Kurulum Yöntemi |
@@ -258,6 +276,7 @@ Tüm projelerde kullanmak için kişisel beceri olarak kurmak istersen yukarıda
 | KIMI CLI | ✅ Destekleniyor | `install.sh kimi` |
 | Nanobot | ✅ Destekleniyor | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ Destekleniyor | `install.sh kiro` |
+| CodeBuddy | ✅ Destekleniyor | `install.sh codebuddy` |
 
 ---
 

--- a/READMEs/README.zh-CN.md
+++ b/READMEs/README.zh-CN.md
@@ -185,7 +185,7 @@ Understand-Anything 可在多个 AI 编码平台上运行。
 /plugin install understand-anything
 ```
 
-### 一行命令安装（Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro）
+### 一行命令安装（Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro / CodeBuddy）
 
 **macOS / Linux：**
 ```bash
@@ -203,7 +203,7 @@ iwr -useb https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/i
 
 > **关于技能调用方式：** 不同平台的调用前缀不同。大多数平台使用斜杠命令（`/understand`），但 **Codex 使用 `$`** —— 请输入 `$understand`，而不是 `/understand`。如果两种前缀都不被识别，直接用自然语言请求即可：*“使用 understand 技能分析这个项目”*。
 
-- 支持的 `<platform>` 取值：`gemini`、`codex`、`opencode`、`pi`、`openclaw`、`antigravity`、`vibe`、`vscode`、`hermes`、`cline`、`kimi`、`nanobot`、`kiro`
+- 支持的 `<platform>` 取值：`gemini`、`codex`、`opencode`、`pi`、`openclaw`、`antigravity`、`vibe`、`vscode`、`hermes`、`cline`、`kimi`、`nanobot`、`kiro`、`codebuddy`
 - 后续更新：`./install.sh --update`
 - 卸载：`./install.sh --uninstall <platform>`
 
@@ -237,6 +237,24 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 若需要在所有项目中使用（个人技能），运行上面的 `install.sh` 并选择 `kiro` 平台即可。
 
+### CodeBuddy
+
+CodeBuddy IDE 和 CodeBuddy Code 会在克隆此仓库后，通过内置在 `understand-anything-plugin/` 中的 `.codebuddy-plugin/plugin.json` 自动发现插件。无需手动安装 — 只需克隆并在 CodeBuddy 中打开即可。
+
+也可以运行下面的安装脚本，将其作为个人技能安装（所有项目可用）：
+
+**macOS / Linux：**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/install.sh | bash -s codebuddy
+```
+
+**Windows（PowerShell）：**
+```powershell
+.\install.ps1 codebuddy
+```
+
+安装完成后，重启 CodeBuddy 并运行 `/understand` 分析你的项目。
+
 ### 多平台兼容
 
 | 平台 | 状态 | 安装方式 |
@@ -257,6 +275,7 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 | KIMI CLI | ✅ 支持 | `install.sh kimi` |
 | Nanobot | ✅ 支持 | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ 支持 | `install.sh kiro` |
+| CodeBuddy | ✅ 支持 | `install.sh codebuddy` |
 
 ---
 

--- a/READMEs/README.zh-TW.md
+++ b/READMEs/README.zh-TW.md
@@ -185,7 +185,7 @@ Understand-Anything 可在多個 AI 編碼平台上執行。
 /plugin install understand-anything
 ```
 
-### 一行指令安裝（Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro）
+### 一行指令安裝（Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Nanobot / Kiro / CodeBuddy）
 
 **macOS / Linux：**
 ```bash
@@ -203,7 +203,7 @@ iwr -useb https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/i
 
 > **關於技能呼叫方式：** 不同平台的呼叫前綴不同。大多數平台使用斜線指令（`/understand`），但 **Codex 使用 `$`** —— 請輸入 `$understand`，而不是 `/understand`。如果兩種前綴都無法辨識，直接用自然語言請求即可：*「使用 understand 技能分析這個專案」*。
 
-- 支援的 `<platform>` 取值：`gemini`、`codex`、`opencode`、`pi`、`openclaw`、`antigravity`、`vibe`、`vscode`、`hermes`、`cline`、`kimi`、`nanobot`、`kiro`
+- 支援的 `<platform>` 取值：`gemini`、`codex`、`opencode`、`pi`、`openclaw`、`antigravity`、`vibe`、`vscode`、`hermes`、`cline`、`kimi`、`nanobot`、`kiro`、`codebuddy`
 - 後續更新：`./install.sh --update`
 - 解除安裝：`./install.sh --uninstall <platform>`
 
@@ -237,6 +237,24 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 若需要在所有專案中使用（個人技能），執行上面的 `install.sh` 並選擇 `kiro` 平台即可。
 
+### CodeBuddy
+
+CodeBuddy IDE 與 CodeBuddy Code 會在複製此儲存庫後，透過內建在 `understand-anything-plugin/` 中的 `.codebuddy-plugin/plugin.json` 自動發現外掛程式。無需手動安裝 — 只需複製並在 CodeBuddy 中開啟即可。
+
+也可以執行下面的安裝指令稿，將其作為個人技能安裝（所有專案可用）：
+
+**macOS / Linux：**
+```bash
+curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/install.sh | bash -s codebuddy
+```
+
+**Windows（PowerShell）：**
+```powershell
+.\install.ps1 codebuddy
+```
+
+安裝完成後，重新啟動 CodeBuddy 並執行 `/understand` 分析你的專案。
+
 ### 多平台相容性
 
 | 平台 | 狀態 | 安裝方式 |
@@ -257,6 +275,7 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 | KIMI CLI | ✅ 支援 | `install.sh kimi` |
 | Nanobot | ✅ 支援 | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ 支援 | `install.sh kiro` |
+| CodeBuddy | ✅ 支援 | `install.sh codebuddy` |
 
 ---
 

--- a/homepage/src/components/Install.astro
+++ b/homepage/src/components/Install.astro
@@ -17,7 +17,7 @@
 <span class="cmd">/plugin install</span> understand-anything
 <span class="cmd">/understand</span></code></pre>
     </div>
-    <p class="install-note">Works with <strong>Claude Code</strong>, <strong>Codex</strong>, <strong>OpenCode</strong>, <strong>Gemini CLI</strong>, and more.</p>
+    <p class="install-note">Works with <strong>Claude Code</strong>, <strong>Codex</strong>, <strong>OpenCode</strong>, <strong>Gemini CLI</strong>, <strong>CodeBuddy</strong>, and more.</p>
   </div>
 </section>
 

--- a/install.ps1
+++ b/install.ps1
@@ -36,6 +36,7 @@ $Platforms = [ordered]@{
     antigravity = @{ Target = (Join-Path $HOME '.gemini\antigravity\skills'); Style = 'folder' }
     vibe        = @{ Target = (Join-Path $HOME '.vibe\skills');               Style = 'per-skill' }
     vscode      = @{ Target = (Join-Path $HOME '.copilot\skills');            Style = 'per-skill' }
+    codebuddy   = @{ Target = (Join-Path $HOME '.codebuddy\skills');          Style = 'per-skill' }
     hermes      = @{ Target = (Join-Path $HOME '.hermes\skills');             Style = 'folder' }
     cline       = @{ Target = (Join-Path $HOME '.cline\skills');              Style = 'folder' }
     kimi        = @{ Target = (Join-Path $HOME '.kimi\skills');               Style = 'folder' }
@@ -244,6 +245,9 @@ function Cmd-Install([string]$Id) {
     }
     if ($Id -eq 'kiro') {
         Write-Host "`n  Usage: kiro-cli chat --agent understand `"Analyze this project`""
+    }
+    if ($Id -eq 'codebuddy') {
+        Write-Host "`n  Usage: In CodeBuddy, run /understand to analyze the current project."
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -36,6 +36,7 @@ openclaw|$HOME/.openclaw/skills|folder
 antigravity|$HOME/.gemini/antigravity/skills|folder
 vibe|$HOME/.vibe/skills|per-skill
 vscode|$HOME/.copilot/skills|per-skill
+codebuddy|$HOME/.codebuddy/skills|per-skill
 hermes|$HOME/.hermes/skills|folder
 cline|$HOME/.cline/skills|folder
 kimi|$HOME/.kimi/skills|folder
@@ -231,6 +232,9 @@ KIROEOF
   fi
   if [[ "$id" == "kiro" ]]; then
     printf '\n  Usage: kiro-cli chat --agent understand "Analyze this project"\n'
+  fi
+  if [[ "$id" == "codebuddy" ]]; then
+    printf '\n  Usage: In CodeBuddy, run /understand to analyze the current project.\n'
   fi
 }
 

--- a/understand-anything-plugin/.codebuddy-plugin/plugin.json
+++ b/understand-anything-plugin/.codebuddy-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "understand-anything",
+  "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
+  "version": "2.9.0",
+  "author": {
+    "name": "Egonex"
+  },
+  "homepage": "https://github.com/Egonex-AI/Understand-Anything",
+  "repository": "https://github.com/Egonex-AI/Understand-Anything",
+  "license": "MIT",
+  "keywords": [
+    "codebase-analysis",
+    "knowledge-graph",
+    "architecture",
+    "onboarding",
+    "dashboard"
+  ]
+}


### PR DESCRIPTION
## Summary

Add native CodeBuddy support: introduce a `.codebuddy-plugin/plugin.json`
plugin manifest so CodeBuddy IDE / CodeBuddy Code auto-discover the plugin
when the repo is cloned, and register `codebuddy` as an installable platform
in `install.sh` / `install.ps1` (skills link into `~/.codebuddy/skills`).
Documentation updated across `README.md`, all 7 localized READMEs, the
homepage install section, and the `CLAUDE.md` version-sync list.

## Linked issue(s)

<!-- Leave empty — no tracking issue. -->

## How I tested this

- [x] `pnpm lint`
- [x] `pnpm --filter @understand-anything/core test`
- [x] `pnpm test`
- [x] Manual smoke test (describe above)

Local verification (Node 22.14.0 / pnpm 10.6.2, matching the
`packageManager` pin):

- `pnpm lint` — 0 ESLint errors
- `pnpm --filter @understand-anything/core test` — 46 files / 976 tests passed
- `pnpm test` — all assertions pass (490+ passed, 15 skipped). A single
  vitest worker timeout occurred under full-suite concurrency on Windows;
  the affected file (`test_extract_import_map.test.mjs`) passes 60/60 in
  isolation. No source or test files are touched by this PR.
- `understand-anything-plugin/.codebuddy-plugin/plugin.json` validated as
  well-formed JSON, matching the existing `.claude-plugin/plugin.json` shape
- `install.ps1` parses cleanly (PowerShell syntax parser)
- `install.sh` / `install.ps1` platform tables dry-run checked
  (`codebuddy` → `~/.codebuddy/skills`, per-skill style)
- All 8 READMEs (en + 7 locales) updated consistently; each shows the new
  CodeBuddy row and installation section

## Versioning

- [ ] Version bumped in all five manifests, OR
- [x] N/A — internal/docs-only change
