### PR TITLE
fix(dashboard): support secure loopback auto-auth

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "author": {
     "name": "Egonex"
   },

--- a/.copilot-plugin/plugin.json
+++ b/.copilot-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "author": {
     "name": "Egonex"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "understand-anything",
   "displayName": "Understand Anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "author": {
     "name": "Egonex"
   },

--- a/tests/skill/viewer/test_viewer.test.mjs
+++ b/tests/skill/viewer/test_viewer.test.mjs
@@ -4,32 +4,35 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execFileSync, spawn } from "node:child_process";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
-const VIEWER_BIN = join(
-  REPO_ROOT,
-  "understand-anything-plugin",
-  "packages",
-  "viewer",
-  "bin",
-  "viewer.mjs",
-);
+const VIEWER_BIN = join(REPO_ROOT, "understand-anything-plugin", "packages", "viewer", "bin", "viewer.mjs");
 const VIEWER_DIST = join(REPO_ROOT, "understand-anything-plugin", "packages", "viewer", "dist");
 
 function fixtureGraph(gitCommitHash) {
   return {
     version: "1.0.0",
     project: {
-      name: "fixture", languages: ["ts"], frameworks: [], description: "d",
-      analyzedAt: "2026-07-17T00:00:00.000Z", gitCommitHash,
+      name: "fixture",
+      languages: ["ts"],
+      frameworks: [],
+      description: "d",
+      analyzedAt: "2026-07-17T00:00:00.000Z",
+      gitCommitHash,
     },
     nodes: [
       {
-        id: "file:src/a.ts", type: "file", name: "a.ts", filePath: "src/a.ts",
-        summary: "s", tags: [], complexity: "simple",
+        id: "file:src/a.ts",
+        type: "file",
+        name: "a.ts",
+        filePath: "src/a.ts",
+        summary: "s",
+        tags: [],
+        complexity: "simple",
       },
     ],
     edges: [],
@@ -58,21 +61,33 @@ function setupProject(dataDirName) {
 
   const dataDir = join(root, dataDirName);
   mkdirSync(dataDir, { recursive: true });
-  writeFileSync(
-    join(dataDir, "knowledge-graph.json"),
-    JSON.stringify(fixtureGraph(git(root, "rev-parse", "HEAD"))),
-  );
+  writeFileSync(join(dataDir, "knowledge-graph.json"), JSON.stringify(fixtureGraph(git(root, "rev-parse", "HEAD"))));
   return root;
 }
 
-/** Start the viewer and wait for the printed URL. Returns { proc, url, token, port }. */
-function startViewer(projectRoot) {
+function requestWithHost(url, host) {
   return new Promise((resolvePromise, rejectPromise) => {
-    const proc = spawn(
-      process.execPath,
-      [VIEWER_BIN, projectRoot, "--no-open", "--port", "0"],
-      { env: { ...process.env }, stdio: ["ignore", "pipe", "pipe"] },
-    );
+    const request = httpRequest(url, { headers: { host } }, (response) => {
+      response.resume();
+      response.on("end", () =>
+        resolvePromise({
+          status: response.statusCode ?? 0,
+          location: response.headers.location ?? null,
+        }),
+      );
+    });
+    request.once("error", rejectPromise);
+    request.end();
+  });
+}
+
+/** Start the viewer and wait for the printed URL. Returns { proc, url, token, port }. */
+function startViewer(projectRoot, extraEnv = {}) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const proc = spawn(process.execPath, [VIEWER_BIN, projectRoot, "--no-open", "--port", "0"], {
+      env: { ...process.env, UNDERSTAND_AUTO_AUTH: "0", ...extraEnv },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
     let out = "";
     const timer = setTimeout(() => {
       proc.kill();
@@ -80,10 +95,16 @@ function startViewer(projectRoot) {
     }, 10_000);
     const onData = (chunk) => {
       out += String(chunk);
-      const m = out.match(/http:\/\/127\.0\.0\.1:(\d+)\/\?token=([a-f0-9]+)/);
+      const m = out.match(/Dashboard URL: (http:\/\/127\.0\.0\.1:(\d+)\/[^\s]*)/);
       if (m) {
         clearTimeout(timer);
-        resolvePromise({ proc, url: m[0], port: Number(m[1]), token: m[2] });
+        const parsedUrl = new URL(m[1]);
+        resolvePromise({
+          proc,
+          url: m[1],
+          port: Number(m[2]),
+          token: parsedUrl.searchParams.get("token") ?? extraEnv.UNDERSTAND_ACCESS_TOKEN,
+        });
       }
     };
     proc.stdout.on("data", onData);
@@ -122,6 +143,41 @@ describe.skipIf(!existsSync(VIEWER_DIST))("understand-anything-viewer", () => {
     expect(res.status).toBe(403);
   });
 
+  it("auto-authenticates only loopback hosts without caching the token redirect", async () => {
+    const accessToken = "a".repeat(32);
+    const autoViewer = await startViewer(root, {
+      UNDERSTAND_ACCESS_TOKEN: accessToken,
+      UNDERSTAND_AUTO_AUTH: "1",
+    });
+    const autoBase = `http://127.0.0.1:${autoViewer.port}`;
+    try {
+      expect(autoViewer.url).toBe(`${autoBase}/`);
+
+      const redirect = await fetch(`${autoBase}/`, { redirect: "manual" });
+      expect(redirect.status).toBe(302);
+      expect(redirect.headers.get("cache-control")).toBe("no-store");
+      expect(redirect.headers.get("location")).toBe(`/?token=${accessToken}`);
+
+      const dashboard = await fetch(`${autoBase}${redirect.headers.get("location")}`);
+      expect(dashboard.status).toBe(200);
+
+      const protectedEndpoint = await fetch(`${autoBase}/knowledge-graph.json`);
+      expect(protectedEndpoint.status).toBe(403);
+
+      const reboundRoot = await requestWithHost(`${autoBase}/`, "attacker.example");
+      expect(reboundRoot.status).toBe(421);
+      expect(reboundRoot.location).toBeNull();
+
+      const reboundToken = await requestWithHost(
+        `${autoBase}/knowledge-graph.json?token=${accessToken}`,
+        "attacker.example",
+      );
+      expect(reboundToken.status).toBe(421);
+    } finally {
+      autoViewer.proc.kill();
+    }
+  });
+
   it("serves the graph from .ua/ with a valid token", async () => {
     const res = await fetch(`${base()}/knowledge-graph.json?token=${viewer.token}`);
     expect(res.status).toBe(200);
@@ -130,14 +186,20 @@ describe.skipIf(!existsSync(VIEWER_DIST))("understand-anything-viewer", () => {
     expect(graph.nodes[0].filePath).toBe("src/a.ts");
   });
 
+  it("preserves explicit-token access through a custom Host", async () => {
+    const response = await requestWithHost(
+      `${base()}/knowledge-graph.json?token=${viewer.token}`,
+      "dashboard.internal",
+    );
+    expect(response.status).toBe(200);
+  });
+
   it("serves a protected no-store freshness report", async () => {
     const denied = await fetch(`${base()}/staleness.json`);
     expect(denied.status).toBe(403);
     expect(denied.headers.get("cache-control")).toBe("no-store");
 
-    const res = await fetch(
-      `${base()}/staleness.json?token=${viewer.token}`,
-    );
+    const res = await fetch(`${base()}/staleness.json?token=${viewer.token}`);
     expect(res.status).toBe(200);
     expect(res.headers.get("cache-control")).toBe("no-store");
     expect(await res.json()).toMatchObject({
@@ -152,17 +214,13 @@ describe.skipIf(!existsSync(VIEWER_DIST))("understand-anything-viewer", () => {
   });
 
   it("serves file content only for files listed in the graph", async () => {
-    const ok = await fetch(
-      `${base()}/file-content.json?token=${viewer.token}&path=${encodeURIComponent("src/a.ts")}`,
-    );
+    const ok = await fetch(`${base()}/file-content.json?token=${viewer.token}&path=${encodeURIComponent("src/a.ts")}`);
     expect(ok.status).toBe(200);
     const body = await ok.json();
     expect(body.content).toContain("export const a");
     expect(body.language).toBe("typescript");
 
-    const denied = await fetch(
-      `${base()}/file-content.json?token=${viewer.token}&path=secret.txt`,
-    );
+    const denied = await fetch(`${base()}/file-content.json?token=${viewer.token}&path=secret.txt`);
     expect(denied.status).toBe(404);
   });
 
@@ -182,9 +240,7 @@ describe.skipIf(!existsSync(VIEWER_DIST))("understand-anything-viewer", () => {
     const legacyRoot = setupProject(".understand-anything");
     const legacyViewer = await startViewer(legacyRoot);
     try {
-      const res = await fetch(
-        `http://127.0.0.1:${legacyViewer.port}/knowledge-graph.json?token=${legacyViewer.token}`,
-      );
+      const res = await fetch(`http://127.0.0.1:${legacyViewer.port}/knowledge-graph.json?token=${legacyViewer.token}`);
       expect(res.status).toBe(200);
       expect((await res.json()).nodes).toHaveLength(1);
     } finally {

--- a/understand-anything-plugin/.claude-plugin/plugin.json
+++ b/understand-anything-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "understand-anything",
   "description": "AI-powered codebase understanding — analyze, visualize, and explain any project",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "author": {
     "name": "Egonex"
   },

--- a/understand-anything-plugin/package.json
+++ b/understand-anything-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@understand-anything/skill",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/understand-anything-plugin/packages/dashboard/src/__tests__/vite-staleness.test.ts
+++ b/understand-anything-plugin/packages/dashboard/src/__tests__/vite-staleness.test.ts
@@ -1,14 +1,10 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
-import {
-  createServer,
-  request as httpRequest,
-  type Server,
-} from "node:http";
+import { createServer, request as httpRequest, type Server } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createDashboardDataMiddleware } from "../../vite.config";
+import { createAutoAuthMiddleware, createDashboardDataMiddleware } from "../../vite.config";
 import { isDashboardFreshnessReport } from "../freshness";
 
 interface HttpResult {
@@ -87,24 +83,61 @@ async function startDashboardServer(accessToken: string): Promise<string> {
   return `http://127.0.0.1:${address.port}`;
 }
 
+async function startAutoAuthServer(accessToken: string, enabled: boolean): Promise<string> {
+  const middleware = createAutoAuthMiddleware(accessToken, enabled);
+  const server = createServer((req, res) => {
+    middleware(req, res, () => {
+      res.statusCode = 204;
+      res.end();
+    });
+  });
+  servers.push(server);
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Auto-auth test server did not expose a TCP port");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
 function requestJson(baseUrl: string, requestPath: string): Promise<HttpResult> {
   return new Promise((resolve, reject) => {
-    const request = httpRequest(
-      `${baseUrl}${requestPath}`,
-      { agent: false },
-      (response) => {
-        const chunks: Buffer[] = [];
-        response.on("data", (chunk: Buffer) => chunks.push(chunk));
-        response.on("end", () => {
-          const text = Buffer.concat(chunks).toString("utf8");
-          resolve({
-            status: response.statusCode ?? 0,
-            body: text.length > 0 ? JSON.parse(text) : null,
-            cacheControl: response.headers["cache-control"] ?? null,
-          });
+    const request = httpRequest(`${baseUrl}${requestPath}`, { agent: false }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer) => chunks.push(chunk));
+      response.on("end", () => {
+        const text = Buffer.concat(chunks).toString("utf8");
+        resolve({
+          status: response.statusCode ?? 0,
+          body: text.length > 0 ? JSON.parse(text) : null,
+          cacheControl: response.headers["cache-control"] ?? null,
         });
-      },
-    );
+      });
+    });
+    request.once("error", reject);
+    request.end();
+  });
+}
+
+function requestWithHost(
+  baseUrl: string,
+  requestPath: string,
+  host: string,
+): Promise<{ status: number; location: string | null }> {
+  return new Promise((resolve, reject) => {
+    const request = httpRequest(`${baseUrl}${requestPath}`, { agent: false, headers: { host } }, (response) => {
+      response.resume();
+      response.on("end", () =>
+        resolve({
+          status: response.statusCode ?? 0,
+          location: response.headers.location ?? null,
+        }),
+      );
+    });
     request.once("error", reject);
     request.end();
   });
@@ -139,128 +172,129 @@ afterEach(async () => {
   });
 });
 
-describe(
-  "dashboard graph freshness endpoint",
-  { timeout: 15_000 },
-  () => {
-    it("rejects an unauthorized request before serving freshness data", async () => {
-      writeGraph("knowledge-graph.json", baselineCommit);
-      const baseUrl = await startDashboardServer("test-token");
+describe("dashboard graph freshness endpoint", { timeout: 15_000 }, () => {
+  it("rejects an unauthorized request before serving freshness data", async () => {
+    writeGraph("knowledge-graph.json", baselineCommit);
+    const baseUrl = await startDashboardServer("test-token");
 
-      await expect(requestJson(baseUrl, "/staleness.json")).resolves.toEqual({
-        status: 403,
-        body: { error: "Forbidden: missing or invalid token" },
-        cacheControl: "no-store",
-      });
+    await expect(requestJson(baseUrl, "/staleness.json")).resolves.toEqual({
+      status: 403,
+      body: { error: "Forbidden: missing or invalid token" },
+      cacheControl: "no-store",
     });
+  });
 
-    it.each([".understand-anything", ".ua"])(
-      "serves a knowledge-only report from %s to an authorized request",
-      async (dataDir) => {
-        writeGraph("knowledge-graph.json", baselineCommit, dataDir);
-        const baseUrl = await startDashboardServer("test-token");
-
-        const response = await requestJson(
-          baseUrl,
-          "/staleness.json?token=test-token",
-        );
-
-        expect(response.status).toBe(200);
-        expect(response.cacheControl).toBe("no-store");
-        expect(isDashboardFreshnessReport(response.body)).toBe(true);
-        expect(response.body).toMatchObject({
-          graphs: {
-            knowledge: {
-              status: "fresh",
-              graphCommitHash: baselineCommit,
-              headCommitHash: baselineCommit,
-            },
-          },
-        });
-        expect(
-          (response.body as { graphs: Record<string, unknown> }).graphs,
-        ).not.toHaveProperty("domain");
-      },
-    );
-
-    it("reports knowledge and domain graph freshness independently", async () => {
-      writeProjectFile("src/index.ts", "export const value = 2;\n");
-      const headCommit = commitAll("project change");
-      writeGraph("knowledge-graph.json", headCommit);
-      writeGraph("domain-graph.json", baselineCommit);
+  it.each([".understand-anything", ".ua"])(
+    "serves a knowledge-only report from %s to an authorized request",
+    async (dataDir) => {
+      writeGraph("knowledge-graph.json", baselineCommit, dataDir);
       const baseUrl = await startDashboardServer("test-token");
 
-      const response = await requestJson(
-        baseUrl,
-        "/staleness.json?token=test-token",
-      );
+      const response = await requestJson(baseUrl, "/staleness.json?token=test-token");
+
+      expect(response.status).toBe(200);
+      expect(response.cacheControl).toBe("no-store");
       expect(isDashboardFreshnessReport(response.body)).toBe(true);
-      expect(response).toMatchObject({
-        status: 200,
-        body: {
-          graphs: {
-            knowledge: {
-              status: "fresh",
-              graphCommitHash: headCommit,
-            },
-            domain: {
-              status: "stale",
-              relation: "behind",
-              graphCommitHash: baselineCommit,
-              headCommitHash: headCommit,
-              commitsBehind: 1,
-              changedFiles: ["src/index.ts"],
-            },
+      expect(response.body).toMatchObject({
+        graphs: {
+          knowledge: {
+            status: "fresh",
+            graphCommitHash: baselineCommit,
+            headCommitHash: baselineCommit,
           },
         },
       });
+      expect((response.body as { graphs: Record<string, unknown> }).graphs).not.toHaveProperty("domain");
+    },
+  );
+
+  it("reports knowledge and domain graph freshness independently", async () => {
+    writeProjectFile("src/index.ts", "export const value = 2;\n");
+    const headCommit = commitAll("project change");
+    writeGraph("knowledge-graph.json", headCommit);
+    writeGraph("domain-graph.json", baselineCommit);
+    const baseUrl = await startDashboardServer("test-token");
+
+    const response = await requestJson(baseUrl, "/staleness.json?token=test-token");
+    expect(isDashboardFreshnessReport(response.body)).toBe(true);
+    expect(response).toMatchObject({
+      status: 200,
+      body: {
+        graphs: {
+          knowledge: {
+            status: "fresh",
+            graphCommitHash: headCommit,
+          },
+          domain: {
+            status: "stale",
+            relation: "behind",
+            graphCommitHash: baselineCommit,
+            headCommitHash: headCommit,
+            commitsBehind: 1,
+            changedFiles: ["src/index.ts"],
+          },
+        },
+      },
     });
+  });
 
-    it("returns 404 when the required knowledge graph is missing", async () => {
-      const baseUrl = await startDashboardServer("test-token");
+  it("returns 404 when the required knowledge graph is missing", async () => {
+    const baseUrl = await startDashboardServer("test-token");
 
-      await expect(
-        requestJson(baseUrl, "/staleness.json?token=test-token"),
-      ).resolves.toEqual({
-        status: 404,
-        body: { error: "No knowledge graph found. Run /understand first." },
-        cacheControl: "no-store",
-      });
+    await expect(requestJson(baseUrl, "/staleness.json?token=test-token")).resolves.toEqual({
+      status: 404,
+      body: { error: "No knowledge graph found. Run /understand first." },
+      cacheControl: "no-store",
     });
+  });
 
-    it("returns a safe 500 response for invalid knowledge graph JSON", async () => {
-      fs.writeFileSync(
-        path.join(graphDirectory(), "knowledge-graph.json"),
-        "{not-json",
-        "utf8",
-      );
-      const baseUrl = await startDashboardServer("test-token");
+  it("returns a safe 500 response for invalid knowledge graph JSON", async () => {
+    fs.writeFileSync(path.join(graphDirectory(), "knowledge-graph.json"), "{not-json", "utf8");
+    const baseUrl = await startDashboardServer("test-token");
 
-      await expect(
-        requestJson(baseUrl, "/staleness.json?token=test-token"),
-      ).resolves.toEqual({
-        status: 500,
-        body: { error: "Failed to read graph file" },
-        cacheControl: "no-store",
-      });
+    await expect(requestJson(baseUrl, "/staleness.json?token=test-token")).resolves.toEqual({
+      status: 500,
+      body: { error: "Failed to read graph file" },
+      cacheControl: "no-store",
     });
+  });
 
-    it("returns a safe 500 response for invalid optional domain graph JSON", async () => {
-      writeGraph("knowledge-graph.json", baselineCommit);
-      fs.writeFileSync(
-        path.join(graphDirectory(), "domain-graph.json"),
-        "{not-json",
-        "utf8",
-      );
-      const baseUrl = await startDashboardServer("test-token");
+  it("returns a safe 500 response for invalid optional domain graph JSON", async () => {
+    writeGraph("knowledge-graph.json", baselineCommit);
+    fs.writeFileSync(path.join(graphDirectory(), "domain-graph.json"), "{not-json", "utf8");
+    const baseUrl = await startDashboardServer("test-token");
 
-      await expect(
-        requestJson(baseUrl, "/staleness.json?token=test-token"),
-      ).resolves.toEqual({
-        status: 500,
-        body: { error: "Failed to read graph file" },
-        cacheControl: "no-store",
-      });
+    await expect(requestJson(baseUrl, "/staleness.json?token=test-token")).resolves.toEqual({
+      status: 500,
+      body: { error: "Failed to read graph file" },
+      cacheControl: "no-store",
     });
-  },
-);
+  });
+});
+
+describe("dashboard loopback auto-auth middleware", () => {
+  it("redirects a loopback root without caching the bearer token", async () => {
+    const baseUrl = await startAutoAuthServer("test-token", true);
+    const response = await fetch(`${baseUrl}/`, { redirect: "manual" });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/?token=test-token");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("rejects hostile hosts before issuing a token redirect", async () => {
+    const baseUrl = await startAutoAuthServer("test-token", true);
+    const response = await requestWithHost(baseUrl, "/", "attacker.example");
+
+    expect(response.status).toBe(421);
+    expect(response.location).toBeNull();
+  });
+
+  it("preserves the default explicit-token flow when disabled", async () => {
+    const baseUrl = await startAutoAuthServer("test-token", false);
+    const response = await fetch(`${baseUrl}/`, { redirect: "manual" });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("location")).toBeNull();
+  });
+});

--- a/understand-anything-plugin/packages/dashboard/vite.config.ts
+++ b/understand-anything-plugin/packages/dashboard/vite.config.ts
@@ -16,6 +16,7 @@ import {
 // This token is printed to the terminal and must be in the URL
 // to fetch knowledge-graph.json or diff-overlay.json.
 const ACCESS_TOKEN = process.env.UNDERSTAND_ACCESS_TOKEN || crypto.randomBytes(16).toString("hex");
+const AUTO_AUTH = process.env.UNDERSTAND_AUTO_AUTH === "1";
 const MAX_SOURCE_FILE_BYTES = 1024 * 1024;
 
 // Legacy directory first — projects analyzed before the `.ua` rename keep
@@ -300,7 +301,7 @@ const config: DashboardViteConfig = {
   server: {
     host: "127.0.0.1",
     port: 5173,
-    open: `/?token=${ACCESS_TOKEN}`,
+    open: AUTO_AUTH ? "/" : `/?token=${ACCESS_TOKEN}`,
   },
 
   resolve: {
@@ -352,9 +353,23 @@ const config: DashboardViteConfig = {
         server.httpServer?.once("listening", () => {
           const address = server.httpServer?.address();
           const port = typeof address === "object" && address ? address.port : 5173;
+          const dashboardUrl = AUTO_AUTH
+            ? `http://127.0.0.1:${port}/`
+            : `http://127.0.0.1:${port}/?token=${ACCESS_TOKEN}`;
           console.log(
-            `\n  🔑  Dashboard URL: http://127.0.0.1:${port}/?token=${ACCESS_TOKEN}\n`
+            `\n  🔑  Dashboard URL: ${dashboardUrl}\n`
           );
+        });
+
+        server.middlewares.use((req, res, next) => {
+          const url = new URL(req.url ?? "/", "http://127.0.0.1:5173");
+          if (AUTO_AUTH && url.pathname === "/" && !url.searchParams.has("token")) {
+            res.statusCode = 302;
+            res.setHeader("Location", `/?token=${encodeURIComponent(ACCESS_TOKEN)}`);
+            res.end();
+            return;
+          }
+          next();
         });
 
         server.middlewares.use(createDashboardDataMiddleware(ACCESS_TOKEN));

--- a/understand-anything-plugin/packages/dashboard/vite.config.ts
+++ b/understand-anything-plugin/packages/dashboard/vite.config.ts
@@ -6,11 +6,7 @@ import path from "path";
 import fs from "fs";
 import crypto from "crypto";
 import type { IncomingMessage, ServerResponse } from "http";
-import {
-  getGraphFreshnessBatch,
-  type GraphFreshnessInput,
-  type GraphFreshnessResult,
-} from "../core/src/staleness";
+import { getGraphFreshnessBatch, type GraphFreshnessInput, type GraphFreshnessResult } from "../core/src/staleness";
 
 // Generate a one-time token when the server process starts.
 // This token is printed to the terminal and must be in the URL
@@ -23,16 +19,43 @@ const MAX_SOURCE_FILE_BYTES = 1024 * 1024;
 // their existing `.understand-anything/` data.
 const UA_DIR_CANDIDATES = [".understand-anything", ".ua"];
 
+export function isLoopbackHost(host: string | undefined): boolean {
+  if (typeof host !== "string") return false;
+  return /^(?:(?:localhost|127\.0\.0\.1)(?::\d{1,5})?|\[::1\](?::\d{1,5})?)$/i.test(host);
+}
+
+export function createAutoAuthMiddleware(accessToken: string, enabled: boolean) {
+  return (req: IncomingMessage, res: ServerResponse, next: () => void): void => {
+    if (!enabled) {
+      next();
+      return;
+    }
+    if (!isLoopbackHost(req.headers.host)) {
+      res.statusCode = 421;
+      res.setHeader("Content-Type", "application/json");
+      res.end(
+        JSON.stringify({
+          error: "Misdirected Request: loopback Host required",
+        }),
+      );
+      return;
+    }
+    const url = new URL(req.url ?? "/", "http://127.0.0.1:5173");
+    if (url.pathname === "/" && !url.searchParams.has("token")) {
+      res.statusCode = 302;
+      res.setHeader("Cache-Control", "no-store");
+      res.setHeader("Location", `/?token=${encodeURIComponent(accessToken)}`);
+      res.end();
+      return;
+    }
+    next();
+  };
+}
+
 function graphFileCandidates(fileName: string): string[] {
   const graphDir = process.env.GRAPH_DIR;
-  const roots = [
-    ...(graphDir ? [graphDir] : []),
-    process.cwd(),
-    path.resolve(process.cwd(), "../../.."),
-  ];
-  return roots.flatMap((root) =>
-    UA_DIR_CANDIDATES.map((dir) => path.resolve(root, dir, fileName)),
-  );
+  const roots = [...(graphDir ? [graphDir] : []), process.cwd(), path.resolve(process.cwd(), "../../..")];
+  return roots.flatMap((root) => UA_DIR_CANDIDATES.map((dir) => path.resolve(root, dir, fileName)));
 }
 
 function findGraphFile(fileName: string): string | null {
@@ -203,14 +226,8 @@ function readGraphMetadata(graphFile: string): GraphFreshnessInput {
     };
   };
   return {
-    graphCommitHash:
-      typeof graph.project?.gitCommitHash === "string"
-        ? graph.project.gitCommitHash
-        : undefined,
-    lastAnalyzedAt:
-      typeof graph.project?.analyzedAt === "string"
-        ? graph.project.analyzedAt
-        : undefined,
+    graphCommitHash: typeof graph.project?.gitCommitHash === "string" ? graph.project.gitCommitHash : undefined,
+    lastAnalyzedAt: typeof graph.project?.analyzedAt === "string" ? graph.project.analyzedAt : undefined,
   };
 }
 
@@ -225,9 +242,7 @@ export async function readGraphFreshness() {
   let domainInput: GraphFreshnessInput | undefined;
   try {
     knowledgeInput = readGraphMetadata(graphFile);
-    domainInput = fs.existsSync(domainGraphFile)
-      ? readGraphMetadata(domainGraphFile)
-      : undefined;
+    domainInput = fs.existsSync(domainGraphFile) ? readGraphMetadata(domainGraphFile) : undefined;
   } catch {
     return rejectFileRequest("Failed to read graph file", 500);
   }
@@ -252,15 +267,9 @@ export async function readGraphFreshness() {
   };
 }
 
-type DashboardDataMiddleware = (
-  req: IncomingMessage,
-  res: ServerResponse,
-  next: () => void,
-) => void;
+type DashboardDataMiddleware = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
 
-export function createDashboardDataMiddleware(
-  accessToken: string,
-): DashboardDataMiddleware {
+export function createDashboardDataMiddleware(accessToken: string): DashboardDataMiddleware {
   return (req, res, next) => {
     const url = new URL(req.url ?? "/", "http://127.0.0.1:5173");
     if (url.pathname !== "/staleness.json") {
@@ -325,16 +334,15 @@ const config: DashboardViteConfig = {
           // bloat the main bundle. graphology is similarly large.
           if (id.includes("node_modules/elkjs/")) return "elk";
           if (id.includes("node_modules/graphology")) return "graphology";
-          if (
-            id.includes("node_modules/@dagrejs/") ||
-            id.includes("node_modules/d3-force/")
-          ) {
+          if (id.includes("node_modules/@dagrejs/") || id.includes("node_modules/d3-force/")) {
             return "graph-layout";
           }
           if (
             id.includes("node_modules/react-markdown/") ||
             id.includes("node_modules/hast-util-to-jsx-runtime/") ||
-            /[\\/]node_modules[\\/](remark|rehype|mdast|hast|unist|micromark|decode-named-character-reference|property-information|space-separated-tokens|comma-separated-tokens|html-url-attributes|devlop|bail|ccount|character-entities|is-plain-obj|trim-lines|trough|unified|vfile|zwitch)/.test(id)
+            /[\\/]node_modules[\\/](remark|rehype|mdast|hast|unist|micromark|decode-named-character-reference|property-information|space-separated-tokens|comma-separated-tokens|html-url-attributes|devlop|bail|ccount|character-entities|is-plain-obj|trim-lines|trough|unified|vfile|zwitch)/.test(
+              id,
+            )
           ) {
             return "markdown";
           }
@@ -356,21 +364,10 @@ const config: DashboardViteConfig = {
           const dashboardUrl = AUTO_AUTH
             ? `http://127.0.0.1:${port}/`
             : `http://127.0.0.1:${port}/?token=${ACCESS_TOKEN}`;
-          console.log(
-            `\n  🔑  Dashboard URL: ${dashboardUrl}\n`
-          );
+          console.log(`\n  🔑  Dashboard URL: ${dashboardUrl}\n`);
         });
 
-        server.middlewares.use((req, res, next) => {
-          const url = new URL(req.url ?? "/", "http://127.0.0.1:5173");
-          if (AUTO_AUTH && url.pathname === "/" && !url.searchParams.has("token")) {
-            res.statusCode = 302;
-            res.setHeader("Location", `/?token=${encodeURIComponent(ACCESS_TOKEN)}`);
-            res.end();
-            return;
-          }
-          next();
-        });
+        server.middlewares.use(createAutoAuthMiddleware(ACCESS_TOKEN, AUTO_AUTH));
 
         server.middlewares.use(createDashboardDataMiddleware(ACCESS_TOKEN));
 
@@ -393,7 +390,9 @@ const config: DashboardViteConfig = {
           // FIX 3 — require the one-time token on all data endpoints.
           // Requests without a matching ?token= get a 403.
           if (url.searchParams.get("token") !== ACCESS_TOKEN) {
-            sendJson(res, 403, { error: "Forbidden: missing or invalid token" });
+            sendJson(res, 403, {
+              error: "Forbidden: missing or invalid token",
+            });
             return;
           }
 
@@ -425,10 +424,10 @@ const config: DashboardViteConfig = {
             pathname === "/diff-overlay.json"
               ? "diff-overlay.json"
               : pathname === "/meta.json"
-              ? "meta.json"
-              : pathname === "/domain-graph.json"
-              ? "domain-graph.json"
-              : "knowledge-graph.json";
+                ? "meta.json"
+                : pathname === "/domain-graph.json"
+                  ? "domain-graph.json"
+                  : "knowledge-graph.json";
 
           const candidates = graphFileCandidates(fileName);
 
@@ -458,8 +457,8 @@ const config: DashboardViteConfig = {
                   const rel = abs.startsWith(projectRoot)
                     ? abs.slice(projectRoot.length).replace(/^[\\/]/, "")
                     : path.isAbsolute(abs)
-                    ? path.basename(abs) // absolute but outside root — use filename only
-                    : abs;              // already relative — keep as-is
+                      ? path.basename(abs) // absolute but outside root — use filename only
+                      : abs; // already relative — keep as-is
                   return { ...node, filePath: rel };
                 });
               }
@@ -481,7 +480,11 @@ const config: DashboardViteConfig = {
           res.statusCode = 404;
           if (pathname === "/knowledge-graph.json") {
             res.setHeader("Content-Type", "application/json");
-            res.end(JSON.stringify({ error: "No knowledge graph found. Run /understand first." }));
+            res.end(
+              JSON.stringify({
+                error: "No knowledge graph found. Run /understand first.",
+              }),
+            );
           } else {
             res.end();
           }

--- a/understand-anything-plugin/packages/viewer/README.md
+++ b/understand-anything-plugin/packages/viewer/README.md
@@ -12,6 +12,14 @@ npx https://github.com/Egonex-AI/Understand-Anything/releases/latest/download/un
 
 The project directory (default: current directory) must contain a data directory — `.ua/` or legacy `.understand-anything/` — with a `knowledge-graph.json`. The terminal prints a tokenized URL (`http://127.0.0.1:<port>/?token=…`) and opens it in your browser.
 
+For a clean loopback URL, opt into one-time automatic authentication:
+
+```bash
+UNDERSTAND_AUTO_AUTH=1 npx https://github.com/Egonex-AI/Understand-Anything/releases/latest/download/understand-anything-viewer.tgz /path/to/analyzed/project
+```
+
+This mode redirects the clean root URL through the tokenized URL once. The dashboard stores the token for that tab and removes it from the address bar. Protected graph and source endpoints still require the token, redirects are not cached, and non-loopback `Host` headers are rejected to prevent DNS rebinding. Leave the variable unset for the explicit tokenized-URL flow.
+
 Options: `--port <n>` (default 5173, auto-increments if taken), `--no-open`.
 
 Everything is served read-only from local disk, bound to `127.0.0.1`, and gated behind a one-time access token — no data leaves your machine.

--- a/understand-anything-plugin/packages/viewer/bin/viewer.mjs
+++ b/understand-anything-plugin/packages/viewer/bin/viewer.mjs
@@ -84,6 +84,7 @@ if (!graphDir) {
 }
 
 const ACCESS_TOKEN = process.env.UNDERSTAND_ACCESS_TOKEN || crypto.randomBytes(16).toString("hex");
+const AUTO_AUTH = process.env.UNDERSTAND_AUTO_AUTH === "1";
 
 // ── Helpers (mirroring vite.config.ts) ────────────────────────────────────
 
@@ -320,6 +321,16 @@ const server = createServer((req, res) => {
   const url = new URL(req.url ?? "/", "http://127.0.0.1");
   const pathname = url.pathname;
 
+  // Local helpers can make the root URL frictionless without weakening the
+  // protected graph and source-file endpoints. The dashboard consumes the
+  // token once, stores it for this tab, and removes it from the address bar.
+  if (AUTO_AUTH && pathname === "/" && !url.searchParams.has("token")) {
+    res.statusCode = 302;
+    res.setHeader("Location", `/?token=${encodeURIComponent(ACCESS_TOKEN)}`);
+    res.end();
+    return;
+  }
+
   if (pathname === "/staleness.json") {
     res.setHeader("Cache-Control", "no-store");
   }
@@ -378,7 +389,9 @@ function listen(attemptPort, attemptsLeft) {
   server.listen(attemptPort, "127.0.0.1", () => {
     const address = server.address();
     const boundPort = typeof address === "object" && address ? address.port : attemptPort;
-    const dashboardUrl = `http://127.0.0.1:${boundPort}/?token=${ACCESS_TOKEN}`;
+    const dashboardUrl = AUTO_AUTH
+      ? `http://127.0.0.1:${boundPort}/`
+      : `http://127.0.0.1:${boundPort}/?token=${ACCESS_TOKEN}`;
     console.log(`\n  Serving graph from ${graphDir}`);
     console.log(`  🔑  Dashboard URL: ${dashboardUrl}\n`);
     if (openBrowser) {

--- a/understand-anything-plugin/packages/viewer/bin/viewer.mjs
+++ b/understand-anything-plugin/packages/viewer/bin/viewer.mjs
@@ -65,20 +65,20 @@ for (let i = 0; i < args.length; i++) {
 if (!fs.existsSync(DIST_DIR)) {
   console.error(
     "Error: embedded dashboard build not found. This tarball was packed " +
-    "without running the build — run `pnpm --filter understand-anything-viewer build` first.",
+      "without running the build — run `pnpm --filter understand-anything-viewer build` first.",
   );
   process.exit(1);
 }
 
-const graphDir = UA_DIR_CANDIDATES
-  .map((d) => path.join(projectRoot, d))
-  .find((d) => fs.existsSync(path.join(d, "knowledge-graph.json")));
+const graphDir = UA_DIR_CANDIDATES.map((d) => path.join(projectRoot, d)).find((d) =>
+  fs.existsSync(path.join(d, "knowledge-graph.json")),
+);
 
 if (!graphDir) {
   console.error(
     `Error: no knowledge graph found under ${projectRoot}\n` +
-    "Expected .ua/knowledge-graph.json (or legacy .understand-anything/). " +
-    "Generate one with /understand first, or pass the project directory as an argument.",
+      "Expected .ua/knowledge-graph.json (or legacy .understand-anything/). " +
+      "Generate one with /understand first, or pass the project directory as an argument.",
   );
   process.exit(1);
 }
@@ -92,6 +92,11 @@ function sendJson(res, statusCode, payload) {
   res.statusCode = statusCode;
   res.setHeader("Content-Type", "application/json");
   res.end(JSON.stringify(payload));
+}
+
+function isLoopbackHost(host) {
+  if (typeof host !== "string") return false;
+  return /^(?:(?:localhost|127\.0\.0\.1)(?::\d{1,5})?|\[::1\](?::\d{1,5})?)$/i.test(host);
 }
 
 function normalizeGraphPath(filePath) {
@@ -133,17 +138,40 @@ function graphFilePathSet() {
 function detectLanguage(filePath) {
   const ext = path.extname(filePath).slice(1).toLowerCase();
   const byExt = {
-    bash: "bash", c: "c", cc: "cpp", cpp: "cpp", cs: "csharp", css: "css",
-    go: "go", h: "c", hpp: "cpp", html: "markup", java: "java",
-    js: "javascript", jsx: "jsx", json: "json", md: "markdown",
-    mjs: "javascript", py: "python", rb: "ruby", rs: "rust", sh: "bash",
-    ts: "typescript", tsx: "tsx", txt: "text", yaml: "yaml", yml: "yaml",
+    bash: "bash",
+    c: "c",
+    cc: "cpp",
+    cpp: "cpp",
+    cs: "csharp",
+    css: "css",
+    go: "go",
+    h: "c",
+    hpp: "cpp",
+    html: "markup",
+    java: "java",
+    js: "javascript",
+    jsx: "jsx",
+    json: "json",
+    md: "markdown",
+    mjs: "javascript",
+    py: "python",
+    rb: "ruby",
+    rs: "rust",
+    sh: "bash",
+    ts: "typescript",
+    tsx: "tsx",
+    txt: "text",
+    yaml: "yaml",
+    yml: "yaml",
   };
   return byExt[ext] ?? "text";
 }
 
 function readSourceFile(url) {
-  const reject = (message, statusCode = 400) => ({ statusCode, payload: { error: message } });
+  const reject = (message, statusCode = 400) => ({
+    statusCode,
+    payload: { error: message },
+  });
   const requestedPath = url.searchParams.get("path") ?? "";
   if (!requestedPath) return reject("Missing path");
   if (requestedPath.includes("\0")) return reject("Invalid path");
@@ -225,7 +253,9 @@ function serveGraphJson(res, fileName) {
     return;
   }
   if (fileName === "knowledge-graph.json") {
-    sendJson(res, 404, { error: "No knowledge graph found. Run /understand first." });
+    sendJson(res, 404, {
+      error: "No knowledge graph found. Run /understand first.",
+    });
   } else {
     res.statusCode = 404;
     res.end();
@@ -233,18 +263,10 @@ function serveGraphJson(res, fileName) {
 }
 
 function readGraphMetadata(fileName) {
-  const graph = JSON.parse(
-    fs.readFileSync(path.join(graphDir, fileName), "utf-8"),
-  );
+  const graph = JSON.parse(fs.readFileSync(path.join(graphDir, fileName), "utf-8"));
   return {
-    graphCommitHash:
-      typeof graph.project?.gitCommitHash === "string"
-        ? graph.project.gitCommitHash
-        : undefined,
-    lastAnalyzedAt:
-      typeof graph.project?.analyzedAt === "string"
-        ? graph.project.analyzedAt
-        : undefined,
+    graphCommitHash: typeof graph.project?.gitCommitHash === "string" ? graph.project.gitCommitHash : undefined,
+    lastAnalyzedAt: typeof graph.project?.analyzedAt === "string" ? graph.project.analyzedAt : undefined,
   };
 }
 
@@ -262,9 +284,7 @@ async function readGraphFreshness() {
   try {
     inputs = {
       knowledge: readGraphMetadata("knowledge-graph.json"),
-      ...(fs.existsSync(domainGraph)
-        ? { domain: readGraphMetadata("domain-graph.json") }
-        : {}),
+      ...(fs.existsSync(domainGraph) ? { domain: readGraphMetadata("domain-graph.json") } : {}),
     };
   } catch {
     return {
@@ -282,10 +302,18 @@ async function readGraphFreshness() {
 }
 
 const CONTENT_TYPES = {
-  ".css": "text/css", ".html": "text/html", ".ico": "image/x-icon",
-  ".js": "text/javascript", ".json": "application/json", ".map": "application/json",
-  ".png": "image/png", ".svg": "image/svg+xml", ".txt": "text/plain",
-  ".wasm": "application/wasm", ".woff": "font/woff", ".woff2": "font/woff2",
+  ".css": "text/css",
+  ".html": "text/html",
+  ".ico": "image/x-icon",
+  ".js": "text/javascript",
+  ".json": "application/json",
+  ".map": "application/json",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".txt": "text/plain",
+  ".wasm": "application/wasm",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
 };
 
 function serveStatic(res, pathname) {
@@ -321,11 +349,21 @@ const server = createServer((req, res) => {
   const url = new URL(req.url ?? "/", "http://127.0.0.1");
   const pathname = url.pathname;
 
+  // Binding to loopback is not sufficient against DNS rebinding: reject any
+  // request whose HTTP Host does not also name the loopback interface.
+  if (AUTO_AUTH && !isLoopbackHost(req.headers.host)) {
+    sendJson(res, 421, {
+      error: "Misdirected Request: loopback Host required",
+    });
+    return;
+  }
+
   // Local helpers can make the root URL frictionless without weakening the
   // protected graph and source-file endpoints. The dashboard consumes the
   // token once, stores it for this tab, and removes it from the address bar.
   if (AUTO_AUTH && pathname === "/" && !url.searchParams.has("token")) {
     res.statusCode = 302;
+    res.setHeader("Cache-Control", "no-store");
     res.setHeader("Location", `/?token=${encodeURIComponent(ACCESS_TOKEN)}`);
     res.end();
     return;
@@ -396,7 +434,11 @@ function listen(attemptPort, attemptsLeft) {
     console.log(`  🔑  Dashboard URL: ${dashboardUrl}\n`);
     if (openBrowser) {
       const opener = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-      spawn(opener, [dashboardUrl], { shell: process.platform === "win32", stdio: "ignore", detached: true }).unref();
+      spawn(opener, [dashboardUrl], {
+        shell: process.platform === "win32",
+        stdio: "ignore",
+        detached: true,
+      }).unref();
     }
   });
 }

--- a/understand-anything-plugin/packages/viewer/package.json
+++ b/understand-anything-plugin/packages/viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "understand-anything-viewer",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Standalone read-only viewer for Understand-Anything knowledge graphs — no Claude Code or LLM required.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- add opt-in `UNDERSTAND_AUTO_AUTH=1` clean-root entry for Vite and the standalone viewer
- preserve bearer-token checks on graph and source endpoints
- reject non-loopback Host headers in auto-auth mode to prevent DNS rebinding
- mark token-bearing redirects `Cache-Control: no-store`
- document the mode and bump all plugin manifests to 2.9.5

## Verification

- `pnpm test` — 509 passed, 4 skipped
- `pnpm lint`
- dashboard production build
- standalone viewer production build
- live checks: clean root 302/no-store, unauthenticated endpoint 403, hostile Host 421, authenticated dashboard 200
- independent agent peer review: ship

## Compatibility

The feature is opt-in. With `UNDERSTAND_AUTO_AUTH` unset, the existing explicit tokenized-URL flow and custom-Host behavior remain unchanged.