### PR TITLE
fix: extract function values wrapped in a call, array or object

### DIFF
--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/typescript-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/typescript-extractor.test.ts
@@ -85,4 +85,84 @@ describe("TypeScriptExtractor", () => {
       parser.delete();
     });
   });
+
+  // ---- Function values wrapped in a call, array or object ----
+  //
+  // A declarator whose value is a call was previously skipped outright, so the
+  // dominant idioms of modern React/TypeScript produced no symbol at all and
+  // their files dropped out of the graph: forwardRef and memo components, cva
+  // variants, Redux createSlice, TanStack column tables.
+
+  describe("extractStructure - wrapped function values", () => {
+    const names = (code: string): string[] => {
+      const { tree, parser, root } = parse(code);
+      const result = extractor.extractStructure(root);
+      const out = result.functions.map((f) => f.name);
+      tree.delete();
+      parser.delete();
+      return out;
+    };
+
+    it("extracts a component wrapped in forwardRef", () => {
+      expect(
+        names(`const Button = forwardRef((props, ref) => { return null; });`),
+      ).toContain("Button");
+    });
+
+    it("extracts a component wrapped in memo", () => {
+      expect(
+        names(`const Card = memo(function Inner() { return null; });`),
+      ).toContain("Card");
+    });
+
+    it("extracts through a member-call wrapper such as React.forwardRef", () => {
+      expect(
+        names(`const Input = React.forwardRef((p, ref) => { return null; });`),
+      ).toContain("Input");
+    });
+
+    it("extracts a slice whose handlers sit inside an object argument", () => {
+      expect(
+        names(`const slice = createSlice({
+  reducers: { setX: (state, action) => { state.x = action.payload; } },
+});`),
+      ).toContain("slice");
+    });
+
+    it("extracts a table whose cell renderers sit inside an array", () => {
+      expect(
+        names(`const columns = [{ accessorKey: "id", cell: (row) => row.id }];`),
+      ).toContain("columns");
+    });
+
+    it("extracts a constructed value carrying a callback", () => {
+      expect(
+        names(`const client = new QueryClient({ retry: () => false });`),
+      ).toContain("client");
+    });
+
+    // Guard against the obvious over-correction: a const bound to a plain
+    // value is not a function and must not become one.
+    it("does not invent a symbol for a plain literal", () => {
+      const out = names(`const answer = 42;
+const label = "hello";
+const config = { retries: 3, verbose: true };
+const list = [1, 2, 3];`);
+      expect(out).not.toContain("answer");
+      expect(out).not.toContain("label");
+      expect(out).not.toContain("config");
+      expect(out).not.toContain("list");
+    });
+
+    // Regression guards: the direct forms must keep working.
+    it("still extracts a direct arrow function", () => {
+      expect(names(`const add = (a: number, b: number) => a + b;`)).toContain(
+        "add",
+      );
+    });
+
+    it("still extracts a direct function expression", () => {
+      expect(names(`const run = function () { return 1; };`)).toContain("run");
+    });
+  });
 });

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/typescript-extractor.ts
@@ -326,34 +326,76 @@ export class TypeScriptExtractor implements LanguageExtractor {
 
       const nameNode = child.childForFieldName("name");
       const valueNode = child.childForFieldName("value");
+      if (!nameNode || !valueNode) continue;
 
-      if (
-        nameNode &&
-        valueNode &&
-        (valueNode.type === "arrow_function" ||
-          valueNode.type === "function_expression" ||
-          valueNode.type === "function")
-      ) {
-        const params = extractParams(
-          valueNode.childForFieldName("parameters") ??
-            valueNode.children.find(
-              (c) => c.type === "formal_parameters",
-            ) ??
-            null,
-        );
-        const returnType = extractReturnType(valueNode);
+      const fnNode = this.resolveFunctionValue(valueNode);
+      if (!fnNode) continue;
 
-        functions.push({
-          name: nameNode.text,
-          lineRange: [
-            node.startPosition.row + 1,
-            node.endPosition.row + 1,
-          ],
-          params,
-          returnType,
-        });
-      }
+      const params = extractParams(
+        fnNode.childForFieldName("parameters") ??
+          fnNode.children.find((c) => c.type === "formal_parameters") ??
+          null,
+      );
+      const returnType = extractReturnType(fnNode);
+
+      functions.push({
+        name: nameNode.text,
+        lineRange: [
+          node.startPosition.row + 1,
+          node.endPosition.row + 1,
+        ],
+        params,
+        returnType,
+      });
     }
