### PR TITLE
fix(merge): hard-fail on non-empty unrecognized batch filenames (#641)

### DIFF
--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -1197,10 +1197,11 @@ class TestIncrementalBatchExisting(unittest.TestCase):
 
 class TestUnrecognizedBatchFilename(unittest.TestCase):
     """File-analyzer fuses multiple batches into one output (e.g.,
-    `batch-fused-8-13.json`, `batch-8-13.json`) — the merge script's regex
-    requires `batch-<N>.json` or `batch-<N>-part-<K>.json` and would
-    otherwise silently drop the contents. The script must warn loudly and
-    surface the drop in its report so the downstream review step catches it.
+    `batch-fused-8-13.json`, `batch-8-13.json`) — the merge script accepts
+    only `batch-<N>.json`, `batch-<N>-part-<K>.json`, and
+    `batch-existing.json`. Non-empty unrecognized files must hard-fail
+    (#641) so a partial graph is never written; empty stubs still warn
+    and continue.
     """
 
     def setUp(self) -> None:
@@ -1231,9 +1232,9 @@ class TestUnrecognizedBatchFilename(unittest.TestCase):
         assembled = _j.loads(out_path.read_text(encoding="utf-8")) if out_path.exists() else {}
         return result.returncode, result.stderr, assembled
 
-    def test_fused_filename_emits_stderr_warning(self) -> None:
-        # `batch-fused-3-5.json` does not match the merge regex —
-        # script must warn on stderr (not silently drop).
+    def test_fused_filename_hard_fails_without_writing_graph(self) -> None:
+        # `batch-fused-3-5.json` does not match the merge regex and carries
+        # content — script must exit non-zero and not write a partial graph.
         self._write_batch("batch-1.json", [_file_node("src/a.ts")], [])
         self._write_batch("batch-2.json", [_file_node("src/b.ts")], [])
         self._write_batch(
@@ -1241,56 +1242,41 @@ class TestUnrecognizedBatchFilename(unittest.TestCase):
             [_file_node("src/c.ts"), _file_node("src/d.ts"), _file_node("src/e.ts")],
             [],
         )
-        rc, stderr, _assembled = self._run_merge()
-        self.assertEqual(rc, 0)
-        self.assertIn("Warning: merge-batch-graphs:", stderr)
+        rc, stderr, assembled = self._run_merge()
+        self.assertNotEqual(rc, 0)
+        self.assertIn("Error: merge-batch-graphs:", stderr)
         self.assertIn("unrecognized filenames", stderr)
         self.assertIn("batch-fused-3-5.json", stderr)
-        # Remediation hint must be present so users know what to fix.
         self.assertIn("file-analyzer", stderr)
         self.assertIn("batch-<N>.json", stderr)
+        self.assertEqual(assembled, {})
+        self.assertFalse((self.intermediate / "assembled-graph.json").exists())
 
-    def test_fused_filename_surfaces_in_report(self) -> None:
-        # The merge report (printed after the per-file load lines) must
-        # also flag the drop so Phase 3 review picks it up.
+    def test_fused_filename_error_names_lost_files(self) -> None:
         self._write_batch("batch-1.json", [_file_node("src/a.ts")], [])
         self._write_batch(
             "batch-fused-2-4.json", [_file_node("src/x.ts")], [],
         )
-        rc, stderr, _assembled = self._run_merge()
-        self.assertEqual(rc, 0)
-        # "dropped N batch file(s) with unrecognized filenames" appears in the
-        # report section (printed after "Output: ..." line).
-        self.assertIn("dropped 1 batch file(s) with unrecognized filenames", stderr)
+        rc, stderr, assembled = self._run_merge()
+        self.assertNotEqual(rc, 0)
+        self.assertIn("refusing to merge", stderr)
         self.assertIn("batch-fused-2-4.json", stderr)
-        self.assertIn(
-            "every node/edge in these files was excluded from the final graph",
-            stderr,
-        )
+        self.assertIn("would be lost", stderr)
+        self.assertEqual(assembled, {})
 
-    def test_recognized_batches_still_loaded(self) -> None:
-        # With both recognized and unrecognized files present, recognized
-        # ones must still produce a valid assembled graph.
+    def test_recognized_batches_alone_still_merge(self) -> None:
+        # Without unrecognized files, recognized batches still produce a
+        # valid assembled graph (control for the hard-fail path above).
         self._write_batch("batch-1.json", [_file_node("src/a.ts")], [])
         self._write_batch("batch-2.json", [_file_node("src/b.ts")], [])
-        self._write_batch(
-            "batch-fused-3-5.json",
-            [_file_node("src/dropped-c.ts")],
-            [],
-        )
         rc, _stderr, assembled = self._run_merge()
         self.assertEqual(rc, 0)
         node_ids = {n["id"] for n in assembled["nodes"]}
-        # batch-1 + batch-2 survive
-        self.assertIn("file:src/a.ts", node_ids)
-        self.assertIn("file:src/b.ts", node_ids)
-        # batch-fused-3-5.json content is excluded
-        self.assertNotIn("file:src/dropped-c.ts", node_ids)
         self.assertEqual(node_ids, {"file:src/a.ts", "file:src/b.ts"})
 
-    def test_range_filename_also_unrecognized(self) -> None:
+    def test_range_filename_also_hard_fails(self) -> None:
         # A bare range like `batch-8-13.json` is just as broken as
-        # `batch-fused-8-13.json` — both must be flagged. The regex
+        # `batch-fused-8-13.json` — both must hard-fail. The regex
         # `batch-(\d+)(?:-part-(\d+))?\.json` requires the literal
         # `-part-` separator before a second number.
         self._write_batch("batch-1.json", [_file_node("src/a.ts")], [])
@@ -1300,13 +1286,25 @@ class TestUnrecognizedBatchFilename(unittest.TestCase):
             [],
         )
         rc, stderr, assembled = self._run_merge()
