### PR TITLE
Add CodeBuddy platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Understand-Anything works across multiple AI coding platforms.
 ```
 
 
-### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae / Nanobot / Kiro)
+### One-line install (Codex / OpenCode / OpenClaw / Antigravity / Gemini CLI / Pi Agent / Vibe CLI / VS Code Copilot / Hermes / Cline / KIMI CLI / Trae / Nanobot / Kiro / CodeBuddy)
 
 
 **macOS / Linux:**
@@ -217,7 +217,7 @@ The installer clones the repo to `~/.understand-anything/repo` and creates the r
 
 > **Note on invoking skills:** the invocation prefix differs per platform. Most platforms use slash commands (`/understand`), but **Codex uses `$` instead** — type `$understand`, not `/understand`. If neither prefix is recognized on your platform, just ask in plain language: *"Use the understand skill to analyze this project."*
 
-- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`
+- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`, `codebuddy`
 - Update later: `./install.sh --update`
 - Uninstall: `./install.sh --uninstall <platform>`
 
@@ -272,6 +272,7 @@ For personal skills (available across all projects), run the `install.sh` above 
 | Trae | ✅ Supported | `install.sh trae` |
 | Nanobot | ✅ Supported | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ Supported | `install.sh kiro` |
+| CodeBuddy | ✅ Supported | `install.sh codebuddy` |
 
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,7 @@ kimi|$HOME/.kimi/skills|folder
 trae|$HOME/.trae/skills|per-skill
 nanobot|$HOME/.nanobot/workspace/skills|per-skill
 kiro|$HOME/.kiro/skills|per-skill
+codebuddy|$HOME/.codebuddy/skills|per-skill
 EOF
 }
 
@@ -231,6 +232,10 @@ KIROEOF
   fi
   if [[ "$id" == "kiro" ]]; then
     printf '\n  Usage: kiro-cli chat --agent understand "Analyze this project"\n'
+  fi
+  if [[ "$id" == "codebuddy" ]]; then
+    printf '\n  Usage: type /understand (or @command://understand) in CodeBuddy to analyze a project.\n'
+    printf '         Restart the CodeBuddy window if the skills are not picked up immediately.\n'
   fi
 }
 


### PR DESCRIPTION
## Summary
- `install.sh`: add a `codebuddy` platform row (`~/.codebuddy/skills`, per-skill layout) and a CodeBuddy-specific usage tip.
- `README.md`: list CodeBuddy in the one-line install heading, the supported `<platform>` values, and the Platform Compatibility table.

## Why
CodeBuddy discovers per-skill plugins under `~/.codebuddy/skills/<name>/SKILL.md`, the same layout as `gemini`/`codex`, so no extra adapter is required — only a different symlink target.

## Verified
`bash install.sh codebuddy` correctly symlinks all 9 skills (`understand`, `understand-chat`, `understand-dashboard`, `understand-diff`, `understand-domain`, `understand-explain`, `understand-onboard`, `understand-knowledge`, `understand-figma`) and each `SKILL.md` resolves.

## Usage
In CodeBuddy, type `/understand` (or `@command://understand`), then restart the window to pick up the skills.
