### PR TITLE
feat: add freebuff platform to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The installer clones the repo to `~/.understand-anything/repo` and creates the r
 
 > **Note on invoking skills:** the invocation prefix differs per platform. Most platforms use slash commands (`/understand`), but **Codex uses `$` instead** — type `$understand`, not `/understand`. If neither prefix is recognized on your platform, just ask in plain language: *"Use the understand skill to analyze this project."*
 
-- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`
+- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`, `freebuff`
 - Update later: `./install.sh --update`
 - Uninstall: `./install.sh --uninstall <platform>`
 
@@ -251,6 +251,14 @@ After installation:
 
 For personal skills (available across all projects), run the `install.sh` above with the `kiro` platform.
 
+### Freebuff
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/install.sh | bash -s freebuff
+```
+
+Freebuff reads its skills from `~/.agents/skills/`, so the installer symlinks each understand-* skill there (same layout as `codex`/`gemini`). Restart Freebuff or start a new session to pick up the skills.
+
 ### Platform Compatibility
 
 | Platform | Status | Install Method |
@@ -272,6 +280,7 @@ For personal skills (available across all projects), run the `install.sh` above 
 | Trae | ✅ Supported | `install.sh trae` |
 | Nanobot | ✅ Supported | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ Supported | `install.sh kiro` |
+| Freebuff | ✅ Supported | `install.sh freebuff` |
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ curl -fsSL https://raw.githubusercontent.com/Egonex-AI/Understand-Anything/main/
 
 Freebuff reads its skills from `~/.agents/skills/`, so the installer symlinks each understand-* skill there (same layout as `codex`/`gemini`). Restart Freebuff or start a new session to pick up the skills.
 
+On Windows, run the PowerShell installer and choose `freebuff` (or pass it directly: `./install.ps1 freebuff`).
+
 ### Platform Compatibility
 
 | Platform | Status | Install Method |

--- a/install.ps1
+++ b/install.ps1
@@ -42,6 +42,7 @@ $Platforms = [ordered]@{
     trae        = @{ Target = (Join-Path $HOME '.trae\skills');               Style = 'per-skill' }
     nanobot     = @{ Target = (Join-Path $HOME '.nanobot\workspace\skills');  Style = 'per-skill' }
     kiro        = @{ Target = (Join-Path $HOME '.kiro\skills');               Style = 'per-skill' }
+    freebuff    = @{ Target = (Join-Path $HOME '.agents\skills');             Style = 'per-skill' }
 }
 
 function Show-Usage {

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,7 @@ kimi|$HOME/.kimi/skills|folder
 trae|$HOME/.trae/skills|per-skill
 nanobot|$HOME/.nanobot/workspace/skills|per-skill
 kiro|$HOME/.kiro/skills|per-skill
+freebuff|$HOME/.agents/skills|per-skill
 EOF
 }
 


### PR DESCRIPTION
Adds the `freebuff` platform to `install.sh` (per-skill symlink layout into `~/.agents/skills/`, same as `codex`/`gemini`) plus README docs (supported values, install section, compatibility table).

Freebuff reads skills from `~/.agents/skills/`, so no new installer logic is needed beyond a platform-table row.