+        self.assertNotEqual(rc, 0)
+        self.assertIn("Error: merge-batch-graphs:", stderr)
+        self.assertIn("batch-8-13.json", stderr)
+        self.assertEqual(assembled, {})
+        self.assertFalse((self.intermediate / "assembled-graph.json").exists())
+
+    def test_empty_unrecognized_filename_warns_but_continues(self) -> None:
+        # Empty stubs carry no nodes/edges — warn and continue rather than
+        # hard-fail (#641 "when the unrecognized file is non-empty").
+        self._write_batch("batch-1.json", [_file_node("src/a.ts")], [])
+        self._write_batch("batch-fused-empty.json", [], [])
+        rc, stderr, assembled = self._run_merge()
         self.assertEqual(rc, 0)
         self.assertIn("Warning: merge-batch-graphs:", stderr)
-        self.assertIn("batch-8-13.json", stderr)
-        # Content is dropped
+        self.assertIn("unrecognized filenames", stderr)
+        self.assertIn("batch-fused-empty.json", stderr)
+        self.assertIn("dropped 1 empty batch file(s) with unrecognized filenames", stderr)
         node_ids = {n["id"] for n in assembled["nodes"]}
-        self.assertNotIn("file:src/x.ts", node_ids)
-        self.assertNotIn("file:src/y.ts", node_ids)
+        self.assertEqual(node_ids, {"file:src/a.ts"})
 
 
 class TestEmptyBatchGuard(unittest.TestCase):

--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -488,7 +488,7 @@ Use these hints for common edge patterns:
 
 `<batchIndex>` is the **ORIGINAL integer batch index** from the input `batches.json`. Even if your dispatch prompt fused multiple batches into one call (e.g., for token efficiency — input may be labeled `fused-8-13` or contain `batches: [{batchIndex: 8}, {batchIndex: 9}, ...]`), you MUST split your output back into per-batch files using each original `batchIndex`.
 
-**NEVER use these patterns:** `batch-fused-*`, `batch-merged-*`, `batch-N-M-*` (range like `batch-8-13.json`), `batches-*`, or any other variant. The downstream merge script (`merge-batch-graphs.py`) requires the regex `batch-(\d+)(?:-part-(\d+))?\.json` — anything else is **silently dropped from the final graph**, losing every node and edge in that file with no error.
+**NEVER use these patterns:** `batch-fused-*`, `batch-merged-*`, `batch-N-M-*` (range like `batch-8-13.json`), `batches-*`, or any other variant. The downstream merge script (`merge-batch-graphs.py`) accepts only `batch-<N>.json`, `batch-<N>-part-<K>.json`, and (for incremental carry-over) `batch-existing.json` — anything else that carries nodes/edges causes the merge to **hard-fail**, so a partial graph is never written.
 
 **Example.** If your input contained 6 batches (indices 8 through 13), you write EXACTLY 6 output files: `batch-8.json`, `batch-9.json`, `batch-10.json`, `batch-11.json`, `batch-12.json`, `batch-13.json`. Not one combined `batch-fused-8-13.json`. Not one `batch-8-13.json`. Six files, one per original `batchIndex`. Run Steps A–F below independently for each batch's nodes/edges.
 

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -170,6 +170,31 @@ def batch_sort_key(path: Path) -> tuple[int, int, str]:
     return (batch_index, part_number or 0, path.name)
 
 
