### PR TITLE
fix(schema): drop documented_by alias that reverses the edge (#653)

### DIFF
--- a/understand-anything-plugin/packages/core/src/__tests__/schema.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/schema.test.ts
@@ -5,6 +5,8 @@ import {
   autoFixGraph,
   NODE_TYPE_ALIASES,
   EDGE_TYPE_ALIASES,
+  DESIGN_EDGE_TYPE_ALIASES,
+  NON_DESIGN_EDGE_TYPE_ALIASES,
 } from "../schema.js";
 import type { KnowledgeGraph } from "../types.js";
 
@@ -245,6 +247,21 @@ describe("schema validation", () => {
     );
   });
 
+  it('drops "documented_by" edge type because it inverts edge direction', () => {
+    const graph = structuredClone(validGraph);
+    (graph.edges[0] as any).type = "documented_by";
+
+    const result = validateGraph(graph);
+    expect(result.success).toBe(true);
+    // Not rewritten to "documents": that would keep the edge but point it
+    // the wrong way, code -> doc, where canonical "documents" runs doc ->
+    // code. Dropping it puts a visible issue in front of the caller.
+    expect(result.data!.edges.length).toBe(0);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ level: "dropped", category: "invalid-edge" })
+    );
+  });
+
   it("drops truly invalid edge types after normalization", () => {
     const graph = structuredClone(validGraph);
     (graph.edges[0] as any).type = "totally_bogus";
@@ -272,6 +289,26 @@ describe("schema validation", () => {
         EDGE_TYPE_ALIASES,
         `chain detected: ${alias} → ${target} → ${EDGE_TYPE_ALIASES[target]}`,
       ).not.toHaveProperty(target);
+    }
+  });
+
+  // The alias tables only rewrite `type`, they never swap source/target, so
+  // aliasing a converse form silently reverses the edge. Each of these was
+  // either removed after shipping (fd0df15, #653) or deliberately kept out,
+  // and nothing but a comment was stopping the next one from coming back.
+  it("converse edge forms are never alias keys in any edge table", () => {
+    const converseForms = ["tests", "implemented_by", "documented_by"];
+    for (const table of [
+      EDGE_TYPE_ALIASES,
+      DESIGN_EDGE_TYPE_ALIASES,
+      NON_DESIGN_EDGE_TYPE_ALIASES,
+    ]) {
+      for (const form of converseForms) {
+        expect(
+          table,
+          `"${form}" inverts edge direction, so it must not be an alias key`,
+        ).not.toHaveProperty(form);
+      }
     }
   });
 });

