### PR TITLE
fix(skills): correct argument-hint formatting in SKILL.md

### DIFF
--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand
 description: Analyze a codebase to produce an interactive knowledge graph for understanding architecture, components, and relationships
-argument-hint: ["[path] [--full|--auto-update|--no-auto-update|--review|--language <lang>|--exclude <patterns>]"]
+argument-hint: "[path] [--full|--auto-update|--no-auto-update|--review|--language <lang>|--exclude <patterns>]"
 ---
 
 # /understand


### PR DESCRIPTION
## Summary

<!-- One or two sentences on what this PR changes and why. -->
fix(skills): correct argument-hint formatting in SKILL.md

<img width="1262" height="197" alt="image" src="https://github.com/user-attachments/assets/7c294468-ec89-4c64-bf93-e51598f59d64" />


## Linked issue(s)

<!-- e.g. Closes #123, Refs #456. Leave empty if there's no tracking issue. -->
#638 
## How I tested this

<!-- Concrete steps. "Ran the test suite" is fine; "Ran /understand on a 3k-file
Swift repo and verified the dashboard shows non-empty edges" is better. -->

- [ ] `pnpm lint`
- [ ] `pnpm --filter @understand-anything/core test`
- [ ] `pnpm test`
- [x] Manual smoke test (describe above)

## Versioning

<!-- If this PR ships a user-visible behavior change, bump the version in ALL
five manifests per CLAUDE.md. If it's docs/tests/internal-only, leave them
alone and the maintainer will bump on merge. -->

- [x] Version bumped in all five manifests, OR
- [ ] N/A — internal/docs-only change