+def batch_file_has_content(path: Path) -> bool:
+    """Return True when a batch file would lose nodes/edges if dropped.
+
+    Used to hard-fail on unrecognized non-empty filenames (#641) while still
+    tolerating empty stub files that carry no graph payload.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    if not raw.strip():
+        return False
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # Unparseable but non-empty — treat as content so we refuse to
+        # silently discard whatever the agent intended to merge.
+        return True
+    if not isinstance(data, dict):
+        return True
+    nodes = data.get("nodes") or []
+    edges = data.get("edges") or []
+    return len(nodes) > 0 or len(edges) > 0
+
+
 # ── Batch loading ─────────────────────────────────────────────────────────
 
 def load_batch(path: Path) -> dict[str, Any] | None:
@@ -1087,15 +1112,17 @@ def main() -> None:
     # files from multi-part file-analyzer outputs. Files that don't match the
     # `batch-existing.json` / `batch-<N>.json` / `batch-<N>-part-<K>.json`
     # pattern (e.g. fused `batch-fused-8-13.json`, range `batch-8-13.json`)
-    # would otherwise be silently dropped during load — flag them loudly
-    # instead so the user can fix the file-analyzer agent.
+    # must not be silently dropped when they carry graph content (#641) —
+    # hard-fail so a partial merge never ships.
     from collections import defaultdict as _dd
     by_batch = _dd(list)
     unrecognized_batch_files: list[str] = []
+    unrecognized_by_name: dict[str, Path] = {}
     for f in batch_files:
         parsed = parse_batch_filename(f.name)
         if parsed is None:
             unrecognized_batch_files.append(f.name)
+            unrecognized_by_name[f.name] = f
         else:
             batch_index, part_number = parsed
             by_batch[batch_index].append((f.name, part_number))
@@ -1107,11 +1134,34 @@ def main() -> None:
             if len(unrecognized_batch_files) > 5
             else ""
         )
+        contentful = [
+            name
+            for name in unrecognized_batch_files
+            if batch_file_has_content(unrecognized_by_name[name])
+        ]
+        if contentful:
+            content_preview = ", ".join(contentful[:5])
+            content_suffix = (
+                f" (+{len(contentful) - 5} more)"
+                if len(contentful) > 5
+                else ""
+            )
+            print(
+                f"Error: merge-batch-graphs: refusing to merge — "
+                f"{len(contentful)} batch file(s) with unrecognized "
+                f"filenames carry nodes/edges that would be lost — "
+                f"files: {content_preview}{content_suffix} — fix the "
+                f"file-analyzer agent to use only batch-<N>.json, "
+                f"batch-<N>-part-<K>.json, or batch-existing.json",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         print(
             f"Warning: merge-batch-graphs: {len(unrecognized_batch_files)} "
-            f"batch file(s) with unrecognized filenames will be DROPPED — "
-            f"files: {preview}{suffix} — fix the file-analyzer agent to use "
-            f"only batch-<N>.json or batch-<N>-part-<K>.json patterns",
+            f"empty batch file(s) with unrecognized filenames will be "
+            f"DROPPED — files: {preview}{suffix} — fix the file-analyzer "
+            f"agent to use only batch-<N>.json or batch-<N>-part-<K>.json "
+            f"patterns",
             file=sys.stderr,
         )
 
@@ -1203,8 +1253,9 @@ def main() -> None:
         for w in empty_batch_warnings:
             report.append(f"  - {w}")
 
-    # Surface unrecognized-filename drops to the phase report so the
-    # downstream review step sees them, not just stderr.
+    # Surface unrecognized empty-filename stubs to the phase report so the
+    # downstream review step sees them. Non-empty unrecognized files already
+    # hard-failed above (#641).
     if unrecognized_batch_files:
         preview = ", ".join(unrecognized_batch_files[:5])
         suffix = (
@@ -1214,11 +1265,10 @@ def main() -> None:
         )
         report.append("")
         report.append(
-            f"Warning: dropped {len(unrecognized_batch_files)} batch file(s) "
-            f"with unrecognized filenames — files: {preview}{suffix} — "
+            f"Warning: dropped {len(unrecognized_batch_files)} empty batch "
+            f"file(s) with unrecognized filenames — files: {preview}{suffix} — "
             f"fix the file-analyzer agent to use only batch-<N>.json or "
-            f"batch-<N>-part-<K>.json patterns (every node/edge in these "
-            f"files was excluded from the final graph)"
+            f"batch-<N>-part-<K>.json patterns"
         )
 
     # Recover any imports edges file-analyzer batches dropped despite


### PR DESCRIPTION
## Summary
- `batch-existing.json` is already accepted on main (via #564); this PR addresses the remaining #641 suggestion: turn silent-ish drops of unrecognized batch filenames into a hard failure when those files carry nodes/edges.
- `merge-batch-graphs.py` now refuses to write `assembled-graph.json` if any unrecognized `batch-*.json` (e.g. `batch-fused-*`, `batch-8-13.json`) has content, exiting non-zero with a clear error.
- Empty unrecognized stubs still warn and continue, so stray empty files do not block a valid merge.
- Updated `file-analyzer.md` so agents know bad filenames hard-fail instead of being silently dropped.

Fixes #641

## Test plan
- [x] `PYTHONDONTWRITEBYTECODE=1 python -m unittest tests.skill.understand.test_merge_batch_graphs -v` (81/81 pass)
- [ ] Confirm incremental path with only `batch-existing.json` + `batch-<N>.json` still merges (unchanged)
- [ ] Drop a non-empty `batch-fused-1-2.json` into `intermediate/` and confirm merge exits non-zero with no `assembled-graph.json`
- [ ] Drop an empty unrecognized stub and confirm merge warns but still succeeds
