### PR TITLE
feat: add Haskell language support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.9.4",
+  "version": "2.10.0",
   "author": {
     "name": "Egonex"
   },

--- a/.copilot-plugin/plugin.json
+++ b/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.9.4",
+  "version": "2.10.0",
   "author": {
     "name": "Egonex"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "understand-anything",
   "displayName": "Understand Anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.9.4",
+  "version": "2.10.0",
   "author": {
     "name": "Egonex"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       tree-sitter-go:
         specifier: ^0.25.0
         version: 0.25.0
+      tree-sitter-haskell:
+        specifier: ^0.23.1
+        version: 0.23.1
       tree-sitter-java:
         specifier: ^0.23.5
         version: 0.23.5
@@ -2879,6 +2882,14 @@ packages:
     resolution: {integrity: sha512-APBc/Dq3xz/e35Xpkhb1blu5UgW+2E3RyGWawZSCNcbGwa7jhSQPS8KsUupuzBla8PCo8+lz9W/JDJjmfRa2tw==}
     peerDependencies:
       tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-haskell@0.23.1:
+    resolution: {integrity: sha512-qG4CYhejveu9DLMLEGBz/n9/TTeGSFLC6wniwOgG6m8/v7Dng8qR0ob0EVG7+XH+9WiOxohpGA23EhceWuxY4w==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
     peerDependenciesMeta:
       tree-sitter:
         optional: true
@@ -6310,6 +6321,11 @@ snapshots:
       tree-sitter-c: 0.23.6
 
   tree-sitter-go@0.25.0:
+    dependencies:
+      node-addon-api: 8.6.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-haskell@0.23.1:
     dependencies:
       node-addon-api: 8.6.0
       node-gyp-build: 4.8.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ allowBuilds:
   tree-sitter-c-sharp: true
   tree-sitter-cpp: true
   tree-sitter-go: true
+  tree-sitter-haskell: true
   tree-sitter-java: true
   tree-sitter-javascript: true
   tree-sitter-php: true

--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -1057,6 +1057,55 @@ describe('extract-import-map.mjs — Scala resolver', () => {
   });
 });
 
+describe('extract-import-map.mjs — Haskell resolver', () => {
+  let projectRoot;
+
+  afterEach(() => {
+    if (projectRoot) {
+      rmSync(projectRoot, { recursive: true, force: true });
+      projectRoot = null;
+    }
+  });
+
+  it('resolves declared modules and drops package imports', () => {
+    projectRoot = setupTree({
+      'src/App/Main.hs': `module App.Main where\nimport Project.Types\nimport qualified Project.Util as Util\nimport Data.Text (Text)\nmain = Util.run\n`,
+      'src/Project/Types.hs': `module Project.Types (User(..)) where\ndata User = User String\n`,
+      'src/Project/Util.hs': `module Project.Util where\nrun = pure ()\n`,
+    });
+    const files = [
+      { path: 'src/App/Main.hs', language: 'haskell', fileCategory: 'code' },
+      { path: 'src/Project/Types.hs', language: 'haskell', fileCategory: 'code' },
+      { path: 'src/Project/Util.hs', language: 'haskell', fileCategory: 'code' },
+    ];
+
+    const result = runScript(projectRoot, { projectRoot, files });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['src/App/Main.hs']).toEqual([
+      'src/Project/Types.hs',
+      'src/Project/Util.hs',
+    ]);
+  });
+
+  it('chooses the nearest duplicate Main module deterministically', () => {
+    projectRoot = setupTree({
+      'app/Runner.hs': `module Runner where\nimport Main\nrun = main\n`,
+      'app/Main.hs': `module Main where\nmain = pure ()\n`,
+      'test/Main.hs': `module Main where\nmain = pure ()\n`,
+    });
+    const files = [
+      { path: 'app/Runner.hs', language: 'haskell', fileCategory: 'code' },
+      { path: 'app/Main.hs', language: 'haskell', fileCategory: 'code' },
+      { path: 'test/Main.hs', language: 'haskell', fileCategory: 'code' },
+    ];
+
+    const result = runScript(projectRoot, { projectRoot, files });
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['app/Runner.hs']).toEqual(['app/Main.hs']);
+  });
+});
+
 describe('extract-import-map.mjs — C# resolver', () => {
   let projectRoot;
 

--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -116,9 +116,27 @@ class IsTestPathTests(unittest.TestCase):
         self.assertTrue(mbg.is_test_path("src/test/scala/com/foo/BarTests.scala"))
 
     def test_haskell_test_files(self) -> None:
-        self.assertTrue(mbg.is_test_path("test/Spanshot/CaptureSpec.hs"))
-        self.assertTrue(mbg.is_test_path("test/Spanshot/CaptureTest.hs"))
-        self.assertTrue(mbg.is_test_path("test/Spanshot/CaptureTests.hs"))
+        for path in [
+            "test/Spanshot/CaptureSpec.hs",
+            "test/Spanshot/CaptureTest.hs",
+            "test/Spanshot/CaptureTests.hs",
+            "test/Spanshot/CaptureSpec.lhs",
+            "test/Spanshot/CaptureTest.lhs",
+            "test/Spanshot/CaptureTests.lhs",
+            "test/Main.hs",
+            "tests/Main.hs",
+            "test/Main.lhs",
+            "tests/Main.lhs",
+        ]:
+            with self.subTest(path=path):
+                self.assertTrue(mbg.is_test_path(path), f"{path} should be a test")
+
+        for path in ["Main.hs", "src/Main.hs", "Main.lhs", "src/Main.lhs"]:
+            with self.subTest(path=path):
+                self.assertFalse(
+                    mbg.is_test_path(path),
+                    f"{path} should remain production",
+                )
 
     def test_csharp_test_files(self) -> None:
         self.assertTrue(mbg.is_test_path("Foo.Tests/BarTests.cs"))
@@ -224,6 +242,11 @@ class ProductionCandidatesTests(unittest.TestCase):
     def test_haskell_cabal_layout(self) -> None:
         cands = mbg.production_candidates("test/Spanshot/CaptureSpec.hs")
         self.assertIn("src/Spanshot/Capture.hs", cands)
+
+    def test_literate_haskell_cabal_layout(self) -> None:
+        cands = mbg.production_candidates("test/Spanshot/CaptureSpec.lhs")
+        self.assertIn("test/Spanshot/Capture.lhs", cands)
+        self.assertIn("src/Spanshot/Capture.lhs", cands)
 
     def test_scala_multimodule_sbt_layout(self) -> None:
         cands = mbg.production_candidates("modules/core/src/test/scala/com/foo/BarSpec.scala")
@@ -369,6 +392,46 @@ class LinkTestsTests(unittest.TestCase):
             edges[0]["target"],
             "file:modules/core/src/test/scala/com/foo/BarSpec.scala",
         )
+
+    def test_literate_haskell_pairing_emits_forward_edge(self) -> None:
+        nodes_by_id = {
+            "file:src/Spanshot/Capture.lhs": _file_node(
+                "src/Spanshot/Capture.lhs",
+            ),
+            "file:test/Spanshot/CaptureSpec.lhs": _file_node(
+                "test/Spanshot/CaptureSpec.lhs",
+            ),
+        }
+        edges: list[dict[str, Any]] = []
+
+        added, dropped, tagged, swapped = mbg.link_tests(nodes_by_id, edges)
+
+        self.assertEqual((added, dropped, tagged, swapped), (1, 0, 1, 0))
+        self.assertEqual(edges[0]["source"], "file:src/Spanshot/Capture.lhs")
+        self.assertEqual(edges[0]["target"], "file:test/Spanshot/CaptureSpec.lhs")
+
+    def test_haskell_test_main_inverted_edge_is_swapped(self) -> None:
+        nodes_by_id = {
+            "file:src/Spanshot/Capture.hs": _file_node(
+                "src/Spanshot/Capture.hs",
+            ),
+            "file:test/Main.hs": _file_node("test/Main.hs"),
+        }
+        edges: list[dict[str, Any]] = [
+            {
+                "source": "file:test/Main.hs",
+                "target": "file:src/Spanshot/Capture.hs",
+                "type": "tested_by",
+                "direction": "forward",
+                "weight": 0.5,
+            },
+        ]
+
+        added, dropped, tagged, swapped = mbg.link_tests(nodes_by_id, edges)
+
+        self.assertEqual((added, dropped, tagged, swapped), (0, 0, 1, 1))
+        self.assertEqual(edges[0]["source"], "file:src/Spanshot/Capture.hs")
+        self.assertEqual(edges[0]["target"], "file:test/Main.hs")
 
     def test_no_production_counterpart_no_edge(self) -> None:
         nodes_by_id = {

--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -115,6 +115,11 @@ class IsTestPathTests(unittest.TestCase):
         self.assertTrue(mbg.is_test_path("src/test/scala/com/foo/BarTest.scala"))
         self.assertTrue(mbg.is_test_path("src/test/scala/com/foo/BarTests.scala"))
 
+    def test_haskell_test_files(self) -> None:
+        self.assertTrue(mbg.is_test_path("test/Spanshot/CaptureSpec.hs"))
+        self.assertTrue(mbg.is_test_path("test/Spanshot/CaptureTest.hs"))
+        self.assertTrue(mbg.is_test_path("test/Spanshot/CaptureTests.hs"))
+
     def test_csharp_test_files(self) -> None:
         self.assertTrue(mbg.is_test_path("Foo.Tests/BarTests.cs"))
         self.assertTrue(mbg.is_test_path("Foo.Tests/BarTest.cs"))
@@ -215,6 +220,10 @@ class ProductionCandidatesTests(unittest.TestCase):
     def test_scala_sbt_layout(self) -> None:
         cands = mbg.production_candidates("src/test/scala/com/foo/BarSpec.scala")
         self.assertIn("src/main/scala/com/foo/Bar.scala", cands)
+
+    def test_haskell_cabal_layout(self) -> None:
+        cands = mbg.production_candidates("test/Spanshot/CaptureSpec.hs")
+        self.assertIn("src/Spanshot/Capture.hs", cands)
 
     def test_scala_multimodule_sbt_layout(self) -> None:
         cands = mbg.production_candidates("modules/core/src/test/scala/com/foo/BarSpec.scala")

--- a/tests/skill/understand/test_scan_project.test.mjs
+++ b/tests/skill/understand/test_scan_project.test.mjs
@@ -161,6 +161,32 @@ describe('scan-project.mjs — language detection', () => {
     expect(byPath(r.output, 'build.sbt').fileCategory).toBe('config');
   });
 
+  it('maps Haskell sources and Cabal manifests', () => {
+    projectRoot = setupTree({
+      'src/Main.hs': 'module Main where\nmain = pure ()\n',
+      'src/Legacy.lhs': '> module Legacy where\n> answer = 42\n',
+      'demo.cabal': 'cabal-version: 3.0\nname: demo\n',
+      'cabal.project': 'packages: .\n',
+      'cabal.project.local': 'optimization: True\n',
+    });
+    const r = runScript(projectRoot);
+    expect(r.status).toBe(0);
+    expect(byPath(r.output, 'src/Main.hs')).toMatchObject({
+      language: 'haskell',
+      fileCategory: 'code',
+    });
+    expect(byPath(r.output, 'src/Legacy.lhs')).toMatchObject({
+      language: 'haskell',
+      fileCategory: 'code',
+    });
+    for (const path of ['demo.cabal', 'cabal.project', 'cabal.project.local']) {
+      expect(byPath(r.output, path)).toMatchObject({
+        language: 'cabal',
+        fileCategory: 'config',
+      });
+    }
+  });
+
   it('maps Ruby, PHP, C, C++ to their language ids', () => {
     projectRoot = setupTree({
       'a.rb': 'puts 1\n',

--- a/understand-anything-plugin/.claude-plugin/plugin.json
+++ b/understand-anything-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.9.4",
+  "version": "2.10.0",
   "author": {
     "name": "Egonex"
   },

--- a/understand-anything-plugin/agents/architecture-analyzer.md
+++ b/understand-anything-plugin/agents/architecture-analyzer.md
@@ -147,7 +147,7 @@ Classify each directory name against known architectural patterns:
 | `sql`, `database`, `schema` | `data` |
 
 Also check file-level patterns:
-- Files matching `*.test.*` or `*.spec.*` or `test_*.py` or `*_test.go` or `*Test.java` or `*_spec.rb` or `*Test.php` or `*Tests.cs` -> `test`
+- Files matching `*.test.*` or `*.spec.*` or `test_*.py` or `*_test.go` or `*Test.java` or `*_spec.rb` or `*Test.php` or `*Tests.cs` or `*Spec.hs`/`*Test.hs` -> `test`
 - Files matching `*.d.ts` -> `types` (TypeScript declaration files only)
 - Files named `index.ts`, `index.js`, or `__init__.py` at a package/directory root -> `entry`
 - Files named `manage.py` at the project root -> `entry` (Django management entry point)
@@ -155,8 +155,9 @@ Also check file-level patterns:
 - Files named `main.go` at `cmd/*/` -> `entry` (Go binary entry points)
 - Files named `main.rs` or `lib.rs` at `src/` -> `entry` (Rust crate roots)
 - Files named `Application.java` or `Program.cs` -> `entry` (JVM / .NET entry points)
+- Files named `Main.hs` under `app/` or `src/` -> `entry` (Haskell executable)
 - Files named `config.ru` -> `entry` (Ruby Rack entry point)
-- Files named `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json` -> `config` (language-level project config)
+- Files named `Cargo.toml`, `go.mod`, `Gemfile`, `pom.xml`, `build.gradle`, `composer.json`, `cabal.project`, `package.yaml`, `stack.yaml`, or matching `*.cabal` -> `config` (language-level project config)
 - `Dockerfile`, `docker-compose.*` -> `infrastructure`
 - `*.tf`, `*.tfvars` -> `infrastructure`
 - `.github/workflows/*`, `.gitlab-ci.yml`, `Jenkinsfile` -> `ci-cd`

--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -131,12 +131,11 @@ Read `$UA_DIR/tmp/ua-file-extract-results-<batchIndex>.json`. The output format 
 
 When any of these arrays is present and non-empty, you MUST iterate it and emit nodes for the significant entries (don't just create the parent file node and call it done). The corresponding `metrics.serviceCount` / `metrics.endpointCount` / `metrics.resourceCount` / `metrics.stepCount` / `metrics.definitionCount` fields tell you how many were extracted at a glance.
 
-**Supported file categories:** The bundled script handles all file categories — `code` (10 languages with tree-sitter: TypeScript, JavaScript, Python, Go, Rust, Java, Ruby, PHP, C/C++, C#), `config`, `docs`, `infra`, `data`, `script`, and `markup`. For languages without tree-sitter support (Swift, Kotlin, PowerShell, Batch, shell scripts of fileCategory `script`), the script outputs basic metrics with empty structural data — you MUST then read the source and supplement at least the function definitions, so these files don't end up as bare `file` nodes:
+**Supported file categories:** The bundled script handles all file categories — including Haskell (`.hs`, `.lhs`) through tree-sitter — plus `config`, `docs`, `infra`, `data`, `script`, and `markup`. For languages without tree-sitter support (PowerShell, Batch, shell scripts of fileCategory `script`), the script outputs basic metrics with empty structural data — you MUST then read the source and supplement at least the function definitions, so these files don't end up as bare `file` nodes:
 
 - **PowerShell** (`.ps1`): match top-level `function NAME { ... }` blocks (case-insensitive); name = `NAME`, params from the param block when present
 - **Bash / shell** (`.sh`, `.bash`): match top-level `NAME() { ... }` and `function NAME { ... }`
 - **Batch** (`.bat`, `.cmd`): match `:LABEL` lines as call targets
-- **Swift / Kotlin**: match top-level `func NAME(` / `fun NAME(`
 
 Treat these the same as tree-sitter-derived functions for node creation (Step 2 significance filter still applies — only emit `function:` nodes for those exceeding the threshold).
 
@@ -210,7 +209,7 @@ For non-code files:
 
 Indicators from script data:
 - Many re-exports + few functions = `barrel`
-- Filename contains `.test.` or `.spec.` or `test_*.py` or `*_test.go` or `*Test.java` or `*_spec.rb` or `*Test.php` or `*Tests.cs` = `test`
+- Filename contains `.test.` or `.spec.` or `test_*.py` or `*_test.go` or `*Test.java` or `*_spec.rb` or `*Test.php` or `*Tests.cs` or `*Spec.hs`/`*Test.hs` = `test`
 - Exports a class with `Handler` or `Controller` in the name = `api-handler`
 - Only type/interface exports = `type-definition`
 - Named `index.ts` or `index.js` at a directory root with re-exports = `entry-point` (JavaScript/TypeScript barrel)
@@ -220,6 +219,7 @@ Indicators from script data:
 - Named `main.rs` or `lib.rs` in `src/` = `entry-point` (Rust crate root)
 - Named `Application.java` or `Main.java` = `entry-point` (Java application)
 - Named `Program.cs` = `entry-point` (.NET application)
+- Named `Main.hs` under `app/` or `src/` = `entry-point` (Haskell executable)
 - Named `config.ru` = `entry-point` (Ruby Rack server)
 - Named `mod.rs` in a directory = `barrel` (Rust module barrel)
 - Dockerfile = `containerization`, `infrastructure`

--- a/understand-anything-plugin/agents/project-scanner.md
+++ b/understand-anything-plugin/agents/project-scanner.md
@@ -39,6 +39,7 @@ Read whichever of these exist at the project root:
 - `Gemfile` — Ruby framework signals
 - `pom.xml`, `build.gradle`, `build.gradle.kts` — JVM project signals
 - `composer.json` — PHP project signals
+- `*.cabal`, `cabal.project`, `package.yaml`, `stack.yaml` — Haskell project signals
 
 From these, synthesize:
 
@@ -174,7 +175,7 @@ Read the output JSON and merge the `importMap` field directly into your final sc
 
 **Capture stderr** when you run the bundled script. Any line starting with `Warning:` should be appended to phase warnings — the SKILL.md orchestrator captures these for the final report. The script also writes a one-line summary `extract-import-map: filesScanned=… filesWithImports=… totalEdges=…` on completion; you can ignore that line or surface it as informational.
 
-**Languages supported.** The bundled script natively handles import resolution for: TypeScript, JavaScript (including CJS `require()`), Python (relative + absolute + `__init__.py`), Go (go.mod prefix stripping), Rust (`use crate::`, `use super::`, `use self::`, and `mod x;` declarations), Java, Kotlin, Scala (dotted FQN + selector lists + package objects), C#, Ruby (`require` + `require_relative`), PHP (composer.json PSR-4 autoload), C, and C++ (`#include` with relative + include/ + src/ probes). Languages outside this set get empty arrays — there is no LLM-based fallback.
+**Languages supported.** The bundled script natively handles import resolution for: TypeScript, JavaScript (including CJS `require()`), Python (relative + absolute + `__init__.py`), Go (go.mod prefix stripping), Rust (`use crate::`, `use super::`, `use self::`, and `mod x;` declarations), Java, Kotlin, Scala (dotted FQN + selector lists + package objects), Haskell (declared module names, including duplicate `Main` modules), C#, Ruby (`require` + `require_relative`), PHP (composer.json PSR-4 autoload), C, and C++ (`#include` with relative + include/ + src/ probes). Languages outside this set get empty arrays — there is no LLM-based fallback.
 
 ---
 
@@ -236,7 +237,7 @@ Then assemble the final output JSON:
 - ALWAYS validate that `totalFiles` matches the actual length of the `files` array.
 - Trust Step B for file enumeration + language detection + category assignment + line counts + complexity. Trust Step C for `importMap`. Your only synthesis is the `description` field (plus the Step A narrative fields: `name`, `frameworks`, `languages`).
 - Do NOT re-implement file enumeration, language detection, or category assignment in your discovery script. Use the bundled `scan-project.mjs`. If the table doesn't cover your project type, file an issue rather than ad-hoc handling.
-- Do NOT attempt to re-implement import resolution. The bundled `extract-import-map.mjs` handles all 13 supported code languages (TS, JS, Python, Go, Rust, Java, Kotlin, Scala, C#, Ruby, PHP, C, C++) deterministically via tree-sitter + per-language resolvers.
+- Do NOT attempt to re-implement import resolution. The bundled `extract-import-map.mjs` handles all 14 supported code languages (TS, JS, Python, Go, Rust, Java, Kotlin, Scala, Haskell, C#, Ruby, PHP, C, C++) deterministically via tree-sitter + per-language resolvers.
 - Every file MUST have a `fileCategory` field with one of: `code`, `config`, `docs`, `infra`, `data`, `script`, `markup` — `scan-project.mjs` guarantees this; just don't strip it.
 
 ## Writing Results

--- a/understand-anything-plugin/agents/tour-builder.md
+++ b/understand-anything-plugin/agents/tour-builder.md
@@ -65,7 +65,7 @@ For every node, count how many other nodes it has edges pointing TO (fan-out). H
 Identify likely entry points using these signals (score each node, sum the scores):
 
 For code files:
-- Filename matches `index.ts`, `index.js`, `main.ts`, `main.js`, `app.ts`, `app.js`, `server.ts`, `server.js`, `mod.rs`, `main.go`, `main.py`, `main.rs`, `manage.py`, `app.py`, `wsgi.py`, `asgi.py`, `run.py`, `__main__.py`, `Application.java`, `Main.java`, `Program.cs`, `config.ru`, `index.php`, `App.swift`, `Application.kt`, `main.cpp`, `main.c` -> +3 points
+- Filename matches `index.ts`, `index.js`, `main.ts`, `main.js`, `app.ts`, `app.js`, `server.ts`, `server.js`, `mod.rs`, `main.go`, `main.py`, `main.rs`, `manage.py`, `app.py`, `wsgi.py`, `asgi.py`, `run.py`, `__main__.py`, `Application.java`, `Main.java`, `Program.cs`, `config.ru`, `index.php`, `App.swift`, `Application.kt`, `Main.hs`, `main.cpp`, `main.c` -> +3 points
 - File is at the project root or one level deep (e.g., `src/index.ts`) -> +1 point
 - High fan-out (top 10%) -> +1 point
 - Low fan-in (bottom 25%) -> +1 point (entry points are imported by few files)

--- a/understand-anything-plugin/package.json
+++ b/understand-anything-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understand-anything/skill",
-  "version": "2.9.4",
+  "version": "2.10.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/understand-anything-plugin/packages/core/package.json
+++ b/understand-anything-plugin/packages/core/package.json
@@ -49,6 +49,7 @@
     "tree-sitter-c-sharp": "^0.23.1",
     "tree-sitter-cpp": "^0.23.4",
     "tree-sitter-go": "^0.25.0",
+    "tree-sitter-haskell": "^0.23.1",
     "tree-sitter-java": "^0.23.5",
     "tree-sitter-javascript": "^0.25.0",
     "tree-sitter-php": "^0.23.11",

--- a/understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts
@@ -93,6 +93,20 @@ describe("LanguageRegistry", () => {
       });
     });
 
+    it("registers Haskell source and literate test conventions", () => {
+      const tests = LanguageRegistry.createDefault().getById("haskell")?.filePatterns.tests;
+      expect(tests).toEqual(expect.arrayContaining([
+        "*Spec.hs",
+        "*Tests.hs",
+        "*Spec.lhs",
+        "*Tests.lhs",
+        "test/Main.hs",
+        "tests/Main.hs",
+        "test/Main.lhs",
+        "tests/Main.lhs",
+      ]));
+    });
+
     it("has no duplicate extension mappings across configs", () => {
       const registry = LanguageRegistry.createDefault();
       const all = registry.getAllLanguages();

--- a/understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/language-registry.test.ts
@@ -49,10 +49,10 @@ describe("LanguageRegistry", () => {
   });
 
   describe("createDefault", () => {
-    it("registers all 42 built-in language configs", () => {
+    it("registers all 43 built-in language configs", () => {
       const registry = LanguageRegistry.createDefault();
       const all = registry.getAllLanguages();
-      expect(all.length).toBe(42);
+      expect(all.length).toBe(43);
     });
 
     it("maps all expected extensions", () => {
@@ -73,6 +73,8 @@ describe("LanguageRegistry", () => {
       expect(registry.getByExtension(".h")?.id).toBe("c");
       expect(registry.getByExtension(".lua")?.id).toBe("lua");
       expect(registry.getByExtension(".js")?.id).toBe("javascript");
+      expect(registry.getByExtension(".hs")?.id).toBe("haskell");
+      expect(registry.getByExtension(".lhs")?.id).toBe("haskell");
     });
 
     it("registers Swift with tree-sitter grammar metadata", () => {
@@ -80,6 +82,14 @@ describe("LanguageRegistry", () => {
       expect(registry.getById("swift")?.treeSitter).toEqual({
         wasmPackage: "@understand-anything/tree-sitter-swift-wasm",
         wasmFile: "tree-sitter-swift.wasm",
+      });
+    });
+
+    it("registers Haskell with tree-sitter grammar metadata", () => {
+      const registry = LanguageRegistry.createDefault();
+      expect(registry.getById("haskell")?.treeSitter).toEqual({
+        wasmPackage: "tree-sitter-haskell",
+        wasmFile: "tree-sitter-haskell.wasm",
       });
     });
 

--- a/understand-anything-plugin/packages/core/src/languages/configs/haskell.ts
+++ b/understand-anything-plugin/packages/core/src/languages/configs/haskell.ts
@@ -1,0 +1,29 @@
+import type { LanguageConfig } from "../types.js";
+
+export const haskellConfig = {
+  id: "haskell",
+  displayName: "Haskell",
+  extensions: [".hs", ".lhs"],
+  treeSitter: {
+    wasmPackage: "tree-sitter-haskell",
+    wasmFile: "tree-sitter-haskell.wasm",
+  },
+  concepts: [
+    "pure functions",
+    "algebraic data types",
+    "pattern matching",
+    "type classes",
+    "higher-kinded types",
+    "monads and applicatives",
+    "lazy evaluation",
+    "newtypes",
+    "GADTs",
+    "language extensions",
+  ],
+  filePatterns: {
+    entryPoints: ["app/Main.hs", "src/Main.hs", "Main.hs"],
+    barrels: [],
+    tests: ["*Spec.hs", "*Test.hs", "test/Main.hs"],
+    config: ["*.cabal", "cabal.project", "stack.yaml", "package.yaml"],
+  },
+} satisfies LanguageConfig;

--- a/understand-anything-plugin/packages/core/src/languages/configs/haskell.ts
+++ b/understand-anything-plugin/packages/core/src/languages/configs/haskell.ts
@@ -23,7 +23,18 @@ export const haskellConfig = {
   filePatterns: {
     entryPoints: ["app/Main.hs", "src/Main.hs", "Main.hs"],
     barrels: [],
-    tests: ["*Spec.hs", "*Test.hs", "test/Main.hs"],
+    tests: [
+      "*Spec.hs",
+      "*Test.hs",
+      "*Tests.hs",
+      "*Spec.lhs",
+      "*Test.lhs",
+      "*Tests.lhs",
+      "test/Main.hs",
+      "tests/Main.hs",
+      "test/Main.lhs",
+      "tests/Main.lhs",
+    ],
     config: ["*.cabal", "cabal.project", "stack.yaml", "package.yaml"],
   },
 } satisfies LanguageConfig;

--- a/understand-anything-plugin/packages/core/src/languages/configs/index.ts
+++ b/understand-anything-plugin/packages/core/src/languages/configs/index.ts
@@ -15,6 +15,7 @@ import { cppConfig } from "./cpp.js";
 import { dartConfig } from "./dart.js";
 import { csharpConfig } from "./csharp.js";
 import { luaConfig } from "./lua.js";
+import { haskellConfig } from "./haskell.js";
 // Non-code language configs
 import { markdownConfig } from "./markdown.js";
 import { yamlConfig } from "./yaml.js";
@@ -61,6 +62,7 @@ export const builtinLanguageConfigs: LanguageConfig[] = [
   cppConfig,
   dartConfig,
   csharpConfig,
+  haskellConfig,
   // Non-code languages
   markdownConfig,
   yamlConfig,
@@ -108,6 +110,7 @@ export {
   cppConfig,
   dartConfig,
   csharpConfig,
+  haskellConfig,
   // Non-code languages
   markdownConfig,
   yamlConfig,

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/haskell-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/haskell-extractor.test.ts
@@ -1,0 +1,86 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import { HaskellExtractor } from "../haskell-extractor.js";
+
+const require = createRequire(import.meta.url);
+let Parser: any;
+let Language: any;
+let haskellLang: any;
+
+beforeAll(async () => {
+  const mod = await import("web-tree-sitter");
+  Parser = mod.Parser;
+  Language = mod.Language;
+  await Parser.init();
+  haskellLang = await Language.load(
+    require.resolve("tree-sitter-haskell/tree-sitter-haskell.wasm"),
+  );
+});
+
+function parse(code: string) {
+  const parser = new Parser();
+  parser.setLanguage(haskellLang);
+  const tree = parser.parse(code);
+  return { parser, tree, root: tree.rootNode };
+}
+
+describe("HaskellExtractor", () => {
+  const extractor = new HaskellExtractor();
+
+  it("extracts functions, signatures, imports, exports, and ADTs", () => {
+    const { parser, tree, root } = parse(`module Demo (User(..), greet) where
+import qualified Data.Text as T
+import Project.Model (Model)
+
+data User = User { userName :: String }
+
+greet :: User -> String
+greet user = T.unpack (userName user)
+
+privateValue = 42
+`);
+    const result = extractor.extractStructure(root);
+
+    expect(result.imports).toEqual([
+      expect.objectContaining({ source: "Data.Text", specifiers: [] }),
+      expect.objectContaining({ source: "Project.Model", specifiers: ["Model"] }),
+    ]);
+    expect(result.functions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "greet", returnType: "User -> String" }),
+      expect.objectContaining({ name: "privateValue" }),
+    ]));
+    expect(result.classes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "User" }),
+    ]));
+    expect(result.exports.map((entry) => entry.name)).toEqual(["User", "greet"]);
+
+    tree.delete();
+    parser.delete();
+  });
+
+  it("extracts type-class members, instances, and nested calls", () => {
+    const { parser, tree, root } = parse(`module Demo where
+class Render a where
+  render :: a -> String
+
+instance Render Int where
+  render value = show value
+
+format value = length (render value)
+`);
+    const structure = extractor.extractStructure(root);
+    const calls = extractor.extractCallGraph(root);
+
+    expect(structure.classes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "Render", methods: ["render"] }),
+      expect.objectContaining({ name: expect.stringMatching(/^instance Render/) }),
+    ]));
+    expect(calls).toEqual(expect.arrayContaining([
+      expect.objectContaining({ caller: "format", callee: "length" }),
+      expect.objectContaining({ caller: "format", callee: "render" }),
+    ]));
+
+    tree.delete();
+    parser.delete();
+  });
+});

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/haskell-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/haskell-extractor.ts
@@ -1,0 +1,283 @@
+import type { StructuralAnalysis, CallGraphEntry } from "../../types.js";
+import type { LanguageExtractor, TreeSitterNode } from "./types.js";
+
+const TYPE_DECLARATIONS = new Set([
+  "data_type",
+  "newtype",
+  "type_synomym", // Upstream grammar spelling.
+  "class",
+  "data_family",
+  "type_family",
+  "data_instance",
+  "type_instance",
+]);
+
+function children(node: TreeSitterNode): TreeSitterNode[] {
+  const result: TreeSitterNode[] = [];
+  for (let i = 0; i < node.childCount; i++) {
+    const child = node.child(i);
+    if (child) result.push(child);
+  }
+  return result;
+}
+
+function firstDescendant(
+  node: TreeSitterNode,
+  wanted: ReadonlySet<string>,
+): TreeSitterNode | null {
+  if (wanted.has(node.type)) return node;
+  for (const child of children(node)) {
+    const found = firstDescendant(child, wanted);
+    if (found) return found;
+  }
+  return null;
+}
+
+function descendants(node: TreeSitterNode, type: string): TreeSitterNode[] {
+  const result: TreeSitterNode[] = [];
+  const walk = (current: TreeSitterNode) => {
+    if (current.type === type) result.push(current);
+    for (const child of children(current)) walk(child);
+  };
+  walk(node);
+  return result;
+}
+
+function declarationName(node: TreeSitterNode): string | null {
+  const named = node.childForFieldName("name");
+  if (named) return named.text;
+  return firstDescendant(node, new Set(["variable", "name", "constructor"]))?.text ?? null;
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function lineRange(node: TreeSitterNode): [number, number] {
+  return [node.startPosition.row + 1, node.endPosition.row + 1];
+}
+
+function signatureTypes(rootNode: TreeSitterNode): Map<string, string> {
+  const signatures = new Map<string, string>();
+  for (const signature of descendants(rootNode, "signature")) {
+    const name = declarationName(signature);
+    const type = signature.childForFieldName("type");
+    if (name && type && !signatures.has(name)) signatures.set(name, type.text);
+  }
+  return signatures;
+}
+
+function parameterTexts(node: TreeSitterNode): string[] {
+  const patterns = node.childForFieldName("patterns");
+  if (!patterns) return [];
+  return children(patterns).filter((child) => child.isNamed).map((child) => child.text);
+}
+
+function importSpecifierName(node: TreeSitterNode): string | null {
+  const symbol = firstDescendant(
+    node,
+    new Set(["variable", "name", "operator", "constructor", "module_id"]),
+  );
+  return symbol?.text ?? null;
+}
+
+function exportName(node: TreeSitterNode): string | null {
+  const module = node.childForFieldName("module");
+  if (module) return module.text;
+  const symbol =
+    node.childForFieldName("variable") ??
+    node.childForFieldName("type") ??
+    firstDescendant(node, new Set(["variable", "name", "operator"]));
+  return symbol?.text ?? null;
+}
+
+/** Structural extractor for modules parsed by tree-sitter-haskell. */
+export class HaskellExtractor implements LanguageExtractor {
+  readonly languageIds = ["haskell"];
+
+  extractStructure(rootNode: TreeSitterNode): StructuralAnalysis {
+    const functions: StructuralAnalysis["functions"] = [];
+    const classes: StructuralAnalysis["classes"] = [];
+    const imports: StructuralAnalysis["imports"] = [];
+    const exports: StructuralAnalysis["exports"] = [];
+    const signatures = signatureTypes(rootNode);
+
+    const header = children(rootNode).find((child) => child.type === "header");
+    const exportList = header?.childForFieldName("exports") ?? null;
+    const explicitExports = exportList !== null;
+    if (exportList) {
+      for (const entry of children(exportList).filter((child) => child.type === "export")) {
+        const name = exportName(entry);
+        if (name) exports.push({ name, lineNumber: entry.startPosition.row + 1 });
+      }
+    }
+
+    const importsNode = children(rootNode).find((child) => child.type === "imports");
+    if (importsNode) {
+      for (const importNode of children(importsNode).filter((child) => child.type === "import")) {
+        const module = importNode.childForFieldName("module");
+        if (!module) continue;
+        const importList = importNode.childForFieldName("names");
+        const specifiers = importList
+          ? unique(children(importList)
+              .filter((child) => child.type === "import_name")
+              .map(importSpecifierName)
+              .filter((name): name is string => name !== null))
+          : [];
+        imports.push({
+          source: module.text,
+          specifiers,
+          lineNumber: importNode.startPosition.row + 1,
+        });
+      }
+    }
+
+    const declarations = children(rootNode).find((child) => child.type === "declarations");
+    if (!declarations) return { functions, classes, imports, exports };
+
+    const functionsByName = new Map<string, StructuralAnalysis["functions"][number]>();
+    for (const declaration of children(declarations)) {
+      if (declaration.type === "function" || declaration.type === "bind") {
+        const name = declarationName(declaration);
+        if (!name) continue;
+        const existing = functionsByName.get(name);
+        if (existing) {
+          existing.lineRange[1] = Math.max(existing.lineRange[1], declaration.endPosition.row + 1);
+          existing.params = unique([...existing.params, ...parameterTexts(declaration)]);
+        } else {
+          functionsByName.set(name, {
+            name,
+            lineRange: lineRange(declaration),
+            params: parameterTexts(declaration),
+            ...(signatures.get(name) ? { returnType: signatures.get(name) } : {}),
+          });
+        }
+        if (!explicitExports) {
+          exports.push({ name, lineNumber: declaration.startPosition.row + 1 });
+        }
+        continue;
+      }
+
+      if (TYPE_DECLARATIONS.has(declaration.type)) {
+        const cls = this.extractTypeDeclaration(declaration);
+        if (!cls) continue;
+        classes.push(cls);
+        if (!explicitExports) {
+          exports.push({ name: cls.name, lineNumber: declaration.startPosition.row + 1 });
+        }
+        continue;
+      }
+
+      if (declaration.type === "instance") {
+        const typeClass = declarationName(declaration) ?? "instance";
+        const patterns = declaration.childForFieldName("patterns")?.text ?? "";
+        const methods = this.memberNames(declaration);
+        classes.push({
+          name: `instance ${typeClass}${patterns ? ` ${patterns}` : ""}`,
+          lineRange: lineRange(declaration),
+          methods,
+          properties: [],
+        });
+      }
+    }
+
+    functions.push(...functionsByName.values());
+    return {
+      functions,
+      classes,
+      imports,
+      exports: this.dedupeExports(exports),
+    };
+  }
+
+  extractCallGraph(rootNode: TreeSitterNode): CallGraphEntry[] {
+    const entries: CallGraphEntry[] = [];
+    const functionStack: string[] = [];
+    const seen = new Set<string>();
+
+    const add = (caller: string, callee: string, lineNumber: number) => {
+      if (!callee || caller === callee) return;
+      const key = `${caller}\0${callee}\0${lineNumber}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      entries.push({ caller, callee, lineNumber });
+    };
+
+    const walk = (node: TreeSitterNode) => {
+      const isDeclaration = node.type === "function" || node.type === "bind";
+      const name = isDeclaration ? declarationName(node) : null;
+      if (name) functionStack.push(name);
+
+      const caller = functionStack[functionStack.length - 1];
+      if (caller && node.type === "apply") {
+        const callee = this.applicationCallee(node);
+        if (callee) add(caller, callee, node.startPosition.row + 1);
+      } else if (caller && node.type === "infix") {
+        const operator = node.childForFieldName("operator");
+        if (operator) add(caller, operator.text, node.startPosition.row + 1);
+      }
+
+      for (const child of children(node)) walk(child);
+      if (name) functionStack.pop();
+    };
+
+    walk(rootNode);
+    return entries;
+  }
+
+  private extractTypeDeclaration(
+    node: TreeSitterNode,
+  ): StructuralAnalysis["classes"][number] | null {
+    const name = declarationName(node);
+    if (!name) return null;
+
+    const methods = node.type === "class" ? this.memberNames(node) : [];
+    const constructorNames = descendants(node, "data_constructor")
+      .map((constructor) => firstDescendant(constructor, new Set(["constructor"]))?.text ?? "");
+    const fieldNames = descendants(node, "field_name").map((field) => field.text);
+
+    return {
+      name,
+      lineRange: lineRange(node),
+      methods: unique(methods),
+      properties: unique([...constructorNames, ...fieldNames]),
+    };
+  }
+
+  private memberNames(node: TreeSitterNode): string[] {
+    const result: string[] = [];
+    const walk = (current: TreeSitterNode) => {
+      if (current !== node && (current.type === "signature" || current.type === "function" || current.type === "bind")) {
+        const name = declarationName(current);
+        if (name) result.push(name);
+        return;
+      }
+      for (const child of children(current)) walk(child);
+    };
+    walk(node);
+    return unique(result);
+  }
+
+  private applicationCallee(node: TreeSitterNode): string | null {
+    let current = node.childForFieldName("function") ?? node.child(0);
+    while (current?.type === "apply") {
+      current = current.childForFieldName("function") ?? current.child(0);
+    }
+    if (!current) return null;
+    if (["variable", "operator", "constructor", "qualified"].includes(current.type)) {
+      return current.text;
+    }
+    return null;
+  }
+
+  private dedupeExports(
+    exports: StructuralAnalysis["exports"],
+  ): StructuralAnalysis["exports"] {
+    const seen = new Set<string>();
+    return exports.filter(({ name }) => {
+      if (seen.has(name)) return false;
+      seen.add(name);
+      return true;
+    });
+  }
+}

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/index.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/index.ts
@@ -13,6 +13,7 @@ export { DartExtractor } from "./dart-extractor.js";
 export { KotlinExtractor } from "./kotlin-extractor.js";
 export { SwiftExtractor } from "./swift-extractor.js";
 export { ScalaExtractor } from "./scala-extractor.js";
+export { HaskellExtractor } from "./haskell-extractor.js";
 
 import type { LanguageExtractor } from "./types.js";
 import { TypeScriptExtractor } from "./typescript-extractor.js";
@@ -28,6 +29,7 @@ import { DartExtractor } from "./dart-extractor.js";
 import { KotlinExtractor } from "./kotlin-extractor.js";
 import { SwiftExtractor } from "./swift-extractor.js";
 import { ScalaExtractor } from "./scala-extractor.js";
+import { HaskellExtractor } from "./haskell-extractor.js";
 
 export const builtinExtractors: LanguageExtractor[] = [
   new TypeScriptExtractor(),
@@ -43,4 +45,5 @@ export const builtinExtractors: LanguageExtractor[] = [
   new KotlinExtractor(),
   new SwiftExtractor(),
   new ScalaExtractor(),
+  new HaskellExtractor(),
 ];

--- a/understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/tree-sitter-plugin.ts
@@ -23,7 +23,7 @@ type TreeSitterLanguage = import("web-tree-sitter").Language;
  * and how to load their WASM grammars. Provides deep structural analysis
  * (functions, classes, imports, exports, call graphs) for all languages
  * with registered extractors: TypeScript, JavaScript, Python, Go, Rust,
- * Java, Ruby, PHP, C/C++, C#, Dart, Kotlin, Swift, and Scala.
+ * Java, Ruby, PHP, C/C++, C#, Dart, Kotlin, Swift, Scala, and Haskell.
  *
  * Languages without tree-sitter configs are gracefully skipped (the LLM
  * agent handles analysis for those).

--- a/understand-anything-plugin/packages/viewer/package.json
+++ b/understand-anything-plugin/packages/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "understand-anything-viewer",
-  "version": "2.9.4",
+  "version": "2.10.0",
   "description": "Standalone read-only viewer for Understand-Anything knowledge graphs — no Claude Code or LLM required.",
   "type": "module",
   "license": "MIT",

--- a/understand-anything-plugin/pnpm-lock.yaml
+++ b/understand-anything-plugin/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       tree-sitter-go:
         specifier: ^0.25.0
         version: 0.25.0
+      tree-sitter-haskell:
+        specifier: ^0.23.1
+        version: 0.23.1
       tree-sitter-java:
         specifier: ^0.23.5
         version: 0.23.5
@@ -1697,6 +1700,14 @@ packages:
     resolution: {integrity: sha512-APBc/Dq3xz/e35Xpkhb1blu5UgW+2E3RyGWawZSCNcbGwa7jhSQPS8KsUupuzBla8PCo8+lz9W/JDJjmfRa2tw==}
     peerDependencies:
       tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-haskell@0.23.1:
+    resolution: {integrity: sha512-qG4CYhejveu9DLMLEGBz/n9/TTeGSFLC6wniwOgG6m8/v7Dng8qR0ob0EVG7+XH+9WiOxohpGA23EhceWuxY4w==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
     peerDependenciesMeta:
       tree-sitter:
         optional: true
@@ -3637,6 +3648,11 @@ snapshots:
       tree-sitter-c: 0.23.6
 
   tree-sitter-go@0.25.0:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-haskell@0.23.1:
     dependencies:
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4

--- a/understand-anything-plugin/pnpm-workspace.yaml
+++ b/understand-anything-plugin/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ allowBuilds:
   tree-sitter-c-sharp: true
   tree-sitter-cpp: true
   tree-sitter-go: true
+  tree-sitter-haskell: true
   tree-sitter-java: true
   tree-sitter-javascript: true
   tree-sitter-php: true

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -199,13 +199,13 @@ Determine whether to run a full analysis or incremental update.
 
 8. **Collect project context for subagent injection:**
    - Read `README.md` (or `README.rst`, `readme.md`) from `$PROJECT_ROOT` if it exists. Store as `$README_CONTENT` (first 3000 characters).
-   - Read the primary package manifest (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`) if it exists. Store as `$MANIFEST_CONTENT`.
+   - Read the primary package manifest (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `pom.xml`, `*.cabal`, `cabal.project`, `package.yaml`) if it exists. Store as `$MANIFEST_CONTENT`.
    - Capture the top-level directory tree:
      ```bash
      find "$PROJECT_ROOT" -maxdepth 2 -type f -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/dist/*' | head -100
      ```
      Store as `$DIR_TREE`.
-   - Detect the project entry point by checking for common patterns (in order): `src/index.ts`, `src/main.ts`, `src/App.tsx`, `index.js`, `main.py`, `manage.py`, `app.py`, `wsgi.py`, `asgi.py`, `run.py`, `__main__.py`, `main.go`, `cmd/*/main.go`, `src/main.rs`, `src/lib.rs`, `src/main/java/**/Application.java`, `Program.cs`, `config.ru`, `index.php`. Store first match as `$ENTRY_POINT`.
+   - Detect the project entry point by checking for common patterns (in order): `src/index.ts`, `src/main.ts`, `src/App.tsx`, `index.js`, `main.py`, `manage.py`, `app.py`, `wsgi.py`, `asgi.py`, `run.py`, `__main__.py`, `main.go`, `cmd/*/main.go`, `src/main.rs`, `src/lib.rs`, `app/Main.hs`, `src/Main.hs`, `Main.hs`, `src/main/java/**/Application.java`, `Program.cs`, `config.ru`, `index.php`. Store first match as `$ENTRY_POINT`.
 
 ---
 

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -307,6 +307,49 @@ async function loadGoModules(projectRoot, files) {
 }
 
 /**
+ * Index Haskell source modules by their declared module name. Imports refer to
+ * declarations (for example `Spanshot.Capture`), not directly to file paths,
+ * and Cabal source roots are project-specific, so deriving paths from the
+ * dotted name alone is unreliable. Reading module headers gives us an exact,
+ * build-tool-independent project index.
+ *
+ * Multiple paths may declare the same module (commonly app/Main.hs and
+ * test/Main.hs). The resolver disambiguates those candidates relative to the
+ * importing file; arrays remain sorted here to keep tie-breaking stable.
+ */
+async function loadHaskellModules(projectRoot, files) {
+  const modules = new Map();
+  const warnings = [];
+  const candidates = [];
+
+  for (const f of files) {
+    const p = toPosix(f.path);
+    if (!p.endsWith('.hs') && !p.endsWith('.lhs')) continue;
+    const absPath = join(projectRoot, p);
+    if (!existsSync(absPath)) continue;
+    candidates.push({ key: p, absPath });
+  }
+
+  const reads = await readFilesParallel(candidates);
+  const moduleRe = /^\s*(?:>\s*)?module\s+([A-Z][A-Za-z0-9_']*(?:\.[A-Z][A-Za-z0-9_']*)*)\b/m;
+  for (const { key: p, raw, err } of reads) {
+    if (err) {
+      warnings.push(`Warning: extract-import-map: could not read Haskell source ${p}\n`);
+      continue;
+    }
+    const declared = raw.match(moduleRe)?.[1];
+    const base = p.slice(p.lastIndexOf('/') + 1).replace(/\.lhs?$/, '');
+    const moduleName = declared || (base === 'Main' ? 'Main' : '');
+    if (!moduleName) continue;
+    if (!modules.has(moduleName)) modules.set(moduleName, []);
+    modules.get(moduleName).push(p);
+  }
+
+  for (const paths of modules.values()) paths.sort(comparePaths);
+  return { modules, warnings };
+}
+
+/**
  * Parse Swift Package.swift target declarations just enough for import-map
  * resolution. Swift imports modules, and SwiftPM target names are module names.
  * The common convention is `Sources/<Target>`, but packages can override the
@@ -454,20 +497,22 @@ async function buildResolutionContext(projectRoot, files) {
   // them to stderr inline. If a loader streamed warnings directly during
   // the concurrent passes, lines from independent loader families could
   // interleave based on I/O timing — that would break the pre-PR
-  // deterministic order (ts → go → php → swift) and make stderr-diff verification
+  // deterministic order (ts → go → php → swift → haskell) and make stderr-diff verification
   // flaky. Drain the buffers in canonical order *after* Promise.all, so
   // a fixture with `(malformed tsconfig.json, malformed composer.json)`
   // always emits `tsconfig…\ncomposer…\n`, never the reverse.
-  const [tsResult, goResult, phpResult, swiftResult] = await Promise.all([
+  const [tsResult, goResult, phpResult, swiftResult, haskellResult] = await Promise.all([
     loadTsConfigs(projectRoot, files),
     loadGoModules(projectRoot, files),
     loadPhpAutoloads(projectRoot, files),
     loadSwiftPackageTargets(projectRoot, files),
+    loadHaskellModules(projectRoot, files),
   ]);
   for (const w of tsResult.warnings) process.stderr.write(w);
   for (const w of goResult.warnings) process.stderr.write(w);
   for (const w of phpResult.warnings) process.stderr.write(w);
   for (const w of swiftResult.warnings) process.stderr.write(w);
+  for (const w of haskellResult.warnings) process.stderr.write(w);
   const tsConfigs = tsResult.configs;
   const goModules = goResult.modules;
   const phpAutoloads = phpResult.autoloads;
@@ -508,6 +553,7 @@ async function buildResolutionContext(projectRoot, files) {
     scalaPackageIndex,
     csIndex,
     swiftModuleIndex,
+    haskellModules: haskellResult.modules,
     phpAutoloads,
     // Dedupe Sets for one-time-per-file warnings. Keyed by importer file
     // path. Mutated by resolvers.
@@ -1710,6 +1756,33 @@ export function resolveCppImport(rawImport, file, ctx) {
 }
 
 // ---------------------------------------------------------------------------
+// Haskell resolver
+// ---------------------------------------------------------------------------
+
+function commonDirectoryPrefixLength(a, b) {
+  const aParts = dirOf(a).split('/').filter(Boolean);
+  const bParts = dirOf(b).split('/').filter(Boolean);
+  let length = 0;
+  while (length < aParts.length && length < bParts.length && aParts[length] === bParts[length]) {
+    length += 1;
+  }
+  return length;
+}
+
+export function resolveHaskellImport(rawImport, file, ctx) {
+  if (!rawImport || typeof rawImport !== 'string') return [];
+  const moduleName = rawImport.trim();
+  const importer = toPosix(file.path);
+  const candidates = (ctx.haskellModules?.get(moduleName) ?? [])
+    .filter(candidate => candidate !== importer);
+  if (candidates.length <= 1) return candidates;
+
+  return [candidates
+    .map(path => ({ path, score: commonDirectoryPrefixLength(importer, path) }))
+    .sort((a, b) => b.score - a.score || comparePaths(a.path, b.path))[0].path];
+}
+
+// ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
 
@@ -1767,6 +1840,9 @@ function resolveImport(imp, file, ctx) {
   }
   if (lang === 'c' || lang === 'cpp') {
     return resolveCppImport(src, file, ctx);
+  }
+  if (lang === 'haskell') {
+    return resolveHaskellImport(src, file, ctx);
   }
   // Ruby is handled via a dedicated pathway because its tree-sitter
   // extractor flattens require vs require_relative into a single field,

--- a/understand-anything-plugin/skills/understand/languages/haskell.md
+++ b/understand-anything-plugin/skills/understand/languages/haskell.md
@@ -1,0 +1,34 @@
+# Haskell Language Prompt Snippet
+
+## Key Concepts
+
+- **Pure Functions and Effects**: Most functions are pure; effects are explicit in types such as `IO`, `ReaderT`, `ExceptT`, or application-specific monad stacks.
+- **Algebraic Data Types**: `data` and `newtype` declarations model sum and product types; constructors and record fields are important domain vocabulary.
+- **Type Classes and Instances**: `class` defines behavior and `instance` supplies implementations. Instance selection is compile-time wiring, not conventional inheritance.
+- **Pattern Matching**: Multiple equations, guards, and `case` expressions jointly define control flow.
+- **Higher-Order Composition**: Point-free functions, operators, functor/applicative/monadic combinators, and lenses can encode substantial behavior compactly.
+- **Language Extensions**: Pragmas such as `GADTs`, `DataKinds`, and `OverloadedStrings` materially change available syntax and type semantics.
+
+## Import Patterns
+
+- `import Project.Module` imports an internal module by its declared module name.
+- `import qualified Data.Text as T` keeps names qualified; calls appear as `T.pack`, `T.unpack`, and similar.
+- `import Project.Types (User(..), UserId)` restricts imported symbols and may expose constructors with `(..)`.
+- `import Project.Module hiding (name)` imports everything except listed names.
+
+## File Patterns
+
+- `*.cabal`, `cabal.project` — Cabal package/component definitions and source roots.
+- `package.yaml` — hpack manifest; `stack.yaml` — Stack resolver/project configuration.
+- `app/Main.hs`, `src/Main.hs`, `Main.hs` — common executable entry points.
+- `src/` — library modules; `app/` — executables; `test/` — test suites.
+- `*Spec.hs`, `*Test.hs` — Hspec/Tasty-style test modules.
+
+## Example Language Notes
+
+> Models capture failures as an algebraic data type and keeps the execution
+> boundary in `IO`; pure planning and validation functions remain independently
+> testable.
+
+> Defines a type-class capability with production and test instances, making
+> dependencies visible in constraints instead of hiding them in global state.

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -117,6 +117,7 @@ _TEST_NAME_PATTERNS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     ".kt": ((), ("Test", "Tests")),
     ".scala": ((), ("Spec", "Suite", "Test", "Tests")),
     ".hs": ((), ("Spec", "Test", "Tests")),
+    ".lhs": ((), ("Spec", "Test", "Tests")),
     ".cs": ((), ("Test", "Tests")),
     ".c": (("test_",), ("_test",)),
     ".cpp": (("test_",), ("_test",)),
@@ -335,6 +336,16 @@ def is_test_path(path: str) -> bool:
     """
     stem, ext = os.path.splitext(_basename(path))
 
+    # Cabal test suites commonly use `test/Main.hs` (or literate Haskell's
+    # `.lhs` equivalent) as their entry point. `Main` alone is not a test
+    # convention, so require an explicit test-directory segment.
+    if (
+        ext in {".hs", ".lhs"}
+        and stem == "Main"
+        and any(seg in {"test", "tests"} for seg in _path_segments(path)[:-1])
+    ):
+        return True
+
     # JS/TS family: the test marker is an infix on the stem (foo.test.ts has
     # stem "foo.test", ext ".ts"), not a prefix/suffix on the stem itself.
     if ext in _JS_TS_TEST_EXTS:
@@ -507,16 +518,16 @@ def production_candidates(test_path: str) -> list[str]:
                 break
 
     # ── Haskell ─────────────────────────────────────────────────
-    elif ext == ".hs":
+    elif ext in {".hs", ".lhs"}:
         for suffix in ("Spec", "Tests", "Test"):
             if stem.endswith(suffix):
                 base_stem = stem[: -len(suffix)]
-                _add_unique(candidates, _join(dir_path, f"{base_stem}.hs"))
+                _add_unique(candidates, _join(dir_path, f"{base_stem}{ext}"))
                 if dir_segs and dir_segs[0] in ("test", "tests"):
                     tail_path = "/".join(dir_segs[1:])
                     for root in ("src", "app", "lib"):
                         new_dir = "/".join(p for p in (root, tail_path) if p)
-                        _add_unique(candidates, _join(new_dir, f"{base_stem}.hs"))
+                        _add_unique(candidates, _join(new_dir, f"{base_stem}{ext}"))
                 break
 
     # ── C# ────────────────────────────────────────────────────────────

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -116,6 +116,7 @@ _TEST_NAME_PATTERNS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     ".java": ((), ("Test", "Tests", "IT")),
     ".kt": ((), ("Test", "Tests")),
     ".scala": ((), ("Spec", "Suite", "Test", "Tests")),
+    ".hs": ((), ("Spec", "Test", "Tests")),
     ".cs": ((), ("Test", "Tests")),
     ".c": (("test_",), ("_test",)),
     ".cpp": (("test_",), ("_test",)),
@@ -503,6 +504,19 @@ def production_candidates(test_path: str) -> list[str]:
                         _add_unique(candidates, f"{new_dir}/{base_stem}.scala")
                         break
                 _add_unique(candidates, _join(dir_path, f"{base_stem}.scala"))
+                break
+
+    # ── Haskell ─────────────────────────────────────────────────
+    elif ext == ".hs":
+        for suffix in ("Spec", "Tests", "Test"):
+            if stem.endswith(suffix):
+                base_stem = stem[: -len(suffix)]
+                _add_unique(candidates, _join(dir_path, f"{base_stem}.hs"))
+                if dir_segs and dir_segs[0] in ("test", "tests"):
+                    tail_path = "/".join(dir_segs[1:])
+                    for root in ("src", "app", "lib"):
+                        new_dir = "/".join(p for p in (root, tail_path) if p)
+                        _add_unique(candidates, _join(new_dir, f"{base_stem}.hs"))
                 break
 
     # ── C# ────────────────────────────────────────────────────────────

--- a/understand-anything-plugin/skills/understand/scan-project.mjs
+++ b/understand-anything-plugin/skills/understand/scan-project.mjs
@@ -124,7 +124,7 @@ const LANGUAGE_BY_EXT = Object.freeze({
   // Python
   '.py': 'python',
   '.pyi': 'python',
-  // Go / Rust / Java / Kotlin / Scala / C# / Swift / Lua
+  // Go / Rust / Java / Kotlin / Scala / C# / Swift / Lua / Haskell
   '.go': 'go',
   '.rs': 'rust',
   '.java': 'java',
@@ -136,6 +136,8 @@ const LANGUAGE_BY_EXT = Object.freeze({
   '.cs': 'csharp',
   '.swift': 'swift',
   '.lua': 'lua',
+  '.hs': 'haskell',
+  '.lhs': 'haskell',
   // Ruby / PHP
   '.rb': 'ruby',
   '.rake': 'ruby',
@@ -204,6 +206,8 @@ const LANGUAGE_BY_EXT = Object.freeze({
   '.properties': 'properties',
   '.mod': 'mod',
   '.sum': 'sum',
+  // Haskell build metadata
+  '.cabal': 'cabal',
 });
 
 /**
@@ -238,6 +242,7 @@ export function detectLanguage(filePath) {
 
   // Dockerfile.dev, Dockerfile.prod, etc. — common variant form.
   if (base === 'Dockerfile' || base.startsWith('Dockerfile.')) return 'dockerfile';
+  if (base === 'cabal.project' || base.startsWith('cabal.project.')) return 'cabal';
 
   // Dotfile names like .env, .env.local — path.extname returns '' for
   // single-segment dotfiles (e.g. '.env') and the SECOND segment for
@@ -317,6 +322,7 @@ const CATEGORY_BY_EXT = Object.freeze({
   '.ini': 'config',
   '.env': 'config',
   '.properties': 'config',
+  '.cabal': 'config',
   '.csproj': 'config',
   '.sln': 'config',
   '.mod': 'config',
@@ -400,6 +406,7 @@ export function detectCategory(filePath) {
   if (base === 'Dockerfile' || base.startsWith('Dockerfile.')) return 'infra';
   if (base.startsWith('docker-compose.')) return 'infra';
   if (base === 'compose.yml' || base === 'compose.yaml') return 'infra';
+  if (base === 'cabal.project' || base.startsWith('cabal.project.')) return 'config';
 
   // Rule 3: infra by path.
   if (posix.startsWith('.github/workflows/')) return 'infra';


### PR DESCRIPTION
## Summary

Adds end-to-end Haskell support, including `.hs` and `.lhs` source detection, Cabal project detection, tree-sitter structural extraction, internal module resolution, test conventions, and analysis guidance. This enables `/understand` to produce useful dependency graphs for real Haskell projects instead of treating their source files as unsupported.

## Linked issue(s)

No linked issue.

## How I tested this

Revalidated against the current branch on 2026-08-16:

- [x] `pnpm lint`
- [x] `pnpm --filter @understand-anything/core build`
- [x] `pnpm --filter @understand-anything/core test` — 980/980 tests passed
- [x] Scanner suite — 42/42 tests passed
- [x] Import-map suite — 62/62 tests passed
- [x] Merge graph Python suite — 85/85 tests passed
- [x] Manual smoke test against Pandoc

Pandoc smoke-test evidence:

- 2,800 files scanned, including 366 Haskell files
- Knowledge graph generated with 7,238 nodes and 8,711 relationships
- Dashboard loaded successfully and rendered the Pandoc architecture graph
- An incremental Haskell probe was detected as the 367th Haskell file
- Its function and export were extracted successfully
- Its `Text.Pandoc` import resolved to `src/Text/Pandoc.hs`

## Resolved regressions

- `test/Main.hs`, `tests/Main.hs`, and their `.lhs` equivalents are now classified as test entry points while production `Main` modules remain production.
- Literate Haskell tests such as `test/FooSpec.lhs` now map deterministically to `.lhs` production candidates under `test/`, `src/`, `app/`, and `lib/`.
- End-to-end regression coverage verifies both `.lhs` supplemental linking and correction of inverted `test/Main.hs → production` edges into canonical `production → test/Main.hs` edges.
- Haskell registry conventions now match the deterministic merger for `Spec`, `Test`, `Tests`, and test-suite `Main` files across `.hs` and `.lhs`.

## Versioning

- [x] Version bumped from `2.9.4` to `2.10.0` in all six manifests required by `CLAUDE.md`.

<img width="1280" height="633" alt="pandoc-haskell-dashboard" src="https://github.com/user-attachments/assets/df7337de-eda3-49bb-a566-bf907f84d165" />