+  }
+
+  /**
+   * Tra ve node ham dai dien cho gia tri cua mot declarator, ke ca khi ham bi
+   * boc trong loi goi hoac nam trong mang/object literal.
+   */
+  private resolveFunctionValue(
+    valueNode: TreeSitterNode | null,
+  ): TreeSitterNode | null {
+    if (!valueNode) return null;
+    const isFn = (t: string): boolean =>
+      t === "arrow_function" ||
+      t === "function_expression" ||
+      t === "function";
+
+    if (isFn(valueNode.type)) return valueNode;
+
+    if (
+      valueNode.type !== "call_expression" &&
+      valueNode.type !== "new_expression" &&
+      valueNode.type !== "array" &&
+      valueNode.type !== "object"
+    ) {
+      return null;
+    }
+
+    // Co chan: literal cau hinh (theme, i18n, route table) co the rat lon, va
+    // ham nay chay cho MOI declarator cua MOI file.
+    const MAX_DEPTH = 8;
+    const MAX_NODES = 2000;
+    let seen = 0;
+
+    const walk = (
+      n: TreeSitterNode,
+      depth: number,
+    ): TreeSitterNode | null => {
+      if (depth > MAX_DEPTH || ++seen > MAX_NODES) return null;
+      for (let i = 0; i < n.childCount; i++) {
+        const c = n.child(i);
+        if (!c) continue;
+        if (isFn(c.type)) return c;
+        const found = walk(c, depth + 1);
+        if (found) return found;
+      }
+      return null;
+    };
+
+    return walk(valueNode, 0);
   }
 
   private extractImport(


### PR DESCRIPTION
## Problem

`TypeScriptExtractor.extractVariableDeclarations` only accepts a declarator
whose value is *directly* an `arrow_function`, `function_expression` or
`function`. Every other value type is skipped, which silently drops the
dominant idioms of modern React/TypeScript:

```ts
const Button   = forwardRef((props, ref) => ...)        // call_expression
const Card     = memo(() => ...)                        // call_expression
const variants = cva(...)                               // call_expression
const slice    = createSlice({ reducers: { ... } })     // call_expression
const client   = new QueryClient({ ... })               // new_expression
const columns: ColumnDef<T>[] = [{ cell: () => ... }]   // array
```

When every top-level declaration in a file uses one of these forms, the file
yields **zero** function nodes and effectively disappears from the graph.

## Impact

Measured on a 360-file React admin codebase: 71 files were missing symbols,
and **56 of them came from this single gap** — shadcn/ui components
(`forwardRef`), TanStack Table column definitions (array literals), and Redux
slices (`createSlice`). Any project built on those libraries is affected the
same way, and nothing in the output signals it: the file nodes are all present,
so the graph looks populated while carrying almost no extracted logic.

## Change

Adds `resolveFunctionValue`, which returns the function node representing a
declarator's value:

- directly, when the value is already a function (unchanged behaviour);
- otherwise by searching a `call_expression`, `new_expression`, `array` or
  `object` for the first function inside it.

The search is bounded (depth 8, 2000 nodes) because configuration literals
such as theme or route tables can be large, and this runs for every declarator
of every file.

Parameters and return type are read from the function actually found rather
than from the wrapper.

## Not affected

A `const` bound to a plain literal, string, number, plain object or plain array
is still **not** reported as a function, so this does not inflate graphs with
non-callable values. There is an explicit test for that.

## Tests

9 new cases in `typescript-extractor.test.ts`: one per wrapper form, a guard
that plain values stay ignored, and regression guards for the two direct forms.

- `pnpm --filter @understand-anything/core test` — 985 passed (46 files)
- `pnpm lint` — clean
- `pnpm build` — clean