--- a/understand-anything-plugin/packages/core/src/schema.ts
+++ b/understand-anything-plugin/packages/core/src/schema.ts
@@ -117,7 +117,6 @@ export const EDGE_TYPE_ALIASES: Record<string, string> = {
   subscribe: "subscribes",
   // Non-code aliases
   describes: "documents",
-  documented_by: "documents",
   creates: "provisions",
   exposes: "serves",
   listens: "serves",
@@ -144,9 +143,12 @@ export const EDGE_TYPE_ALIASES: Record<string, string> = {
   tagged_with: "categorized_under",
   written_by: "authored_by",
   created_by: "authored_by",
-  // Note: "implemented_by" is intentionally NOT aliased to "implements" —
-  // it inverts edge direction (see commit fd0df15). The LLM should use
-  // "implements" with correct source/target instead.
+  // Note: converse forms are intentionally NOT aliased. This table only
+  // rewrites `type`, it never swaps source/target, so aliasing a converse
+  // silently reverses the edge (see commit fd0df15). Deliberately absent:
+  // "tests" (converse of "tested_by"), "implemented_by" (converse of
+  // "implements"), "documented_by" (converse of "documents", see #653).
+  // The LLM should emit the canonical type with the right source/target.
 };
 
 // Design edge aliases — applied only when the graph's kind is "design".


### PR DESCRIPTION
fix(schema): drop the documented_by alias that silently reverses the edge (#653)

Fixes #653.

`EDGE_TYPE_ALIASES` had `documented_by: "documents"`, and `normalizeGraph` only rewrites `type`, it never swaps `source`/`target` (`packages/core/src/schema.ts:519-527`).
So every `documented_by` edge came out pointing the wrong way, and stayed schema-valid while doing it.

Ran the reproduction from the issue against `main` at `3294482` and got the reported output byte for byte:

```
auth.ts --documents--> auth.md
handler.ts --triggers--> queue
auth.ts --implemented_by--> auth.md
```

## The fix

Removed the alias, the same way `fd0df15` handled `tests -> tested_by`.
`documented_by` now falls through to the enum check and `validateGraph` drops the edge with a recorded issue (`schema.ts:636-671`):

```
success: true  edges: 0
[dropped] invalid-edge: edges[0]: Invalid option: expected one of "imports"|... — removed
```

That is the part the issue said was missing: previously nothing errored and no issue was recorded, so an inverted edge was indistinguishable from a correct one.

Swapping endpoints inside `normalizeGraph` was the other option. I did not take it because the repo has already picked a side twice: `fd0df15` removed a converse alias rather than teaching the table to swap, and the note under the table tells the LLM to emit the canonical type with the right source and target. A silent auto-swap would also paper over a prompt problem that is worth seeing.

There was no direction to settle here, it is documented in three places:

- `agents/file-analyzer.md:275` - "Doc file describes or references a code component", direction `forward`
- `agents/tour-builder.md:42` - `{"source": "document:README.md", "target": "file:src/index.ts", "type": "documents"}`
- `agents/architecture-analyzer.md:83` - `document -> file: 3 (documents)`

## Also added a guard

The "intentionally NOT aliased" comment was the only thing keeping `implemented_by` out, and it did not keep `documented_by` out.
There is now a test pinning all three known converse forms against all three edge alias tables, so the next one fails in CI instead of shipping. I also widened the comment to state the rule rather than one instance of it.

## On `triggers_on`

You asked which reading was intended, so here is what the repo says. `triggers` runs actor -> thing triggered:

- `agents/file-analyzer.md:278` - "CI/CD config triggers a pipeline or deployment", `forward`
- `agents/file-analyzer.md:303` - "CI configs: Create `triggers` edges to the deployment targets or test suites they invoke"
- `agents/file-analyzer.md:465` - "CI config runs test commands | `triggers` from CI config to test files"
- `agents/architecture-analyzer.md:85` - `pipeline -> file: 1 (triggers)`

Under that reading `triggers_on` is a converse and belongs in the same list.
I left it in place here because unlike `documented_by` it is not unambiguous in practice - a model can write "workflow triggers_on deploy" and mean the forward sense - and which way to resolve that is your call, not mine.
Say the word and I will add `triggers_on` to the removal and to `converseForms` in this PR. It is a two line change.

The node-alias observation at the end of the issue (`interface`/`struct` -> `class`, `view` -> `table`) is a modelling question rather than a defect, so I left it out of this PR.

## Testing

Both new tests fail on unmodified `main` and pass with the change:

```
× drops "documented_by" edge type because it inverts edge direction
× converse edge forms are never alias keys in any edge table
  → "documented_by" inverts edge direction, so it must not be an alias key:
    expected { extends: 'inherits', …(38) } to not have property "documented_by"
```

Gates run locally on Node 24 / pnpm 10:

- `pnpm lint` clean
- core, skill and viewer builds clean
- `pnpm --filter @understand-anything/core test`: 46 files, 978 tests passed (976 on `main`, plus the 2 added here)
- `pnpm test`: 33 files, 505 passed + 4 skipped, unchanged from `main` (the diff is core-only, root does not pick core up)
- `python -m unittest ...test_merge_batch_graphs ...test_merge_subdomain_graphs ...test_parse_knowledge_base`: 95 OK, no Python touched

I am new to open source, and this pull request was made with AI assistance.
