### PR TITLE
feat: add Augment Code platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The installer clones the repo to `~/.understand-anything/repo` and creates the r
 
 > **Note on invoking skills:** the invocation prefix differs per platform. Most platforms use slash commands (`/understand`), but **Codex uses `$` instead** — type `$understand`, not `/understand`. If neither prefix is recognized on your platform, just ask in plain language: *"Use the understand skill to analyze this project."*
 
-- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`
+- Supported `<platform>` values: `gemini`, `codex`, `opencode`, `pi`, `openclaw`, `antigravity`, `vibe`, `vscode`, `hermes`, `cline`, `kimi`, `trae`, `nanobot`, `kiro`, `augment`
 - Update later: `./install.sh --update`
 - Uninstall: `./install.sh --uninstall <platform>`
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ For personal skills (available across all projects), run the `install.sh` above 
 | Trae | ✅ Supported | `install.sh trae` |
 | Nanobot | ✅ Supported | `install.sh nanobot` |
 | Kiro CLI / IDE | ✅ Supported | `install.sh kiro` |
+| Augment Code | ✅ Supported | `install.sh augment` |
 
 
 ---

--- a/install.ps1
+++ b/install.ps1
@@ -42,6 +42,7 @@ $Platforms = [ordered]@{
     trae        = @{ Target = (Join-Path $HOME '.trae\skills');               Style = 'per-skill' }
     nanobot     = @{ Target = (Join-Path $HOME '.nanobot\workspace\skills');  Style = 'per-skill' }
     kiro        = @{ Target = (Join-Path $HOME '.kiro\skills');               Style = 'per-skill' }
+    augment     = @{ Target = (Join-Path $HOME '.augment\skills');            Style = 'per-skill' }
 }
 
 function Show-Usage {

--- a/install.sh
+++ b/install.sh
@@ -42,6 +42,7 @@ kimi|$HOME/.kimi/skills|folder
 trae|$HOME/.trae/skills|per-skill
 nanobot|$HOME/.nanobot/workspace/skills|per-skill
 kiro|$HOME/.kiro/skills|per-skill
+augment|$HOME/.augment/skills|per-skill
 EOF
 }
 


### PR DESCRIPTION
## Summary

Adds **Augment Code** as a supported installation platform. Augment Code discovers skills from `~/.augment/skills/` via `SKILL.md` files — the same format this project already uses — so no changes to skill files are needed.

## Linked issue(s)

None — self-contained, low-risk installer addition following the same pattern as every other platform.

## How I tested this

```bash
bash install.sh augment
```

```
→ Updating existing checkout at ~/.understand-anything/repo
Already up to date.
→ Linking skills for augment (per-skill → ~/.augment/skills)
  ✓ ~/.augment/skills/understand-chat → ...
  ✓ ~/.augment/skills/understand-dashboard → ...
  ✓ ~/.augment/skills/understand-diff → ...
  ✓ ~/.augment/skills/understand-domain → ...
  ✓ ~/.augment/skills/understand-explain → ...
  ✓ ~/.augment/skills/understand-figma → ...
  ✓ ~/.augment/skills/understand-knowledge → ...
  ✓ ~/.augment/skills/understand-onboard → ...
  ✓ ~/.augment/skills/understand → ...
→ Linking universal plugin root
✓ Installed Understand-Anything for augment
  Restart your CLI or IDE to pick up the skills.
```

All 9 skills symlinked correctly and discovered by Augment Code after restart.

- [x] `pnpm lint`
- [x] `pnpm --filter @understand-anything/core test`
- [x] `pnpm test` (497 passed, 12 skipped — including `platform-table-consistency` tests that enforce `install.sh`, `install.ps1`, and README stay in sync)
- [x] Manual smoke test: `bash install.sh augment` — all skills installed and picked up by Augment Code

## Versioning

- [x] N/A — installer/docs-only change
