### PR TITLE
fix(csharp): restore deterministic dependency resolution

### DIFF
--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -95,6 +95,7 @@ describe('extract-import-map.mjs — TypeScript / JavaScript resolver', () => {
     expect(result.output.stats.filesScanned).toBe(4);
     expect(result.output.stats.filesWithImports).toBe(1);
     expect(result.output.stats.totalEdges).toBe(2);
+    expect(result.output.stats.csharp).toBeUndefined();
   });
 
   it('orders Unicode import targets by locale-independent UTF-16 code units', () => {
@@ -1067,30 +1068,184 @@ describe('extract-import-map.mjs — C# resolver', () => {
     }
   });
 
-  it('resolves c# using directives via dotted-suffix probe', () => {
+  it('resolves C# dependencies from unambiguous declared type references', () => {
     projectRoot = setupTree({
       'Program.cs':
-        `using System;\nusing MyApp.Util.Helper;\nusing MyApp.Models.User;\n\nnamespace MyApp { class Program { } }\n`,
-      'MyApp/Util/Helper.cs':
-        `namespace MyApp.Util { public class Helper { } }\n`,
-      'MyApp/Models/User.cs':
-        `namespace MyApp.Models { public class User { } }\n`,
+        `using MyApp.Services;\nusing MyApp.Repositories;\n\nnamespace MyApp.Controllers;\npublic class Program(IFooService service) : BaseProgram {\n  private readonly IRepository _repository;\n  public void Run(IRepository repository) { }\n}\n`,
+      'Services/IFooService.cs':
+        `namespace MyApp.Services; public interface IFooService { void Run(); }\n`,
+      'Repositories/IRepository.cs':
+        `namespace MyApp.Repositories; public interface IRepository { void Save(); }\n`,
+      'BaseProgram.cs':
+        `namespace MyApp.Controllers; public class BaseProgram { }\n`,
+      'Services/Unused.cs':
+        `namespace MyApp.Services; public class Unused { }\n`,
     });
 
     const result = runScript(projectRoot, {
       projectRoot,
       files: [
         { path: 'Program.cs', language: 'csharp', fileCategory: 'code' },
-        { path: 'MyApp/Util/Helper.cs', language: 'csharp', fileCategory: 'code' },
-        { path: 'MyApp/Models/User.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'Services/IFooService.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'Repositories/IRepository.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'BaseProgram.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'Services/Unused.cs', language: 'csharp', fileCategory: 'code' },
       ],
     });
 
     expect(result.status).toBe(0);
     expect(result.output.importMap['Program.cs']).toEqual([
-      'MyApp/Models/User.cs',
-      'MyApp/Util/Helper.cs',
+      'BaseProgram.cs',
+      'Repositories/IRepository.cs',
+      'Services/IFooService.cs',
     ]);
+    expect(result.output.importMap['Program.cs']).not.toContain('Services/Unused.cs');
+  });
+
+  it('does not resolve ordinary C# namespace using directives by fan-out or file probing', () => {
+    projectRoot = setupTree({
+      'Program.cs':
+        `using MyApp.Services;\n\nnamespace MyApp.Controllers;\npublic class Program { }\n`,
+      'Services/Foo.cs':
+        `namespace MyApp.Services; public class Foo { }\n`,
+      'Services/Bar.cs':
+        `namespace MyApp.Services; public class Bar { }\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'Program.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'Services/Foo.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'Services/Bar.cs', language: 'csharp', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['Program.cs']).toEqual([]);
+  });
+
+  it('skips ambiguous C# type references', () => {
+    projectRoot = setupTree({
+      'Program.cs':
+        `using A;\nusing B;\n\nnamespace App;\npublic class Program(IFoo foo) { }\n`,
+      'A/IFoo.cs':
+        `namespace A; public interface IFoo { }\n`,
+      'B/IFoo.cs':
+        `namespace B; public interface IFoo { }\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'Program.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'A/IFoo.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'B/IFoo.cs', language: 'csharp', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['Program.cs']).toEqual([]);
+  });
+
+  it('does not treat C# alias or static using directives as namespace imports', () => {
+    projectRoot = setupTree({
+      'Services/Service.cs':
+        `using static System.Math;\nusing Repo = App.Repositories;\n\nnamespace App.Services;\npublic class Service(IRepository repository) { }\n`,
+      'Repositories/IRepository.cs':
+        `namespace App.Repositories; public interface IRepository { }\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'Services/Service.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'Repositories/IRepository.cs', language: 'csharp', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['Services/Service.cs']).toEqual([]);
+  });
+
+  it('resolves C# dependencies from using directives inside block namespaces', () => {
+    projectRoot = setupTree({
+      'Services/Service.cs':
+        `namespace App.Services {\n  using App.Repositories;\n  public class Service(IRepository repository) { }\n}\n`,
+      'Repositories/IRepository.cs':
+        `namespace App.Repositories; public interface IRepository { }\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'Services/Service.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'Repositories/IRepository.cs', language: 'csharp', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['Services/Service.cs']).toEqual([
+      'Repositories/IRepository.cs',
+    ]);
+  });
+
+  it('applies C# global using directives across files', () => {
+    projectRoot = setupTree({
+      'GlobalUsings.cs':
+        `global using App.Repositories;\nglobal using static System.Math;\n`,
+      'Services/Service.cs':
+        `namespace App.Services;\npublic class Service(IRepository repository) { }\n`,
+      'Repositories/IRepository.cs':
+        `namespace App.Repositories; public interface IRepository { }\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'GlobalUsings.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'Services/Service.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'Repositories/IRepository.cs', language: 'csharp', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['Services/Service.cs']).toEqual([
+      'Repositories/IRepository.cs',
+    ]);
+  });
+
+  it('scopes C# global using directives to their .csproj project', () => {
+    projectRoot = setupTree({
+      'ProjectA/ProjectA.csproj': '<Project Sdk="Microsoft.NET.Sdk" />\n',
+      'ProjectA/GlobalUsings.cs':
+        `global using ProjectA.Repositories;\n`,
+      'ProjectA/Services/Service.cs':
+        `namespace ProjectA.Services;\npublic class Service(IRepository repository) { }\n`,
+      'ProjectA/Repositories/IRepository.cs':
+        `namespace ProjectA.Repositories; public interface IRepository { }\n`,
+      'ProjectB/ProjectB.csproj': '<Project Sdk="Microsoft.NET.Sdk" />\n',
+      'ProjectB/Services/Service.cs':
+        `namespace ProjectB.Services;\npublic class Service(IRepository repository) { }\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'ProjectA/ProjectA.csproj', language: 'xml', fileCategory: 'config' },
+        { path: 'ProjectA/GlobalUsings.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'ProjectA/Services/Service.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'ProjectA/Repositories/IRepository.cs', language: 'csharp', fileCategory: 'code' },
+        { path: 'ProjectB/ProjectB.csproj', language: 'xml', fileCategory: 'config' },
+        { path: 'ProjectB/Services/Service.cs', language: 'csharp', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.importMap['ProjectA/Services/Service.cs']).toEqual([
+      'ProjectA/Repositories/IRepository.cs',
+    ]);
+    expect(result.output.importMap['ProjectB/Services/Service.cs']).toEqual([]);
   });
 });
 
@@ -1429,7 +1584,7 @@ describe('extract-import-map.mjs — Swift resolver', () => {
     expect(result.output.importMap['Sources/App/Feature.swift']).toEqual([]);
     expect(result.output.stats.filesWithImports).toBe(1);
     expect(result.output.stats.totalEdges).toBe(2);
-  });
+  }, 10000);
 
   it('uses Package.swift custom target paths when module name differs from directory name', () => {
     projectRoot = setupTree({
@@ -1461,7 +1616,7 @@ describe('extract-import-map.mjs — Swift resolver', () => {
       'Core/Model/User.swift',
     ]);
     expect(result.output.importMap['Package.swift']).toEqual([]);
-  });
+  }, 10000);
 
   it('drops Swift SDK imports when no project module matches', () => {
     projectRoot = setupTree({
@@ -1478,7 +1633,7 @@ describe('extract-import-map.mjs — Swift resolver', () => {
     expect(result.status).toBe(0);
     expect(result.output.importMap['Sources/App/View.swift']).toEqual([]);
     expect(result.output.stats.totalEdges).toBe(0);
-  });
+  }, 10000);
 });
 
 describe('extract-import-map.mjs — per-file failure resilience', () => {

--- a/tests/skill/understand/test_extract_structure_outcomes.test.mjs
+++ b/tests/skill/understand/test_extract_structure_outcomes.test.mjs
@@ -37,6 +37,7 @@ const VALID_STRUCTURE_ENTRIES = {
     params: ['value'],
     returnType: 'string',
     typedParams: [{ name: 'value', type: 'string' }],
+    kind: 'constructor',
   },
   classes: {
     name: 'Runner',
@@ -48,7 +49,7 @@ const VALID_STRUCTURE_ENTRIES = {
     fullName: 'App.Services.Runner',
     baseTypes: ['IRunner'],
     primaryConstructorParams: [{ name: 'repository', type: 'IRepository' }],
-    fields: [{ name: '_repository', type: 'IRepository' }],
+    fields: [{ name: '_repository', type: 'IRepository', isStatic: true }],
   },
   imports: {
     source: './dependency.js',
@@ -120,6 +121,10 @@ const MALFORMED_STRUCTURE_ENTRIES = [
     ...VALID_STRUCTURE_ENTRIES.functions,
     typedParams: [{ name: 'value', type: 1 }],
   }],
+  ['a function with an unsupported declaration kind', 'functions', {
+    ...VALID_STRUCTURE_ENTRIES.functions,
+    kind: 'local-function',
+  }],
   ['a class with a non-string name', 'classes', {
     ...VALID_STRUCTURE_ENTRIES.classes,
     name: false,
@@ -143,6 +148,10 @@ const MALFORMED_STRUCTURE_ENTRIES = [
   ['a class with malformed primary constructor params', 'classes', {
     ...VALID_STRUCTURE_ENTRIES.classes,
     primaryConstructorParams: [{ name: 'repository', type: 1 }],
+  }],
+  ['a class with malformed static field metadata', 'classes', {
+    ...VALID_STRUCTURE_ENTRIES.classes,
+    fields: [{ name: '_repository', type: 'IRepository', isStatic: 'yes' }],
   }],
   ['an import with a non-string source', 'imports', {
     ...VALID_STRUCTURE_ENTRIES.imports,
@@ -357,6 +366,26 @@ function analyzeStructuralOutput(mode, analysis) {
 }
 
 describe('extract-structure result mapping', () => {
+  it('preserves C# constructor and static field metadata', () => {
+    const result = extractStructure.buildResult(
+      { path: 'src/Service.cs', language: 'csharp', fileCategory: 'code' },
+      3,
+      3,
+      {
+        ...validAnalysis(),
+        functions: [VALID_STRUCTURE_ENTRIES.functions],
+        classes: [VALID_STRUCTURE_ENTRIES.classes],
+      },
+      null,
+      null,
+    );
+
+    expect(result.functions[0].kind).toBe('constructor');
+    expect(result.classes[0].fields).toEqual([
+      { name: '_repository', type: 'IRepository', isStatic: true },
+    ]);
+  });
+
   it('preserves imports only for C# artifacts', () => {
     const analysis = {
       ...validAnalysis(),

--- a/tests/skill/understand/test_extract_structure_outcomes.test.mjs
+++ b/tests/skill/understand/test_extract_structure_outcomes.test.mjs
@@ -36,17 +36,28 @@ const VALID_STRUCTURE_ENTRIES = {
     lineRange: [1, 2],
     params: ['value'],
     returnType: 'string',
+    typedParams: [{ name: 'value', type: 'string' }],
   },
   classes: {
     name: 'Runner',
     lineRange: [1, 3],
     methods: ['run'],
     properties: ['value'],
+    kind: 'class',
+    namespace: 'App.Services',
+    fullName: 'App.Services.Runner',
+    baseTypes: ['IRunner'],
+    primaryConstructorParams: [{ name: 'repository', type: 'IRepository' }],
+    fields: [{ name: '_repository', type: 'IRepository' }],
   },
   imports: {
     source: './dependency.js',
     specifiers: ['dependency'],
     lineNumber: 1,
+    kind: 'alias',
+    alias: 'Dep',
+    namespace: 'App.Services',
+    isGlobal: true,
   },
   exports: {
     name: 'run',
@@ -105,6 +116,10 @@ const MALFORMED_STRUCTURE_ENTRIES = [
     ...VALID_STRUCTURE_ENTRIES.functions,
     returnType: false,
   }],
+  ['a function with malformed typed params', 'functions', {
+    ...VALID_STRUCTURE_ENTRIES.functions,
+    typedParams: [{ name: 'value', type: 1 }],
+  }],
   ['a class with a non-string name', 'classes', {
     ...VALID_STRUCTURE_ENTRIES.classes,
     name: false,
@@ -121,6 +136,14 @@ const MALFORMED_STRUCTURE_ENTRIES = [
     ...VALID_STRUCTURE_ENTRIES.classes,
     properties: ['value', null],
   }],
+  ['a class with an unsupported C# kind', 'classes', {
+    ...VALID_STRUCTURE_ENTRIES.classes,
+    kind: 'enum',
+  }],
+  ['a class with malformed primary constructor params', 'classes', {
+    ...VALID_STRUCTURE_ENTRIES.classes,
+    primaryConstructorParams: [{ name: 'repository', type: 1 }],
+  }],
   ['an import with a non-string source', 'imports', {
     ...VALID_STRUCTURE_ENTRIES.imports,
     source: null,
@@ -132,6 +155,10 @@ const MALFORMED_STRUCTURE_ENTRIES = [
   ['an import with a non-number line', 'imports', {
     ...VALID_STRUCTURE_ENTRIES.imports,
     lineNumber: '1',
+  }],
+  ['an import with an unsupported C# using kind', 'imports', {
+    ...VALID_STRUCTURE_ENTRIES.imports,
+    kind: 'global',
   }],
   ['an export with a non-string name', 'exports', {
     ...VALID_STRUCTURE_ENTRIES.exports,
@@ -328,6 +355,47 @@ function analyzeStructuralOutput(mode, analysis) {
     'export const value = 1;\n',
   );
 }
+
+describe('extract-structure result mapping', () => {
+  it('preserves imports only for C# artifacts', () => {
+    const analysis = {
+      ...validAnalysis(),
+      imports: [{
+        source: 'App.Repositories',
+        specifiers: [],
+        lineNumber: 1,
+        kind: 'namespace',
+        isGlobal: true,
+      }],
+    };
+
+    const csharp = extractStructure.buildResult(
+      { path: 'src/Service.cs', language: 'csharp', fileCategory: 'code' },
+      1,
+      1,
+      analysis,
+      null,
+      null,
+    );
+    const typescript = extractStructure.buildResult(
+      { path: 'src/service.ts', language: 'typescript', fileCategory: 'code' },
+      1,
+      1,
+      analysis,
+      null,
+      null,
+    );
+
+    expect(csharp.imports).toEqual([{
+      source: 'App.Repositories',
+      specifiers: [],
+      line: 1,
+      kind: 'namespace',
+      isGlobal: true,
+    }]);
+    expect(typescript.imports).toBeUndefined();
+  });
+});
 
 describe('extract-structure analysis outcomes', () => {
   it('skips structure and call-graph analysis when no parser supports the file', () => {

--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -1445,15 +1445,22 @@ class TestUaDirResolution(unittest.TestCase):
 class CSharpDeterministicLinkerTests(unittest.TestCase):
     """Deterministic C# calls and inheritance from extraction artifacts."""
 
-    def _link(self, assembled: dict[str, Any], results: list[dict[str, Any]]) -> dict[str, int]:
+    def _link_with_report(
+        self,
+        assembled: dict[str, Any],
+        results: list[dict[str, Any]],
+    ) -> tuple[dict[str, int], list[str]]:
         with tempfile.TemporaryDirectory(prefix="ua-csharp-link-") as tmp:
             tmp_dir = Path(tmp)
             (tmp_dir / "ua-file-extract-results-1.json").write_text(
                 mbg.json.dumps({"scriptCompleted": True, "results": results}),
                 encoding="utf-8",
             )
-            stats, _report = mbg.link_csharp_deterministic_edges(assembled, tmp_dir)
-            return stats
+            return mbg.link_csharp_deterministic_edges(assembled, tmp_dir)
+
+    def _link(self, assembled: dict[str, Any], results: list[dict[str, Any]]) -> dict[str, int]:
+        stats, _report = self._link_with_report(assembled, results)
+        return stats
 
     def test_no_csharp_results_do_not_emit_report_noise(self) -> None:
         assembled = {"nodes": [_file_node("src/index.ts")], "edges": []}
@@ -1574,7 +1581,6 @@ class CSharpDeterministicLinkerTests(unittest.TestCase):
                 _file_node("Services/FooService.cs"),
                 _class_node("Services/FooService.cs", "FooService"),
                 _function_node("Services/FooService.cs", "Run"),
-                _function_node("Services/FooService.cs", "Validate"),
                 _file_node("Repositories/IRepository.cs"),
                 _class_node("Repositories/IRepository.cs", "IRepository"),
                 _function_node("Repositories/IRepository.cs", "Save"),
@@ -1632,6 +1638,7 @@ class CSharpDeterministicLinkerTests(unittest.TestCase):
         stats = self._link(assembled, results)
 
         self.assertEqual(stats["callsAdded"], 2)
+        self.assertEqual(stats["functionNodesSynthesized"], 1)
         edge_pairs = {(e["source"], e["target"], e["type"]) for e in assembled["edges"]}
         self.assertIn((
             "function:Services/FooService.cs:Run",
@@ -1806,6 +1813,8 @@ class CSharpDeterministicLinkerTests(unittest.TestCase):
         stats = self._link(assembled, results)
 
         self.assertEqual(stats["callsAdded"], 0)
+        self.assertEqual(stats["callsReceiverTypeAmbiguous"], 1)
+        self.assertEqual(stats["callsTargetMethodAmbiguous"], 1)
         self.assertEqual(
             len([e for e in assembled["edges"] if e["type"] == "calls"]),
             1,
@@ -2032,6 +2041,385 @@ class CSharpDeterministicLinkerTests(unittest.TestCase):
             "calls",
         ), edge_pairs)
 
+    def test_synthesizes_missing_inheritance_endpoint_nodes(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("Services/Service.cs"),
+                _file_node("Services/IService.cs"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "Services/Service.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "Service",
+                    "startLine": 1,
+                    "endLine": 3,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.Service",
+                    "methods": [],
+                    "properties": [],
+                    "baseTypes": ["IService", "IDisposable"],
+                }],
+                "functions": [],
+                "callGraph": [],
+            },
+            {
+                "path": "Services/IService.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IService",
+                    "startLine": 1,
+                    "endLine": 2,
+                    "kind": "interface",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.IService",
+                    "methods": [],
+                    "properties": [],
+                }],
+                "functions": [],
+                "callGraph": [],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["classNodesSynthesized"], 2)
+        self.assertEqual(stats["containsEdgesAdded"], 2)
+        self.assertEqual(stats["inheritanceAdded"], 1)
+        self.assertEqual(stats["inheritanceSkipped"], 1)
+        self.assertEqual(stats["inheritanceTypeUnresolved"], 1)
+        nodes_by_id = {node["id"]: node for node in assembled["nodes"]}
+        synthesized = nodes_by_id["class:Services/IService.cs:IService"]
+        self.assertEqual(synthesized["lineRange"], [1, 2])
+        self.assertEqual(synthesized["complexity"], "simple")
+        self.assertIn("auto-linked", synthesized["tags"])
+        edge_pairs = {(e["source"], e["target"], e["type"]) for e in assembled["edges"]}
+        self.assertIn((
+            "class:Services/Service.cs:Service",
+            "class:Services/IService.cs:IService",
+            "implements",
+        ), edge_pairs)
+        self.assertIn((
+            "file:Services/Service.cs",
+            "class:Services/Service.cs:Service",
+            "contains",
+        ), edge_pairs)
+        self.assertIn((
+            "file:Services/IService.cs",
+            "class:Services/IService.cs:IService",
+            "contains",
+        ), edge_pairs)
+
+    def test_synthesizes_missing_call_endpoints_without_replacing_llm_nodes(self) -> None:
+        results = [
+            {
+                "path": "Services/Consumer.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "Consumer",
+                    "startLine": 1,
+                    "endLine": 6,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.Consumer",
+                    "methods": ["Run"],
+                    "properties": [],
+                    "primaryConstructorParams": [{"name": "service", "type": "IService"}],
+                }],
+                "functions": [{
+                    "name": "Run",
+                    "startLine": 3,
+                    "endLine": 5,
+                    "params": [],
+                    "typedParams": [],
+                }],
+                "callGraph": [{"caller": "Run", "callee": "service.Save", "lineNumber": 4}],
+            },
+            {
+                "path": "Services/IService.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IService",
+                    "startLine": 1,
+                    "endLine": 4,
+                    "kind": "interface",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.IService",
+                    "methods": ["Save"],
+                    "properties": [],
+                }],
+                "functions": [{
+                    "name": "Save",
+                    "startLine": 3,
+                    "endLine": 3,
+                    "params": [],
+                    "typedParams": [],
+                }],
+                "callGraph": [],
+            },
+        ]
+        common_nodes = [
+            _file_node("Services/Consumer.cs"),
+            _class_node("Services/Consumer.cs", "Consumer"),
+            _file_node("Services/IService.cs"),
+            _class_node("Services/IService.cs", "IService"),
+        ]
+
+        assembled = {
+            "nodes": common_nodes + [
+                _function_node("Services/Consumer.cs", "Run", summary="LLM caller summary"),
+            ],
+            "edges": [],
+        }
+        first_stats = self._link(assembled, results)
+
+        self.assertEqual(first_stats["functionNodesSynthesized"], 1)
+        self.assertEqual(first_stats["containsEdgesAdded"], 1)
+        self.assertEqual(first_stats["callsAdded"], 1)
+        nodes_by_id = {node["id"]: node for node in assembled["nodes"]}
+        self.assertEqual(
+            nodes_by_id["function:Services/Consumer.cs:Run"]["summary"],
+            "LLM caller summary",
+        )
+        self.assertIn("function:Services/IService.cs:Save", nodes_by_id)
+        first_output = mbg.json.dumps(assembled, sort_keys=True)
+
+        second_stats = self._link(assembled, results)
+
+        self.assertEqual(second_stats["functionNodesSynthesized"], 0)
+        self.assertEqual(second_stats["containsEdgesAdded"], 0)
+        self.assertEqual(second_stats["callsAdded"], 0)
+        self.assertEqual(mbg.json.dumps(assembled, sort_keys=True), first_output)
+
+        missing_caller = {
+            "nodes": common_nodes + [
+                _function_node("Services/IService.cs", "Save", summary="LLM target summary"),
+            ],
+            "edges": [],
+        }
+        caller_stats = self._link(missing_caller, results)
+
+        self.assertEqual(caller_stats["functionNodesSynthesized"], 1)
+        self.assertEqual(caller_stats["callsAdded"], 1)
+        caller_nodes = {node["id"]: node for node in missing_caller["nodes"]}
+        self.assertIn("function:Services/Consumer.cs:Run", caller_nodes)
+        self.assertEqual(
+            caller_nodes["function:Services/IService.cs:Save"]["summary"],
+            "LLM target summary",
+        )
+
+    def test_ambiguous_base_and_dependency_types_are_reported_without_synthesis(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("App/Service.cs"),
+                _file_node("A/IFoo.cs"),
+                _file_node("B/IFoo.cs"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "App/Service.cs",
+                "language": "csharp",
+                "imports": [
+                    {"source": "A", "kind": "namespace", "line": 1},
+                    {"source": "B", "kind": "namespace", "line": 2},
+                ],
+                "classes": [{
+                    "name": "Service",
+                    "startLine": 4,
+                    "endLine": 6,
+                    "kind": "class",
+                    "namespace": "App",
+                    "fullName": "App.Service",
+                    "methods": [],
+                    "properties": [],
+                    "baseTypes": ["IFoo"],
+                    "primaryConstructorParams": [{"name": "foo", "type": "IFoo"}],
+                }],
+                "functions": [],
+                "callGraph": [],
+            },
+            {
+                "path": "A/IFoo.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IFoo",
+                    "startLine": 1,
+                    "endLine": 2,
+                    "kind": "interface",
+                    "namespace": "A",
+                    "fullName": "A.IFoo",
+                    "methods": [],
+                    "properties": [],
+                }],
+                "functions": [],
+                "callGraph": [],
+            },
+            {
+                "path": "B/IFoo.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IFoo",
+                    "startLine": 1,
+                    "endLine": 2,
+                    "kind": "interface",
+                    "namespace": "B",
+                    "fullName": "B.IFoo",
+                    "methods": [],
+                    "properties": [],
+                }],
+                "functions": [],
+                "callGraph": [],
+            },
+        ]
+
+        stats, report = self._link_with_report(assembled, results)
+
+        self.assertEqual(stats["inheritanceAdded"], 0)
+        self.assertEqual(stats["inheritanceSkipped"], 1)
+        self.assertEqual(stats["inheritanceTypeAmbiguous"], 1)
+        self.assertEqual(stats["dependsOnSkipped"], 1)
+        self.assertEqual(stats["dependsOnTypeAmbiguous"], 1)
+        self.assertEqual(stats["classNodesSynthesized"], 0)
+        self.assertEqual(assembled["edges"], [])
+        self.assertIn("  inheritance skip reasons: ambiguous type: 1", report)
+        self.assertIn("  depends_on skip reasons: ambiguous type: 1", report)
+
+    def test_adds_class_dependencies_from_constructors_and_instance_fields_only(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("Consumers.cs"),
+                _file_node("Dependencies.cs"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "Consumers.cs",
+                "language": "csharp",
+                "classes": [
+                    {
+                        "name": "PrimaryConsumer",
+                        "startLine": 1,
+                        "endLine": 3,
+                        "kind": "class",
+                        "namespace": "App",
+                        "fullName": "App.PrimaryConsumer",
+                        "methods": [],
+                        "properties": [],
+                        "primaryConstructorParams": [
+                            {"name": "service", "type": "IService"},
+                            {"name": "logger", "type": "IExternalLogger"},
+                        ],
+                    },
+                    {
+                        "name": "ExplicitConsumer",
+                        "startLine": 5,
+                        "endLine": 10,
+                        "kind": "class",
+                        "namespace": "App",
+                        "fullName": "App.ExplicitConsumer",
+                        "methods": ["ExplicitConsumer"],
+                        "properties": [],
+                    },
+                    {
+                        "name": "FieldConsumer",
+                        "startLine": 12,
+                        "endLine": 20,
+                        "kind": "class",
+                        "namespace": "App",
+                        "fullName": "App.FieldConsumer",
+                        "methods": ["Execute"],
+                        "properties": ["_repository", "Cache"],
+                        "fields": [
+                            {"name": "_repository", "type": "IRepository"},
+                            {"name": "Cache", "type": "ICache", "isStatic": True},
+                        ],
+                    },
+                ],
+                "functions": [
+                    {
+                        "name": "ExplicitConsumer",
+                        "startLine": 7,
+                        "endLine": 9,
+                        "params": ["repository"],
+                        "typedParams": [{"name": "repository", "type": "IRepository"}],
+                        "kind": "constructor",
+                    },
+                    {
+                        "name": "Execute",
+                        "startLine": 17,
+                        "endLine": 19,
+                        "params": ["request"],
+                        "typedParams": [{"name": "request", "type": "IRequest"}],
+                        "kind": "method",
+                    },
+                ],
+                "callGraph": [],
+            },
+            {
+                "path": "Dependencies.cs",
+                "language": "csharp",
+                "classes": [
+                    {
+                        "name": name,
+                        "startLine": line,
+                        "endLine": line,
+                        "kind": "interface",
+                        "namespace": "App",
+                        "fullName": f"App.{name}",
+                        "methods": [],
+                        "properties": [],
+                    }
+                    for line, name in enumerate(
+                        ["IService", "IRepository", "ICache", "IRequest"],
+                        start=1,
+                    )
+                ],
+                "functions": [],
+                "callGraph": [],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["declaredDependenciesScanned"], 4)
+        self.assertEqual(stats["dependsOnAdded"], 3)
+        self.assertEqual(stats["dependsOnSkipped"], 1)
+        self.assertEqual(stats["dependsOnTypeUnresolved"], 1)
+        self.assertEqual(stats["classNodesSynthesized"], 5)
+        edge_pairs = {(e["source"], e["target"], e["type"]) for e in assembled["edges"]}
+        self.assertIn((
+            "class:Consumers.cs:PrimaryConsumer",
+            "class:Dependencies.cs:IService",
+            "depends_on",
+        ), edge_pairs)
+        self.assertIn((
+            "class:Consumers.cs:ExplicitConsumer",
+            "class:Dependencies.cs:IRepository",
+            "depends_on",
+        ), edge_pairs)
+        self.assertIn((
+            "class:Consumers.cs:FieldConsumer",
+            "class:Dependencies.cs:IRepository",
+            "depends_on",
+        ), edge_pairs)
+        self.assertNotIn((
+            "class:Consumers.cs:FieldConsumer",
+            "class:Dependencies.cs:ICache",
+            "depends_on",
+        ), edge_pairs)
+        self.assertNotIn((
+            "class:Consumers.cs:FieldConsumer",
+            "class:Dependencies.cs:IRequest",
+            "depends_on",
+        ), edge_pairs)
+
     def test_same_named_method_in_another_class_in_target_file_is_skipped(self) -> None:
         assembled = {
             "nodes": [
@@ -2099,7 +2487,10 @@ class CSharpDeterministicLinkerTests(unittest.TestCase):
         stats = self._link(assembled, results)
 
         self.assertEqual(stats["callsAdded"], 0)
-        self.assertEqual(assembled["edges"], [])
+        self.assertEqual(stats["callsTargetMethodAmbiguous"], 1)
+        self.assertEqual(stats["functionNodesSynthesized"], 0)
+        self.assertNotIn("calls", {edge["type"] for edge in assembled["edges"]})
+        self.assertIn("depends_on", {edge["type"] for edge in assembled["edges"]})
 
     def test_inherited_method_is_not_linked_to_base_class(self) -> None:
         assembled = {
@@ -2169,6 +2560,7 @@ class CSharpDeterministicLinkerTests(unittest.TestCase):
         stats = self._link(assembled, results)
 
         self.assertEqual(stats["callsAdded"], 0)
+        self.assertEqual(stats["callsTargetMethodMissing"], 1)
         self.assertNotIn("calls", {edge["type"] for edge in assembled["edges"]})
 
     def test_extension_method_is_not_linked_as_instance_method(self) -> None:
@@ -2245,7 +2637,9 @@ class CSharpDeterministicLinkerTests(unittest.TestCase):
         stats = self._link(assembled, results)
 
         self.assertEqual(stats["callsAdded"], 0)
-        self.assertEqual(assembled["edges"], [])
+        self.assertEqual(stats["callsTargetMethodMissing"], 1)
+        self.assertNotIn("calls", {edge["type"] for edge in assembled["edges"]})
+        self.assertIn("depends_on", {edge["type"] for edge in assembled["edges"]})
 
     def test_duplicate_function_node_id_caller_is_skipped(self) -> None:
         assembled = {

--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -2032,7 +2032,7 @@ class CSharpDeterministicLinkerTests(unittest.TestCase):
             "calls",
         ), edge_pairs)
 
-    def test_duplicate_function_node_id_target_is_skipped(self) -> None:
+    def test_same_named_method_in_another_class_in_target_file_is_skipped(self) -> None:
         assembled = {
             "nodes": [
                 _file_node("Services/Service.cs"),
@@ -2093,6 +2093,152 @@ class CSharpDeterministicLinkerTests(unittest.TestCase):
                     {"name": "Run", "startLine": 3, "endLine": 3, "params": [], "typedParams": []},
                     {"name": "Run", "startLine": 8, "endLine": 8, "params": [], "typedParams": []},
                 ],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["callsAdded"], 0)
+        self.assertEqual(assembled["edges"], [])
+
+    def test_inherited_method_is_not_linked_to_base_class(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("Services/Consumer.cs"),
+                _class_node("Services/Consumer.cs", "Consumer"),
+                _function_node("Services/Consumer.cs", "Run"),
+                _file_node("Services/BaseService.cs"),
+                _class_node("Services/BaseService.cs", "BaseService"),
+                _function_node("Services/BaseService.cs", "Validate"),
+                _file_node("Services/DerivedService.cs"),
+                _class_node("Services/DerivedService.cs", "DerivedService"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "Services/Consumer.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "Consumer",
+                    "startLine": 1,
+                    "endLine": 6,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.Consumer",
+                    "methods": ["Run"],
+                    "properties": [],
+                    "primaryConstructorParams": [{"name": "service", "type": "DerivedService"}],
+                }],
+                "functions": [{"name": "Run", "startLine": 3, "endLine": 5, "params": [], "typedParams": []}],
+                "callGraph": [{"caller": "Run", "callee": "service.Validate", "lineNumber": 4}],
+            },
+            {
+                "path": "Services/BaseService.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "BaseService",
+                    "startLine": 1,
+                    "endLine": 4,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.BaseService",
+                    "methods": ["Validate"],
+                    "properties": [],
+                }],
+                "functions": [{"name": "Validate", "startLine": 3, "endLine": 3, "params": [], "typedParams": []}],
+            },
+            {
+                "path": "Services/DerivedService.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "DerivedService",
+                    "startLine": 1,
+                    "endLine": 3,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.DerivedService",
+                    "methods": [],
+                    "properties": [],
+                    "baseTypes": ["BaseService"],
+                }],
+                "functions": [],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["callsAdded"], 0)
+        self.assertNotIn("calls", {edge["type"] for edge in assembled["edges"]})
+
+    def test_extension_method_is_not_linked_as_instance_method(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("Services/Consumer.cs"),
+                _class_node("Services/Consumer.cs", "Consumer"),
+                _function_node("Services/Consumer.cs", "Run"),
+                _file_node("Models/Target.cs"),
+                _class_node("Models/Target.cs", "Target"),
+                _file_node("Extensions/TargetExtensions.cs"),
+                _class_node("Extensions/TargetExtensions.cs", "TargetExtensions"),
+                _function_node("Extensions/TargetExtensions.cs", "Validate"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "Services/Consumer.cs",
+                "language": "csharp",
+                "imports": [{"source": "App.Models", "kind": "namespace", "line": 1}],
+                "classes": [{
+                    "name": "Consumer",
+                    "startLine": 3,
+                    "endLine": 8,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.Consumer",
+                    "methods": ["Run"],
+                    "properties": [],
+                    "primaryConstructorParams": [{"name": "target", "type": "Target"}],
+                }],
+                "functions": [{"name": "Run", "startLine": 5, "endLine": 7, "params": [], "typedParams": []}],
+                "callGraph": [{"caller": "Run", "callee": "target.Validate", "lineNumber": 6}],
+            },
+            {
+                "path": "Models/Target.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "Target",
+                    "startLine": 1,
+                    "endLine": 2,
+                    "kind": "class",
+                    "namespace": "App.Models",
+                    "fullName": "App.Models.Target",
+                    "methods": [],
+                    "properties": [],
+                }],
+                "functions": [],
+            },
+            {
+                "path": "Extensions/TargetExtensions.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "TargetExtensions",
+                    "startLine": 1,
+                    "endLine": 4,
+                    "kind": "class",
+                    "namespace": "App.Extensions",
+                    "fullName": "App.Extensions.TargetExtensions",
+                    "methods": ["Validate"],
+                    "properties": [],
+                }],
+                "functions": [{
+                    "name": "Validate",
+                    "startLine": 3,
+                    "endLine": 3,
+                    "params": ["target"],
+                    "typedParams": [{"name": "target", "type": "Target"}],
+                }],
             },
         ]
 

--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
@@ -51,6 +52,34 @@ def _file_node(path: str, **extra: Any) -> dict[str, Any]:
         "id": f"file:{path}",
         "type": "file",
         "name": path.rsplit("/", 1)[-1],
+        "filePath": path,
+        "summary": "",
+        "tags": [],
+        "complexity": "simple",
+    }
+    node.update(extra)
+    return node
+
+
+def _class_node(path: str, name: str, **extra: Any) -> dict[str, Any]:
+    node: dict[str, Any] = {
+        "id": f"class:{path}:{name}",
+        "type": "class",
+        "name": name,
+        "filePath": path,
+        "summary": "",
+        "tags": [],
+        "complexity": "simple",
+    }
+    node.update(extra)
+    return node
+
+
+def _function_node(path: str, name: str, **extra: Any) -> dict[str, Any]:
+    node: dict[str, Any] = {
+        "id": f"function:{path}:{name}",
+        "type": "function",
+        "name": name,
         "filePath": path,
         "summary": "",
         "tags": [],
@@ -1411,6 +1440,704 @@ class TestUaDirResolution(unittest.TestCase):
             (self.tmp / ".understand-anything" / "intermediate" / "assembled-graph.json").is_file()
         )
         self.assertFalse((self.tmp / ".ua" / "intermediate" / "assembled-graph.json").exists())
+
+
+class CSharpDeterministicLinkerTests(unittest.TestCase):
+    """Deterministic C# calls and inheritance from extraction artifacts."""
+
+    def _link(self, assembled: dict[str, Any], results: list[dict[str, Any]]) -> dict[str, int]:
+        with tempfile.TemporaryDirectory(prefix="ua-csharp-link-") as tmp:
+            tmp_dir = Path(tmp)
+            (tmp_dir / "ua-file-extract-results-1.json").write_text(
+                mbg.json.dumps({"scriptCompleted": True, "results": results}),
+                encoding="utf-8",
+            )
+            stats, _report = mbg.link_csharp_deterministic_edges(assembled, tmp_dir)
+            return stats
+
+    def test_no_csharp_results_do_not_emit_report_noise(self) -> None:
+        assembled = {"nodes": [_file_node("src/index.ts")], "edges": []}
+        with tempfile.TemporaryDirectory(prefix="ua-csharp-link-empty-") as tmp:
+            stats, report = mbg.link_csharp_deterministic_edges(
+                assembled,
+                Path(tmp) / "missing-tmp",
+            )
+
+        self.assertEqual(stats["filesScanned"], 0)
+        self.assertEqual(report, [])
+        self.assertEqual(assembled["edges"], [])
+
+    def test_primary_constructor_receiver_call_and_implements(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("Controllers/FooController.cs"),
+                _class_node("Controllers/FooController.cs", "FooController"),
+                _function_node("Controllers/FooController.cs", "Get"),
+                _file_node("Services/IFooService.cs"),
+                _class_node("Services/IFooService.cs", "IFooService"),
+                _function_node("Services/IFooService.cs", "GetAsync"),
+                _file_node("Services/FooService.cs"),
+                _class_node("Services/FooService.cs", "FooService"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "Controllers/FooController.cs",
+                "language": "csharp",
+                "imports": [{"source": "App.Services", "line": 1, "specifiers": ["Services"]}],
+                "classes": [{
+                    "name": "FooController",
+                    "startLine": 3,
+                    "endLine": 8,
+                    "kind": "class",
+                    "namespace": "App.Controllers",
+                    "fullName": "App.Controllers.FooController",
+                    "methods": ["Get"],
+                    "properties": [],
+                    "primaryConstructorParams": [{"name": "fooService", "type": "IFooService"}],
+                }],
+                "functions": [{
+                    "name": "Get",
+                    "startLine": 5,
+                    "endLine": 7,
+                    "params": [],
+                    "typedParams": [],
+                }],
+                "callGraph": [{"caller": "Get", "callee": "fooService.GetAsync", "lineNumber": 6}],
+            },
+            {
+                "path": "Services/IFooService.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IFooService",
+                    "startLine": 1,
+                    "endLine": 4,
+                    "kind": "interface",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.IFooService",
+                    "methods": ["GetAsync"],
+                    "properties": [],
+                }],
+                "functions": [{
+                    "name": "GetAsync",
+                    "startLine": 3,
+                    "endLine": 3,
+                    "params": [],
+                    "typedParams": [],
+                }],
+                "callGraph": [],
+            },
+            {
+                "path": "Services/FooService.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "FooService",
+                    "startLine": 1,
+                    "endLine": 4,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.FooService",
+                    "methods": [],
+                    "properties": [],
+                    "baseTypes": ["IFooService"],
+                }],
+                "functions": [],
+                "callGraph": [],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["callsAdded"], 1)
+        self.assertEqual(stats["inheritanceAdded"], 1)
+        self.assertIn({
+            "source": "function:Controllers/FooController.cs:Get",
+            "target": "function:Services/IFooService.cs:GetAsync",
+            "type": "calls",
+            "direction": "forward",
+            "weight": 0.8,
+            "deterministic": True,
+        }, assembled["edges"])
+        self.assertIn({
+            "source": "class:Services/FooService.cs:FooService",
+            "target": "class:Services/IFooService.cs:IFooService",
+            "type": "implements",
+            "direction": "forward",
+            "weight": 0.8,
+            "deterministic": True,
+        }, assembled["edges"])
+
+    def test_same_file_call_and_method_parameter_receiver_call(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("Services/FooService.cs"),
+                _class_node("Services/FooService.cs", "FooService"),
+                _function_node("Services/FooService.cs", "Run"),
+                _function_node("Services/FooService.cs", "Validate"),
+                _file_node("Repositories/IRepository.cs"),
+                _class_node("Repositories/IRepository.cs", "IRepository"),
+                _function_node("Repositories/IRepository.cs", "Save"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "Services/FooService.cs",
+                "language": "csharp",
+                "imports": [{"source": "App.Repositories", "line": 1, "specifiers": ["Repositories"]}],
+                "classes": [{
+                    "name": "FooService",
+                    "startLine": 3,
+                    "endLine": 12,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.FooService",
+                    "methods": ["Run", "Validate"],
+                    "properties": [],
+                }],
+                "functions": [
+                    {
+                        "name": "Run",
+                        "startLine": 5,
+                        "endLine": 8,
+                        "params": ["repository"],
+                        "typedParams": [{"name": "repository", "type": "IRepository"}],
+                    },
+                    {"name": "Validate", "startLine": 10, "endLine": 10, "params": [], "typedParams": []},
+                ],
+                "callGraph": [
+                    {"caller": "Run", "callee": "Validate", "lineNumber": 6},
+                    {"caller": "Run", "callee": "repository.Save", "lineNumber": 7},
+                ],
+            },
+            {
+                "path": "Repositories/IRepository.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IRepository",
+                    "startLine": 1,
+                    "endLine": 4,
+                    "kind": "interface",
+                    "namespace": "App.Repositories",
+                    "fullName": "App.Repositories.IRepository",
+                    "methods": ["Save"],
+                    "properties": [],
+                }],
+                "functions": [{"name": "Save", "startLine": 3, "endLine": 3, "params": [], "typedParams": []}],
+                "callGraph": [],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["callsAdded"], 2)
+        edge_pairs = {(e["source"], e["target"], e["type"]) for e in assembled["edges"]}
+        self.assertIn((
+            "function:Services/FooService.cs:Run",
+            "function:Services/FooService.cs:Validate",
+            "calls",
+        ), edge_pairs)
+        self.assertIn((
+            "function:Services/FooService.cs:Run",
+            "function:Repositories/IRepository.cs:Save",
+            "calls",
+        ), edge_pairs)
+
+    def test_inherits_class_and_interface_base_types(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("BaseService.cs"),
+                _class_node("BaseService.cs", "BaseService"),
+                _file_node("Service.cs"),
+                _class_node("Service.cs", "Service"),
+                _file_node("IBase.cs"),
+                _class_node("IBase.cs", "IBase"),
+                _file_node("IService.cs"),
+                _class_node("IService.cs", "IService"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "BaseService.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "BaseService",
+                    "startLine": 1,
+                    "endLine": 2,
+                    "kind": "class",
+                    "namespace": "App",
+                    "fullName": "App.BaseService",
+                    "methods": [],
+                    "properties": [],
+                }],
+            },
+            {
+                "path": "Service.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "Service",
+                    "startLine": 1,
+                    "endLine": 2,
+                    "kind": "class",
+                    "namespace": "App",
+                    "fullName": "App.Service",
+                    "methods": [],
+                    "properties": [],
+                    "baseTypes": ["BaseService"],
+                }],
+            },
+            {
+                "path": "IBase.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IBase",
+                    "startLine": 1,
+                    "endLine": 2,
+                    "kind": "interface",
+                    "namespace": "App",
+                    "fullName": "App.IBase",
+                    "methods": [],
+                    "properties": [],
+                }],
+            },
+            {
+                "path": "IService.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IService",
+                    "startLine": 1,
+                    "endLine": 2,
+                    "kind": "interface",
+                    "namespace": "App",
+                    "fullName": "App.IService",
+                    "methods": [],
+                    "properties": [],
+                    "baseTypes": ["IBase"],
+                }],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["inheritanceAdded"], 2)
+        edge_pairs = {(e["source"], e["target"], e["type"]) for e in assembled["edges"]}
+        self.assertIn(("class:Service.cs:Service", "class:BaseService.cs:BaseService", "inherits"), edge_pairs)
+        self.assertIn(("class:IService.cs:IService", "class:IBase.cs:IBase", "inherits"), edge_pairs)
+
+    def test_ambiguous_receiver_type_and_overloaded_target_are_skipped(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("App/Consumer.cs"),
+                _class_node("App/Consumer.cs", "Consumer"),
+                _function_node("App/Consumer.cs", "Run"),
+                _file_node("A/IFoo.cs"),
+                _class_node("A/IFoo.cs", "IFoo"),
+                _function_node("A/IFoo.cs", "Save"),
+                _file_node("B/IFoo.cs"),
+                _class_node("B/IFoo.cs", "IFoo"),
+                _function_node("B/IFoo.cs", "Save"),
+                _file_node("App/IBar.cs"),
+                _class_node("App/IBar.cs", "IBar"),
+                _function_node("App/IBar.cs", "Find"),
+            ],
+            "edges": [
+                {
+                    "source": "function:App/Consumer.cs:Run",
+                    "target": "function:App/IBar.cs:Find",
+                    "type": "calls",
+                    "direction": "forward",
+                    "weight": 0.5,
+                },
+            ],
+        }
+        results = [
+            {
+                "path": "App/Consumer.cs",
+                "language": "csharp",
+                "imports": [
+                    {"source": "A", "line": 1, "specifiers": ["A"]},
+                    {"source": "B", "line": 2, "specifiers": ["B"]},
+                ],
+                "classes": [{
+                    "name": "Consumer",
+                    "startLine": 4,
+                    "endLine": 9,
+                    "kind": "class",
+                    "namespace": "App",
+                    "fullName": "App.Consumer",
+                    "methods": ["Run"],
+                    "properties": [],
+                    "primaryConstructorParams": [
+                        {"name": "foo", "type": "IFoo"},
+                        {"name": "bar", "type": "IBar"},
+                    ],
+                }],
+                "functions": [{"name": "Run", "startLine": 6, "endLine": 8, "params": [], "typedParams": []}],
+                "callGraph": [
+                    {"caller": "Run", "callee": "foo.Save", "lineNumber": 7},
+                    {"caller": "Run", "callee": "bar.Find", "lineNumber": 8},
+                ],
+            },
+            {
+                "path": "A/IFoo.cs",
+                "language": "csharp",
+                "classes": [{"name": "IFoo", "startLine": 1, "endLine": 3, "kind": "interface", "namespace": "A", "fullName": "A.IFoo", "methods": ["Save"], "properties": []}],
+                "functions": [{"name": "Save", "startLine": 2, "endLine": 2, "params": [], "typedParams": []}],
+            },
+            {
+                "path": "B/IFoo.cs",
+                "language": "csharp",
+                "classes": [{"name": "IFoo", "startLine": 1, "endLine": 3, "kind": "interface", "namespace": "B", "fullName": "B.IFoo", "methods": ["Save"], "properties": []}],
+                "functions": [{"name": "Save", "startLine": 2, "endLine": 2, "params": [], "typedParams": []}],
+            },
+            {
+                "path": "App/IBar.cs",
+                "language": "csharp",
+                "classes": [{"name": "IBar", "startLine": 1, "endLine": 6, "kind": "interface", "namespace": "App", "fullName": "App.IBar", "methods": ["Find", "Find"], "properties": []}],
+                "functions": [
+                    {"name": "Find", "startLine": 2, "endLine": 2, "params": ["id"], "typedParams": [{"name": "id", "type": "int"}]},
+                    {"name": "Find", "startLine": 3, "endLine": 3, "params": ["name"], "typedParams": [{"name": "name", "type": "string"}]},
+                ],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["callsAdded"], 0)
+        self.assertEqual(
+            len([e for e in assembled["edges"] if e["type"] == "calls"]),
+            1,
+        )
+
+    def test_alias_using_does_not_resolve_unqualified_receiver_type(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("Services/Service.cs"),
+                _class_node("Services/Service.cs", "Service"),
+                _function_node("Services/Service.cs", "Run"),
+                _file_node("Repositories/IRepository.cs"),
+                _class_node("Repositories/IRepository.cs", "IRepository"),
+                _function_node("Repositories/IRepository.cs", "Save"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "Services/Service.cs",
+                "language": "csharp",
+                "imports": [{"source": "App.Repositories", "kind": "alias", "alias": "Repo", "line": 1}],
+                "classes": [{
+                    "name": "Service",
+                    "startLine": 3,
+                    "endLine": 8,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.Service",
+                    "methods": ["Run"],
+                    "properties": [],
+                    "primaryConstructorParams": [{"name": "repository", "type": "IRepository"}],
+                }],
+                "functions": [{"name": "Run", "startLine": 5, "endLine": 7, "params": [], "typedParams": []}],
+                "callGraph": [{"caller": "Run", "callee": "repository.Save", "lineNumber": 6}],
+            },
+            {
+                "path": "Repositories/IRepository.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IRepository",
+                    "startLine": 1,
+                    "endLine": 4,
+                    "kind": "interface",
+                    "namespace": "App.Repositories",
+                    "fullName": "App.Repositories.IRepository",
+                    "methods": ["Save"],
+                    "properties": [],
+                }],
+                "functions": [{"name": "Save", "startLine": 3, "endLine": 3, "params": [], "typedParams": []}],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["callsAdded"], 0)
+        self.assertEqual(assembled["edges"], [])
+
+    def test_global_using_resolves_receiver_type_across_files(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("GlobalUsings.cs"),
+                _file_node("Services/Service.cs"),
+                _class_node("Services/Service.cs", "Service"),
+                _function_node("Services/Service.cs", "Run"),
+                _file_node("Repositories/IRepository.cs"),
+                _class_node("Repositories/IRepository.cs", "IRepository"),
+                _function_node("Repositories/IRepository.cs", "Save"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "GlobalUsings.cs",
+                "language": "csharp",
+                "imports": [
+                    {"source": "App.Repositories", "kind": "namespace", "isGlobal": True, "line": 1},
+                    {"source": "System.Math", "kind": "static", "isGlobal": True, "line": 2},
+                ],
+                "classes": [],
+                "functions": [],
+                "callGraph": [],
+            },
+            {
+                "path": "Services/Service.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "Service",
+                    "startLine": 1,
+                    "endLine": 6,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.Service",
+                    "methods": ["Run"],
+                    "properties": [],
+                    "primaryConstructorParams": [{"name": "repository", "type": "IRepository"}],
+                }],
+                "functions": [{"name": "Run", "startLine": 3, "endLine": 5, "params": [], "typedParams": []}],
+                "callGraph": [{"caller": "Run", "callee": "repository.Save", "lineNumber": 4}],
+            },
+            {
+                "path": "Repositories/IRepository.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IRepository",
+                    "startLine": 1,
+                    "endLine": 4,
+                    "kind": "interface",
+                    "namespace": "App.Repositories",
+                    "fullName": "App.Repositories.IRepository",
+                    "methods": ["Save"],
+                    "properties": [],
+                }],
+                "functions": [{"name": "Save", "startLine": 3, "endLine": 3, "params": [], "typedParams": []}],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["callsAdded"], 1)
+        self.assertIn((
+            "function:Services/Service.cs:Run",
+            "function:Repositories/IRepository.cs:Save",
+            "calls",
+        ), {(e["source"], e["target"], e["type"]) for e in assembled["edges"]})
+
+    def test_global_using_is_scoped_to_csproj_project(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("ProjectA/ProjectA.csproj"),
+                _file_node("ProjectA/GlobalUsings.cs"),
+                _file_node("ProjectA/Services/Service.cs"),
+                _class_node("ProjectA/Services/Service.cs", "Service"),
+                _function_node("ProjectA/Services/Service.cs", "Run"),
+                _file_node("ProjectA/Repositories/IRepository.cs"),
+                _class_node("ProjectA/Repositories/IRepository.cs", "IRepository"),
+                _function_node("ProjectA/Repositories/IRepository.cs", "Save"),
+                _file_node("ProjectB/ProjectB.csproj"),
+                _file_node("ProjectB/Services/Service.cs"),
+                _class_node("ProjectB/Services/Service.cs", "Service"),
+                _function_node("ProjectB/Services/Service.cs", "Run"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "ProjectA/GlobalUsings.cs",
+                "language": "csharp",
+                "imports": [
+                    {
+                        "source": "ProjectA.Repositories",
+                        "kind": "namespace",
+                        "isGlobal": True,
+                        "line": 1,
+                    },
+                ],
+                "classes": [],
+                "functions": [],
+                "callGraph": [],
+            },
+            {
+                "path": "ProjectA/Services/Service.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "Service",
+                    "startLine": 1,
+                    "endLine": 6,
+                    "kind": "class",
+                    "namespace": "ProjectA.Services",
+                    "fullName": "ProjectA.Services.Service",
+                    "methods": ["Run"],
+                    "properties": [],
+                    "primaryConstructorParams": [{"name": "repository", "type": "IRepository"}],
+                }],
+                "functions": [{"name": "Run", "startLine": 3, "endLine": 5, "params": [], "typedParams": []}],
+                "callGraph": [{"caller": "Run", "callee": "repository.Save", "lineNumber": 4}],
+            },
+            {
+                "path": "ProjectA/Repositories/IRepository.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "IRepository",
+                    "startLine": 1,
+                    "endLine": 4,
+                    "kind": "interface",
+                    "namespace": "ProjectA.Repositories",
+                    "fullName": "ProjectA.Repositories.IRepository",
+                    "methods": ["Save"],
+                    "properties": [],
+                }],
+                "functions": [{"name": "Save", "startLine": 3, "endLine": 3, "params": [], "typedParams": []}],
+            },
+            {
+                "path": "ProjectB/Services/Service.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "Service",
+                    "startLine": 1,
+                    "endLine": 6,
+                    "kind": "class",
+                    "namespace": "ProjectB.Services",
+                    "fullName": "ProjectB.Services.Service",
+                    "methods": ["Run"],
+                    "properties": [],
+                    "primaryConstructorParams": [{"name": "repository", "type": "IRepository"}],
+                }],
+                "functions": [{"name": "Run", "startLine": 3, "endLine": 5, "params": [], "typedParams": []}],
+                "callGraph": [{"caller": "Run", "callee": "repository.Save", "lineNumber": 4}],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        edge_pairs = {(e["source"], e["target"], e["type"]) for e in assembled["edges"]}
+        self.assertEqual(stats["callsAdded"], 1)
+        self.assertIn((
+            "function:ProjectA/Services/Service.cs:Run",
+            "function:ProjectA/Repositories/IRepository.cs:Save",
+            "calls",
+        ), edge_pairs)
+        self.assertNotIn((
+            "function:ProjectB/Services/Service.cs:Run",
+            "function:ProjectA/Repositories/IRepository.cs:Save",
+            "calls",
+        ), edge_pairs)
+
+    def test_duplicate_function_node_id_target_is_skipped(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("Services/Service.cs"),
+                _class_node("Services/Service.cs", "Service"),
+                _function_node("Services/Service.cs", "Run"),
+                _file_node("Abstractions.cs"),
+                _class_node("Abstractions.cs", "IA"),
+                _class_node("Abstractions.cs", "IB"),
+                _function_node("Abstractions.cs", "Run"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "Services/Service.cs",
+                "language": "csharp",
+                "imports": [{"source": "App", "kind": "namespace", "line": 1}],
+                "classes": [{
+                    "name": "Service",
+                    "startLine": 3,
+                    "endLine": 8,
+                    "kind": "class",
+                    "namespace": "App.Services",
+                    "fullName": "App.Services.Service",
+                    "methods": ["Run"],
+                    "properties": [],
+                    "primaryConstructorParams": [{"name": "a", "type": "IA"}],
+                }],
+                "functions": [{"name": "Run", "startLine": 5, "endLine": 7, "params": [], "typedParams": []}],
+                "callGraph": [{"caller": "Run", "callee": "a.Run", "lineNumber": 6}],
+            },
+            {
+                "path": "Abstractions.cs",
+                "language": "csharp",
+                "classes": [
+                    {
+                        "name": "IA",
+                        "startLine": 1,
+                        "endLine": 4,
+                        "kind": "interface",
+                        "namespace": "App",
+                        "fullName": "App.IA",
+                        "methods": ["Run"],
+                        "properties": [],
+                    },
+                    {
+                        "name": "IB",
+                        "startLine": 6,
+                        "endLine": 9,
+                        "kind": "interface",
+                        "namespace": "App",
+                        "fullName": "App.IB",
+                        "methods": ["Run"],
+                        "properties": [],
+                    },
+                ],
+                "functions": [
+                    {"name": "Run", "startLine": 3, "endLine": 3, "params": [], "typedParams": []},
+                    {"name": "Run", "startLine": 8, "endLine": 8, "params": [], "typedParams": []},
+                ],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["callsAdded"], 0)
+        self.assertEqual(assembled["edges"], [])
+
+    def test_duplicate_function_node_id_caller_is_skipped(self) -> None:
+        assembled = {
+            "nodes": [
+                _file_node("Service.cs"),
+                _class_node("Service.cs", "Service"),
+                _function_node("Service.cs", "Run"),
+                _function_node("Service.cs", "Validate"),
+            ],
+            "edges": [],
+        }
+        results = [
+            {
+                "path": "Service.cs",
+                "language": "csharp",
+                "classes": [{
+                    "name": "Service",
+                    "startLine": 1,
+                    "endLine": 12,
+                    "kind": "class",
+                    "namespace": "App",
+                    "fullName": "App.Service",
+                    "methods": ["Run", "Run", "Validate"],
+                    "properties": [],
+                }],
+                "functions": [
+                    {"name": "Run", "startLine": 3, "endLine": 5, "params": [], "typedParams": []},
+                    {"name": "Run", "startLine": 7, "endLine": 9, "params": ["id"], "typedParams": [{"name": "id", "type": "int"}]},
+                    {"name": "Validate", "startLine": 11, "endLine": 11, "params": [], "typedParams": []},
+                ],
+                "callGraph": [{"caller": "Run", "callee": "Validate", "lineNumber": 4}],
+            },
+        ]
+
+        stats = self._link(assembled, results)
+
+        self.assertEqual(stats["callsAdded"], 0)
+        self.assertEqual(assembled["edges"], [])
 
 
 if __name__ == "__main__":

--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -265,6 +265,8 @@ Using the script's structural data and file categories, create edges:
 | `depends_on` | File has runtime dependency on another project file (broader than imports -- includes dynamic requires, lazy loads) | `0.6` | `forward` |
 | `tested_by` | Production file is exercised by a test file. Emit when you see the test importing/using the production file. Use direction `production → test` if you can; the merge script will flip inverted edges and dedupe. | `0.5` | `forward` |
 
+For C#, the deterministic merge step supplements these edges at three levels: resolved file dependencies use `imports`, constructor and instance-field declared types use `depends_on` between class nodes, and resolved method invocations use `calls` between function nodes. Class-level dependencies target the declared project type (including interfaces), never a guessed runtime implementation; ordinary method parameters and base types are excluded from `depends_on`.
+
 **Note on `tested_by`:** It's fine to emit even if you're unsure of the direction (you typically see the relationship while analyzing the *test* file, where the import points back at production). The merge script (`merge-batch-graphs.py`) canonicalizes direction to `production → test` and drops semantically broken edges (test↔test, prod↔prod, orphan endpoint). Path-convention pairing supplements anything you miss.
 
 #### Edges for non-code files:

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts
@@ -302,6 +302,51 @@ namespace App {
       tree.delete();
       parser.delete();
     });
+
+    it("preserves alias, static, global, and namespace-scoped using metadata", () => {
+      const { tree, parser, root } = parse(`global using System;
+using static System.Math;
+using Repo = App.Repositories;
+namespace App.Services {
+    using App.Repositories;
+    public class Service {}
+}
+`);
+      const result = extractor.extractStructure(root);
+
+      expect(result.imports).toEqual([
+        {
+          source: "System",
+          specifiers: ["System"],
+          lineNumber: 1,
+          kind: "namespace",
+          isGlobal: true,
+        },
+        {
+          source: "System.Math",
+          specifiers: ["Math"],
+          lineNumber: 2,
+          kind: "static",
+        },
+        {
+          source: "App.Repositories",
+          specifiers: ["Repositories"],
+          lineNumber: 3,
+          kind: "alias",
+          alias: "Repo",
+        },
+        {
+          source: "App.Repositories",
+          specifiers: ["Repositories"],
+          lineNumber: 5,
+          kind: "namespace",
+          namespace: "App.Services",
+        },
+      ]);
+
+      tree.delete();
+      parser.delete();
+    });
   });
 
   // ---- Exports ----
@@ -587,10 +632,10 @@ namespace App.Services
 `);
       const result = extractor.extractStructure(root);
 
-      // Functions: UserService (constructor), GetUsers, Log
-      expect(result.functions).toHaveLength(3);
+      // Functions: UserService (constructor), GetUsers, Log, and interface signatures
+      expect(result.functions).toHaveLength(5);
       expect(result.functions.map((f) => f.name).sort()).toEqual(
-        ["GetUsers", "Log", "UserService"].sort(),
+        ["FindAll", "FindById", "GetUsers", "Log", "UserService"].sort(),
       );
 
       // Constructor has params but no return type
@@ -697,6 +742,99 @@ describe("CSharpExtractor - modern type declarations", () => {
 
     expect(result.classes.some((c) => c.name === "Point")).toBe(true);
     expect(result.exports.some((e) => e.name === "Point")).toBe(true);
+
+    tree.delete();
+    parser.delete();
+  });
+
+  it("preserves namespace, declaration kind, base types, and primary constructor params", () => {
+    const { tree, parser, root } = parse(`using App.Repositories;
+namespace App.Services;
+
+public sealed class Service(IRepository repository) : BaseService, IService
+{
+}
+`);
+    const result = extractor.extractStructure(root);
+
+    const service = result.classes.find((c) => c.name === "Service");
+    expect(service).toBeDefined();
+    expect(service!.kind).toBe("class");
+    expect(service!.namespace).toBe("App.Services");
+    expect(service!.fullName).toBe("App.Services.Service");
+    expect(service!.baseTypes).toEqual(["BaseService", "IService"]);
+    expect(service!.primaryConstructorParams).toEqual([
+      { name: "repository", type: "IRepository" },
+    ]);
+
+    tree.delete();
+    parser.delete();
+  });
+
+  it("preserves block and nested namespaces", () => {
+    const { tree, parser, root } = parse(`namespace Outer {
+  namespace Inner {
+    public interface IService { }
+  }
+}
+`);
+    const result = extractor.extractStructure(root);
+
+    const service = result.classes.find((c) => c.name === "IService");
+    expect(service).toBeDefined();
+    expect(service!.namespace).toBe("Outer.Inner");
+    expect(service!.fullName).toBe("Outer.Inner.IService");
+    expect(service!.kind).toBe("interface");
+
+    tree.delete();
+    parser.delete();
+  });
+
+  it("preserves typed method parameters and typed fields", () => {
+    const { tree, parser, root } = parse(`namespace App;
+
+public class Service
+{
+    private readonly IRepository _repository;
+    public void Run(IRepository repository) { }
+}
+`);
+    const result = extractor.extractStructure(root);
+
+    const service = result.classes.find((c) => c.name === "Service");
+    expect(service).toBeDefined();
+    expect(service!.fields).toEqual([
+      { name: "_repository", type: "IRepository" },
+    ]);
+
+    const run = result.functions.find((fn) => fn.name === "Run");
+    expect(run).toBeDefined();
+    expect(run!.params).toEqual(["repository"]);
+    expect(run!.typedParams).toEqual([
+      { name: "repository", type: "IRepository" },
+    ]);
+
+    tree.delete();
+    parser.delete();
+  });
+
+  it("emits interface methods as function nodes", () => {
+    const { tree, parser, root } = parse(`namespace App;
+
+public interface IService
+{
+    Task RunAsync(int id);
+}
+`);
+    const result = extractor.extractStructure(root);
+
+    const service = result.classes.find((c) => c.name === "IService");
+    expect(service).toBeDefined();
+    expect(service!.methods).toEqual(["RunAsync"]);
+    const run = result.functions.find((fn) => fn.name === "RunAsync");
+    expect(run).toBeDefined();
+    expect(run!.returnType).toBe("Task");
+    expect(run!.typedParams).toEqual([{ name: "id", type: "int" }]);
 
     tree.delete();
     parser.delete();

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/__tests__/csharp-extractor.test.ts
@@ -54,6 +54,7 @@ describe("CSharpExtractor", () => {
       expect(result.functions).toHaveLength(2);
 
       expect(result.functions[0].name).toBe("GetName");
+      expect(result.functions[0].kind).toBe("method");
       expect(result.functions[0].params).toEqual(["id"]);
       expect(result.functions[0].returnType).toBe("string");
 
@@ -78,6 +79,7 @@ describe("CSharpExtractor", () => {
 
       expect(result.functions).toHaveLength(1);
       expect(result.functions[0].name).toBe("Foo");
+      expect(result.functions[0].kind).toBe("constructor");
       expect(result.functions[0].params).toEqual(["name", "value"]);
       expect(result.functions[0].returnType).toBeUndefined();
 
@@ -796,6 +798,7 @@ public sealed class Service(IRepository repository) : BaseService, IService
 public class Service
 {
     private readonly IRepository _repository;
+    private static readonly ICache Cache;
     public void Run(IRepository repository) { }
 }
 `);
@@ -805,11 +808,13 @@ public class Service
     expect(service).toBeDefined();
     expect(service!.fields).toEqual([
       { name: "_repository", type: "IRepository" },
+      { name: "Cache", type: "ICache", isStatic: true },
     ]);
 
     const run = result.functions.find((fn) => fn.name === "Run");
     expect(run).toBeDefined();
     expect(run!.params).toEqual(["repository"]);
+    expect(run!.kind).toBe("method");
     expect(run!.typedParams).toEqual([
       { name: "repository", type: "IRepository" },
     ]);

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts
@@ -449,6 +449,7 @@ export class CSharpExtractor implements LanguageExtractor {
             params: typedParams.map(param => param.name),
             returnType: extractReturnType(methodNode),
             typedParams,
+            kind: "method",
           });
         }
       }
@@ -547,6 +548,7 @@ export class CSharpExtractor implements LanguageExtractor {
       params,
       returnType,
       typedParams,
+      kind: "method",
     });
 
     if (hasModifier(node, "public")) {
@@ -580,6 +582,7 @@ export class CSharpExtractor implements LanguageExtractor {
       ],
       params,
       typedParams,
+      kind: "constructor",
       // Constructors have no return type
     });
 
@@ -629,6 +632,7 @@ export class CSharpExtractor implements LanguageExtractor {
         fields.push({
           name: nameNode.text,
           type,
+          ...(hasModifier(node, "static") ? { isStatic: true } : {}),
         });
 
         if (hasModifier(node, "public")) {

--- a/understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts
+++ b/understand-anything-plugin/packages/core/src/plugins/extractors/csharp-extractor.ts
@@ -1,4 +1,9 @@
-import type { StructuralAnalysis, CallGraphEntry } from "../../types.js";
+import type {
+  CallGraphEntry,
+  StructuralAnalysis,
+  TypedField,
+  TypedParameter,
+} from "../../types.js";
 import type { LanguageExtractor, TreeSitterNode } from "./types.js";
 import { findChild, findChildren } from "./base-extractor.js";
 
@@ -7,15 +12,19 @@ import { findChild, findChildren } from "./base-extractor.js";
  *
  * Each `parameter` child has a `name` field (identifier) and a `type` field.
  */
-function extractParams(paramsNode: TreeSitterNode | null): string[] {
+function extractTypedParams(paramsNode: TreeSitterNode | null): TypedParameter[] {
   if (!paramsNode) return [];
-  const params: string[] = [];
+  const params: TypedParameter[] = [];
 
   const paramNodes = findChildren(paramsNode, "parameter");
   for (const param of paramNodes) {
     const nameNode = param.childForFieldName("name");
+    const typeNode = param.childForFieldName("type");
     if (nameNode) {
-      params.push(nameNode.text);
+      params.push({
+        name: nameNode.text,
+        type: typeNode?.text ?? "",
+      });
     }
   }
 
@@ -54,29 +63,83 @@ function hasModifier(node: TreeSitterNode, modifier: string): boolean {
   return false;
 }
 
-/**
- * Extract the namespace source text from a using_directive.
- *
- * Handles both simple identifiers (`using System;`) and qualified names
- * (`using System.Collections.Generic;`). For aliased usings like
- * `using Alias = Some.Namespace;`, extracts the target namespace.
- */
-function extractUsingSource(node: TreeSitterNode): string | null {
-  // Check for alias form: `using Alias = Some.Namespace;`
-  const hasEquals = findChild(node, "=") !== null;
+type CSharpUsingInfo = {
+  source: string;
+  kind: "namespace" | "alias" | "static";
+  alias?: string;
+  isGlobal: boolean;
+};
 
+/**
+ * Extract source and C#-specific kind metadata from a using_directive.
+ */
+function extractUsingInfo(node: TreeSitterNode): CSharpUsingInfo | null {
+  const isGlobal = findChild(node, "global") !== null;
+  const isStatic = findChild(node, "static") !== null;
+  const hasEquals = findChild(node, "=") !== null;
   if (hasEquals) {
-    // The target namespace is the qualified_name after the `=`
     const qualifiedName = findChild(node, "qualified_name");
-    return qualifiedName ? qualifiedName.text : null;
+    const alias = node.childForFieldName("name")?.text;
+    return qualifiedName
+      ? { source: qualifiedName.text, kind: "alias", alias, isGlobal }
+      : null;
   }
 
-  // Simple or qualified using
   const qualifiedName = findChild(node, "qualified_name");
-  if (qualifiedName) return qualifiedName.text;
+  if (qualifiedName) {
+    return {
+      source: qualifiedName.text,
+      kind: isStatic ? "static" : "namespace",
+      isGlobal,
+    };
+  }
 
   const identifier = findChild(node, "identifier");
-  return identifier ? identifier.text : null;
+  return identifier
+    ? { source: identifier.text, kind: isStatic ? "static" : "namespace", isGlobal }
+    : null;
+}
+
+function extractNamespaceName(node: TreeSitterNode): string | null {
+  const nameNode = node.childForFieldName("name");
+  return nameNode?.text ?? null;
+}
+
+function joinNamespace(parentNamespace: string | null, childNamespace: string | null): string | undefined {
+  if (parentNamespace && childNamespace) return `${parentNamespace}.${childNamespace}`;
+  return parentNamespace ?? childNamespace ?? undefined;
+}
+
+function declarationKind(node: TreeSitterNode): "class" | "interface" | "struct" | "record" {
+  switch (node.type) {
+    case "interface_declaration":
+      return "interface";
+    case "struct_declaration":
+      return "struct";
+    case "record_declaration":
+      return "record";
+    default:
+      return "class";
+  }
+}
+
+function extractBaseTypes(node: TreeSitterNode): string[] {
+  const baseList = findChild(node, "base_list");
+  if (!baseList) return [];
+
+  const baseTypes: string[] = [];
+  for (let i = 0; i < baseList.childCount; i++) {
+    const child = baseList.child(i);
+    if (!child) continue;
+    if (
+      child.type === "identifier" ||
+      child.type === "qualified_name" ||
+      child.type === "generic_name"
+    ) {
+      baseTypes.push(child.text);
+    }
+  }
+  return baseTypes;
 }
 
 /**
@@ -132,7 +195,7 @@ export class CSharpExtractor implements LanguageExtractor {
     const imports: StructuralAnalysis["imports"] = [];
     const exports: StructuralAnalysis["exports"] = [];
 
-    this.walkTopLevel(rootNode, functions, classes, imports, exports);
+    this.walkTopLevel(rootNode, functions, classes, imports, exports, null);
 
     return { functions, classes, imports, exports };
   }
@@ -212,34 +275,36 @@ export class CSharpExtractor implements LanguageExtractor {
     classes: StructuralAnalysis["classes"],
     imports: StructuralAnalysis["imports"],
     exports: StructuralAnalysis["exports"],
+    namespaceContext: string | null,
   ): void {
+    let currentNamespace = namespaceContext;
     for (let i = 0; i < node.childCount; i++) {
       const child = node.child(i);
       if (!child) continue;
 
       switch (child.type) {
         case "using_directive":
-          this.extractUsing(child, imports);
+          this.extractUsing(child, imports, currentNamespace);
           break;
 
         case "namespace_declaration":
           // Recurse into namespace body (declaration_list)
-          this.walkNamespaceBody(child, functions, classes, imports, exports);
+          this.walkNamespaceBody(child, functions, classes, imports, exports, currentNamespace);
           break;
 
         case "file_scoped_namespace_declaration":
-          // File-scoped namespace: declarations are siblings at the root,
-          // not children of this node. Nothing to recurse into.
+          // File-scoped namespace: declarations are siblings at the root.
+          currentNamespace = joinNamespace(currentNamespace, extractNamespaceName(child)) ?? null;
           break;
 
         case "class_declaration":
         case "record_declaration":
         case "struct_declaration":
-          this.extractClass(child, functions, classes, exports);
+          this.extractClass(child, functions, classes, exports, currentNamespace);
           break;
 
         case "interface_declaration":
-          this.extractInterface(child, functions, classes, exports);
+          this.extractInterface(child, functions, classes, exports, currentNamespace);
           break;
       }
     }
@@ -255,7 +320,9 @@ export class CSharpExtractor implements LanguageExtractor {
     classes: StructuralAnalysis["classes"],
     imports: StructuralAnalysis["imports"],
     exports: StructuralAnalysis["exports"],
+    namespaceContext: string | null,
   ): void {
+    const currentNamespace = joinNamespace(namespaceContext, extractNamespaceName(nsNode)) ?? null;
     const body = nsNode.childForFieldName("body");
     if (!body) return;
 
@@ -264,19 +331,23 @@ export class CSharpExtractor implements LanguageExtractor {
       if (!child) continue;
 
       switch (child.type) {
+        case "using_directive":
+          this.extractUsing(child, imports, currentNamespace);
+          break;
+
         case "class_declaration":
         case "record_declaration":
         case "struct_declaration":
-          this.extractClass(child, functions, classes, exports);
+          this.extractClass(child, functions, classes, exports, currentNamespace);
           break;
 
         case "interface_declaration":
-          this.extractInterface(child, functions, classes, exports);
+          this.extractInterface(child, functions, classes, exports, currentNamespace);
           break;
 
         case "namespace_declaration":
           // Nested namespaces
-          this.walkNamespaceBody(child, functions, classes, imports, exports);
+          this.walkNamespaceBody(child, functions, classes, imports, exports, currentNamespace);
           break;
       }
     }
@@ -285,14 +356,19 @@ export class CSharpExtractor implements LanguageExtractor {
   private extractUsing(
     node: TreeSitterNode,
     imports: StructuralAnalysis["imports"],
+    namespaceContext: string | null,
   ): void {
-    const source = extractUsingSource(node);
-    if (!source) return;
+    const info = extractUsingInfo(node);
+    if (!info) return;
 
     imports.push({
-      source,
-      specifiers: [lastComponent(source)],
+      source: info.source,
+      specifiers: [lastComponent(info.source)],
       lineNumber: node.startPosition.row + 1,
+      kind: info.kind,
+      ...(info.alias ? { alias: info.alias } : {}),
+      ...(info.isGlobal ? { isGlobal: true } : {}),
+      ...(namespaceContext ? { namespace: namespaceContext } : {}),
     });
   }
 
@@ -301,18 +377,22 @@ export class CSharpExtractor implements LanguageExtractor {
     functions: StructuralAnalysis["functions"],
     classes: StructuralAnalysis["classes"],
     exports: StructuralAnalysis["exports"],
+    namespaceContext: string | null,
   ): void {
     const nameNode = node.childForFieldName("name");
     if (!nameNode) return;
 
     const methods: string[] = [];
     const properties: string[] = [];
+    const fields: TypedField[] = [];
+    const primaryConstructorParams = extractTypedParams(findChild(node, "parameter_list"));
 
     const body = node.childForFieldName("body");
     if (body) {
-      this.extractClassBodyMembers(body, methods, properties, functions, exports);
+      this.extractClassBodyMembers(body, methods, properties, fields, functions, exports);
     }
 
+    const namespace = namespaceContext ?? undefined;
     classes.push({
       name: nameNode.text,
       lineRange: [
@@ -321,6 +401,12 @@ export class CSharpExtractor implements LanguageExtractor {
       ],
       methods,
       properties,
+      kind: declarationKind(node),
+      namespace,
+      fullName: namespace ? `${namespace}.${nameNode.text}` : nameNode.text,
+      baseTypes: extractBaseTypes(node),
+      primaryConstructorParams,
+      fields,
     });
 
     if (hasModifier(node, "public")) {
@@ -336,6 +422,7 @@ export class CSharpExtractor implements LanguageExtractor {
     functions: StructuralAnalysis["functions"],
     classes: StructuralAnalysis["classes"],
     exports: StructuralAnalysis["exports"],
+    namespaceContext: string | null,
   ): void {
     const nameNode = node.childForFieldName("name");
     if (!nameNode) return;
@@ -351,6 +438,18 @@ export class CSharpExtractor implements LanguageExtractor {
         const methNameNode = methodNode.childForFieldName("name");
         if (methNameNode) {
           methods.push(methNameNode.text);
+          const paramsNode = methodNode.childForFieldName("parameters");
+          const typedParams = extractTypedParams(paramsNode ?? null);
+          functions.push({
+            name: methNameNode.text,
+            lineRange: [
+              methodNode.startPosition.row + 1,
+              methodNode.endPosition.row + 1,
+            ],
+            params: typedParams.map(param => param.name),
+            returnType: extractReturnType(methodNode),
+            typedParams,
+          });
         }
       }
 
@@ -364,6 +463,7 @@ export class CSharpExtractor implements LanguageExtractor {
       }
     }
 
+    const namespace = namespaceContext ?? undefined;
     classes.push({
       name: nameNode.text,
       lineRange: [
@@ -372,6 +472,10 @@ export class CSharpExtractor implements LanguageExtractor {
       ],
       methods,
       properties,
+      kind: "interface",
+      namespace,
+      fullName: namespace ? `${namespace}.${nameNode.text}` : nameNode.text,
+      baseTypes: extractBaseTypes(node),
     });
 
     if (hasModifier(node, "public")) {
@@ -390,6 +494,7 @@ export class CSharpExtractor implements LanguageExtractor {
     body: TreeSitterNode,
     methods: string[],
     properties: string[],
+    fields: TypedField[],
     functions: StructuralAnalysis["functions"],
     exports: StructuralAnalysis["exports"],
   ): void {
@@ -411,7 +516,7 @@ export class CSharpExtractor implements LanguageExtractor {
           break;
 
         case "field_declaration":
-          this.extractField(child, properties, exports);
+          this.extractField(child, properties, fields, exports);
           break;
       }
     }
@@ -427,7 +532,8 @@ export class CSharpExtractor implements LanguageExtractor {
     if (!nameNode) return;
 
     const paramsNode = node.childForFieldName("parameters");
-    const params = extractParams(paramsNode ?? null);
+    const typedParams = extractTypedParams(paramsNode ?? null);
+    const params = typedParams.map(param => param.name);
     const returnType = extractReturnType(node);
 
     methods.push(nameNode.text);
@@ -440,6 +546,7 @@ export class CSharpExtractor implements LanguageExtractor {
       ],
       params,
       returnType,
+      typedParams,
     });
 
     if (hasModifier(node, "public")) {
@@ -460,7 +567,8 @@ export class CSharpExtractor implements LanguageExtractor {
     if (!nameNode) return;
 
     const paramsNode = node.childForFieldName("parameters");
-    const params = extractParams(paramsNode ?? null);
+    const typedParams = extractTypedParams(paramsNode ?? null);
+    const params = typedParams.map(param => param.name);
 
     methods.push(nameNode.text);
 
@@ -471,6 +579,7 @@ export class CSharpExtractor implements LanguageExtractor {
         node.endPosition.row + 1,
       ],
       params,
+      typedParams,
       // Constructors have no return type
     });
 
@@ -503,18 +612,24 @@ export class CSharpExtractor implements LanguageExtractor {
   private extractField(
     node: TreeSitterNode,
     properties: string[],
+    fields: TypedField[],
     exports: StructuralAnalysis["exports"],
   ): void {
     // field_declaration -> variable_declaration -> variable_declarator(s)
     const varDecl = findChild(node, "variable_declaration");
     if (!varDecl) return;
 
+    const type = varDecl.childForFieldName("type")?.text ?? "";
     const declarators = findChildren(varDecl, "variable_declarator");
     for (const decl of declarators) {
       // variable_declarator's first child is the identifier
       const nameNode = findChild(decl, "identifier");
       if (nameNode) {
         properties.push(nameNode.text);
+        fields.push({
+          name: nameNode.text,
+          type,
+        });
 
         if (hasModifier(node, "public")) {
           exports.push({

--- a/understand-anything-plugin/packages/core/src/types.ts
+++ b/understand-anything-plugin/packages/core/src/types.ts
@@ -189,6 +189,7 @@ export interface TypedParameter {
 export interface TypedField {
   name: string;
   type: string;
+  isStatic?: boolean;
 }
 
 // Plugin interfaces
@@ -199,6 +200,7 @@ export interface StructuralAnalysis {
     params: string[];
     returnType?: string;
     typedParams?: TypedParameter[];
+    kind?: "method" | "constructor";
   }>;
   classes: Array<{
     name: string;

--- a/understand-anything-plugin/packages/core/src/types.ts
+++ b/understand-anything-plugin/packages/core/src/types.ts
@@ -181,11 +181,46 @@ export interface ReferenceResolution {
   line?: number;
 }
 
+export interface TypedParameter {
+  name: string;
+  type: string;
+}
+
+export interface TypedField {
+  name: string;
+  type: string;
+}
+
 // Plugin interfaces
 export interface StructuralAnalysis {
-  functions: Array<{ name: string; lineRange: [number, number]; params: string[]; returnType?: string }>;
-  classes: Array<{ name: string; lineRange: [number, number]; methods: string[]; properties: string[] }>;
-  imports: Array<{ source: string; specifiers: string[]; lineNumber: number }>;
+  functions: Array<{
+    name: string;
+    lineRange: [number, number];
+    params: string[];
+    returnType?: string;
+    typedParams?: TypedParameter[];
+  }>;
+  classes: Array<{
+    name: string;
+    lineRange: [number, number];
+    methods: string[];
+    properties: string[];
+    kind?: "class" | "interface" | "struct" | "record";
+    namespace?: string;
+    fullName?: string;
+    baseTypes?: string[];
+    primaryConstructorParams?: TypedParameter[];
+    fields?: TypedField[];
+  }>;
+  imports: Array<{
+    source: string;
+    specifiers: string[];
+    lineNumber: number;
+    kind?: "namespace" | "alias" | "static";
+    alias?: string;
+    isGlobal?: boolean;
+    namespace?: string;
+  }>;
   exports: Array<{ name: string; lineNumber: number; isDefault?: boolean }>;
   // Non-code structural data (all optional for backward compat)
   sections?: SectionInfo[];

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -1257,14 +1257,265 @@ function compareScalaPackageMembers(a, b) {
 // ---------------------------------------------------------------------------
 // C# resolver
 //
-// C# `using Foo.Bar;` declarations are typically NAMESPACES, not files, and
-// the C# convention is namespace = directory (loose). Tree-sitter's C#
-// extractor captures these as imports with the dotted source. We probe the
-// dotted path against the .cs index the same way Java/Kotlin do.
+// C# `using Foo.Bar;` declarations are namespaces, not file references.
+// We therefore do not convert namespace imports into file edges. C# file
+// dependencies are produced from declared type evidence collected in the
+// two-pass C# prepass below.
 // ---------------------------------------------------------------------------
 
-export function resolveCSharpImport(rawImport, _file, ctx) {
-  return resolveDottedFqn(rawImport, '.cs', ctx.csIndex);
+export function resolveCSharpImport(_rawImport, _file, _ctx) {
+  return [];
+}
+
+function stripCSharpTypeWrappers(typeName) {
+  let out = String(typeName ?? '').trim();
+  if (!out) return '';
+  out = out.replace(/\?+$/g, '').replace(/\[\]$/g, '').trim();
+  const genericStart = out.indexOf('<');
+  if (genericStart !== -1) out = out.slice(0, genericStart).trim();
+  return out;
+}
+
+function isCSharpBuiltInType(typeName) {
+  return new Set([
+    'bool', 'byte', 'sbyte', 'char', 'decimal', 'double', 'float',
+    'int', 'uint', 'long', 'ulong', 'object', 'short', 'ushort',
+    'string', 'void', 'dynamic',
+  ]).has(typeName);
+}
+
+function buildCSharpTypeIndex(analysesByPath) {
+  const fullNameIndex = new Map();
+  const simpleNameIndex = new Map();
+
+  for (const [filePath, analysis] of analysesByPath.entries()) {
+    for (const cls of analysis?.classes ?? []) {
+      if (!cls?.name || typeof cls.name !== 'string') continue;
+      const namespace = typeof cls.namespace === 'string' ? cls.namespace : '';
+      const fullName = typeof cls.fullName === 'string' && cls.fullName
+        ? cls.fullName
+        : namespace ? `${namespace}.${cls.name}` : cls.name;
+      const decl = {
+        name: cls.name,
+        fullName,
+        namespace,
+        kind: cls.kind,
+        filePath,
+        classInfo: cls,
+      };
+      if (!fullNameIndex.has(fullName)) fullNameIndex.set(fullName, []);
+      fullNameIndex.get(fullName).push(decl);
+      if (!simpleNameIndex.has(cls.name)) simpleNameIndex.set(cls.name, []);
+      simpleNameIndex.get(cls.name).push(decl);
+    }
+  }
+
+  return { fullNameIndex, simpleNameIndex };
+}
+
+function isCSharpProjectPath(path) {
+  return /\.csproj$/i.test(path);
+}
+
+function buildCSharpProjectDirs(files) {
+  return [...new Set(files
+    .map(file => toPosix(String(file?.path ?? '')))
+    .filter(isCSharpProjectPath)
+    .map(dirOf))]
+    .sort(comparePaths);
+}
+
+function pathIsInsideDir(path, dir) {
+  return dir === '' || path === dir || path.startsWith(`${dir}/`);
+}
+
+function csharpProjectKeyForPath(filePath, projectDirs) {
+  if (projectDirs.length <= 1) {
+    return projectDirs[0] ?? '__implicit_csharp_project__';
+  }
+  const matches = projectDirs
+    .filter(dir => pathIsInsideDir(filePath, dir))
+    .sort((a, b) => {
+      const depthDiff = b.split('/').length - a.split('/').length;
+      return depthDiff || comparePaths(a, b);
+    });
+  return matches[0] ?? null;
+}
+
+function collectCSharpGlobalUsingNamespaces(analysesByPath, projectDirs) {
+  const namespacesByProject = new Map();
+  for (const [filePath, analysis] of analysesByPath.entries()) {
+    const projectKey = csharpProjectKeyForPath(filePath, projectDirs);
+    if (projectKey === null) continue;
+    if (!namespacesByProject.has(projectKey)) namespacesByProject.set(projectKey, new Set());
+    const namespaces = namespacesByProject.get(projectKey);
+    for (const imp of analysis?.imports ?? []) {
+      const kind = imp?.kind ?? 'namespace';
+      if (
+        imp?.isGlobal === true &&
+        kind === 'namespace' &&
+        typeof imp.source === 'string' &&
+        imp.source.length > 0
+      ) {
+        namespaces.add(imp.source);
+      }
+    }
+  }
+  return new Map([...namespacesByProject.entries()]
+    .map(([projectKey, namespaces]) => [projectKey, [...namespaces].sort(comparePaths)]));
+}
+
+async function buildCSharpAnalysisContext(projectRoot, files, registry) {
+  const analysesByPath = new Map();
+  const failedPaths = new Set();
+  const projectDirs = buildCSharpProjectDirs(files);
+  const csharpFiles = files
+    .filter(file => file.fileCategory === 'code' && file.language === 'csharp')
+    .map(file => {
+      const key = toPosix(file.path);
+      return { key, absPath: join(projectRoot, key) };
+    });
+
+  const reads = await readFilesParallel(csharpFiles);
+  for (const { key, raw, err } of reads) {
+    if (err) {
+      process.stderr.write(
+        `Warning: extract-import-map: C# prepass failed for ${key} ` +
+        `(read error: ${err.message}) — importMap[${key}]=[]\n`,
+      );
+      failedPaths.add(key);
+      continue;
+    }
+
+    try {
+      const analysis = registry.analyzeFile(key, raw);
+      analysesByPath.set(key, analysis);
+    } catch (err) {
+      process.stderr.write(
+        `Warning: extract-import-map: C# prepass failed for ${key} ` +
+        `(analyze error: ${err.message}) — importMap[${key}]=[]\n`,
+      );
+      failedPaths.add(key);
+    }
+  }
+
+  return {
+    analysesByPath,
+    failedPaths,
+    typeIndex: buildCSharpTypeIndex(analysesByPath),
+    projectDirs,
+    globalUsingNamespacesByProject: collectCSharpGlobalUsingNamespaces(analysesByPath, projectDirs),
+  };
+}
+
+function resolveUniqueCSharpType(typeText, namespace, usingNamespaces, ctx) {
+  const typeName = stripCSharpTypeWrappers(typeText);
+  if (!typeName || isCSharpBuiltInType(typeName)) {
+    return { status: 'unresolved', declaration: null };
+  }
+
+  const candidates = [];
+  if (typeName.includes('.')) {
+    candidates.push(typeName);
+  } else {
+    if (namespace) candidates.push(`${namespace}.${typeName}`);
+    else candidates.push(typeName);
+    for (const usingNamespace of usingNamespaces) {
+      candidates.push(`${usingNamespace}.${typeName}`);
+    }
+  }
+
+  const seenDeclarations = new Set();
+  const matches = [];
+  for (const candidate of candidates) {
+    const declarations = ctx.csharp?.typeIndex.fullNameIndex.get(candidate) ?? [];
+    for (const decl of declarations) {
+      const key = `${decl.fullName}|${decl.filePath}`;
+      if (seenDeclarations.has(key)) continue;
+      seenDeclarations.add(key);
+      matches.push(decl);
+    }
+  }
+
+  if (matches.length === 1) {
+    return { status: 'resolved', declaration: matches[0] };
+  }
+  if (matches.length > 1) {
+    return { status: 'ambiguous', declaration: null };
+  }
+  return { status: 'unresolved', declaration: null };
+}
+
+function findContainingCSharpClass(classes, lineNumber) {
+  const matches = (classes ?? []).filter(cls =>
+    Array.isArray(cls.lineRange) &&
+    cls.lineRange[0] <= lineNumber &&
+    lineNumber <= cls.lineRange[1]);
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function csharpUsingAppliesToNamespace(usingEntry, namespace) {
+  const usingNamespace = typeof usingEntry.namespace === 'string'
+    ? usingEntry.namespace
+    : '';
+  if (!usingNamespace) return true;
+  return namespace === usingNamespace || namespace.startsWith(`${usingNamespace}.`);
+}
+
+function csharpUsingNamespacesFor(analysis, namespace, ctx, filePath) {
+  const projectKey = csharpProjectKeyForPath(filePath, ctx.csharp?.projectDirs ?? []);
+  const globalNamespaces = projectKey === null
+    ? []
+    : ctx.csharp?.globalUsingNamespacesByProject.get(projectKey) ?? [];
+  const namespaces = new Set(globalNamespaces);
+  for (const source of (analysis?.imports ?? [])
+    .filter(imp => {
+      const kind = imp?.kind ?? 'namespace';
+      return (
+        imp?.isGlobal !== true &&
+        kind === 'namespace' &&
+        typeof imp.source === 'string' &&
+        imp.source.length > 0 &&
+        csharpUsingAppliesToNamespace(imp, namespace)
+      );
+    })
+    .map(imp => imp.source)) {
+    namespaces.add(source);
+  }
+  return [...namespaces].sort(comparePaths);
+}
+
+function resolveCSharpFileDependencies(file, analysis, ctx) {
+  const resolvedSet = new Set();
+  const sourcePath = toPosix(file.path);
+
+  const resolveReference = (typeText, namespace) => {
+    const usingNamespaces = csharpUsingNamespacesFor(analysis, namespace, ctx, sourcePath);
+    const result = resolveUniqueCSharpType(typeText, namespace, usingNamespaces, ctx);
+    if (
+      result.status === 'resolved' &&
+      result.declaration.filePath !== sourcePath
+    ) {
+      resolvedSet.add(result.declaration.filePath);
+    }
+  };
+
+  for (const cls of analysis?.classes ?? []) {
+    const namespace = typeof cls.namespace === 'string' ? cls.namespace : '';
+    for (const baseType of cls.baseTypes ?? []) resolveReference(baseType, namespace);
+    for (const param of cls.primaryConstructorParams ?? []) resolveReference(param.type, namespace);
+    for (const field of cls.fields ?? []) resolveReference(field.type, namespace);
+  }
+
+  for (const fn of analysis?.functions ?? []) {
+    const containingClass = findContainingCSharpClass(analysis.classes, fn.lineRange?.[0] ?? 0);
+    const namespace = typeof containingClass?.namespace === 'string'
+      ? containingClass.namespace
+      : '';
+    for (const param of fn.typedParams ?? []) resolveReference(param.type, namespace);
+  }
+
+  return [...resolvedSet].sort(comparePaths);
 }
 
 // ---------------------------------------------------------------------------
@@ -1843,6 +2094,17 @@ async function main() {
   // tsconfig/go.mod/composer.json files inside is parallelised — see
   // `buildResolutionContext`.
   const ctx = await buildResolutionContext(projectRoot, files);
+  if (treeSitterReady) {
+    ctx.csharp = await buildCSharpAnalysisContext(projectRoot, files, registry);
+  } else {
+    ctx.csharp = {
+      analysesByPath: new Map(),
+      failedPaths: new Set(),
+      typeIndex: { fullNameIndex: new Map(), simpleNameIndex: new Map() },
+      projectDirs: buildCSharpProjectDirs(files),
+      globalUsingNamespacesByProject: new Map(),
+    };
+  }
 
   const importMap = {};
   let filesWithImports = 0;
@@ -1862,6 +2124,25 @@ async function main() {
     // already emitted at startup.
     if (!treeSitterReady) {
       importMap[path] = [];
+      continue;
+    }
+
+    if (file.language === 'csharp') {
+      if (ctx.csharp.failedPaths.has(path)) {
+        importMap[path] = [];
+        continue;
+      }
+      const analysis = ctx.csharp.analysesByPath.get(path);
+      if (!analysis) {
+        importMap[path] = [];
+        continue;
+      }
+      const resolved = resolveCSharpFileDependencies(file, analysis, ctx);
+      importMap[path] = resolved;
+      if (resolved.length > 0) {
+        filesWithImports += 1;
+        totalEdges += resolved.length;
+      }
       continue;
     }
 
@@ -1938,13 +2219,15 @@ async function main() {
     }
   }
 
+  const stats = {
+    filesScanned: files.length,
+    filesWithImports,
+    totalEdges,
+  };
+
   const output = {
     scriptCompleted: true,
-    stats: {
-      filesScanned: files.length,
-      filesWithImports,
-      totalEdges,
-    },
+    stats,
     importMap,
   };
 

--- a/understand-anything-plugin/skills/understand/extract-structure-result.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure-result.mjs
@@ -47,6 +47,11 @@ function isTypedNameArray(value) {
     typeof entry.type === 'string');
 }
 
+function isTypedFieldArray(value) {
+  return isTypedNameArray(value) && value.every(entry =>
+    entry.isStatic === undefined || typeof entry.isStatic === 'boolean');
+}
+
 function hasValidOptionalField(value, field, validator) {
   return value[field] === undefined || validator(value[field]);
 }
@@ -62,7 +67,9 @@ const STRUCTURE_ENTRY_VALIDATORS = {
     isLineRange(entry.lineRange) &&
     isStringArray(entry.params) &&
     hasValidOptionalField(entry, 'returnType', value => typeof value === 'string') &&
-    hasValidOptionalField(entry, 'typedParams', isTypedNameArray),
+    hasValidOptionalField(entry, 'typedParams', isTypedNameArray) &&
+    hasValidOptionalField(entry, 'kind', value =>
+      ['method', 'constructor'].includes(value)),
   classes: entry =>
     typeof entry.name === 'string' &&
     isLineRange(entry.lineRange) &&
@@ -74,7 +81,7 @@ const STRUCTURE_ENTRY_VALIDATORS = {
     hasValidOptionalField(entry, 'fullName', value => typeof value === 'string') &&
     hasValidOptionalField(entry, 'baseTypes', isStringArray) &&
     hasValidOptionalField(entry, 'primaryConstructorParams', isTypedNameArray) &&
-    hasValidOptionalField(entry, 'fields', isTypedNameArray),
+    hasValidOptionalField(entry, 'fields', isTypedFieldArray),
   imports: entry =>
     typeof entry.source === 'string' &&
     isStringArray(entry.specifiers) &&
@@ -255,6 +262,7 @@ export function buildResult(file, totalLines, nonEmptyLines, analysis, callGraph
       params: fn.params || [],
       ...(fn.returnType ? { returnType: fn.returnType } : {}),
       ...(fn.typedParams ? { typedParams: fn.typedParams } : {}),
+      ...(fn.kind ? { kind: fn.kind } : {}),
     }));
   }
 

--- a/understand-anything-plugin/skills/understand/extract-structure-result.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure-result.mjs
@@ -40,6 +40,13 @@ function isLineRange(value) {
     value.every(isFiniteInteger);
 }
 
+function isTypedNameArray(value) {
+  return Array.isArray(value) && value.every(entry =>
+    isPlainObject(entry) &&
+    typeof entry.name === 'string' &&
+    typeof entry.type === 'string');
+}
+
 function hasValidOptionalField(value, field, validator) {
   return value[field] === undefined || validator(value[field]);
 }
@@ -54,16 +61,29 @@ const STRUCTURE_ENTRY_VALIDATORS = {
     typeof entry.name === 'string' &&
     isLineRange(entry.lineRange) &&
     isStringArray(entry.params) &&
-    hasValidOptionalField(entry, 'returnType', value => typeof value === 'string'),
+    hasValidOptionalField(entry, 'returnType', value => typeof value === 'string') &&
+    hasValidOptionalField(entry, 'typedParams', isTypedNameArray),
   classes: entry =>
     typeof entry.name === 'string' &&
     isLineRange(entry.lineRange) &&
     isStringArray(entry.methods) &&
-    isStringArray(entry.properties),
+    isStringArray(entry.properties) &&
+    hasValidOptionalField(entry, 'kind', value =>
+      ['class', 'interface', 'struct', 'record'].includes(value)) &&
+    hasValidOptionalField(entry, 'namespace', value => typeof value === 'string') &&
+    hasValidOptionalField(entry, 'fullName', value => typeof value === 'string') &&
+    hasValidOptionalField(entry, 'baseTypes', isStringArray) &&
+    hasValidOptionalField(entry, 'primaryConstructorParams', isTypedNameArray) &&
+    hasValidOptionalField(entry, 'fields', isTypedNameArray),
   imports: entry =>
     typeof entry.source === 'string' &&
     isStringArray(entry.specifiers) &&
-    isFiniteInteger(entry.lineNumber),
+    isFiniteInteger(entry.lineNumber) &&
+    hasValidOptionalField(entry, 'kind', value =>
+      ['namespace', 'alias', 'static'].includes(value)) &&
+    hasValidOptionalField(entry, 'alias', value => typeof value === 'string') &&
+    hasValidOptionalField(entry, 'isGlobal', value => typeof value === 'boolean') &&
+    hasValidOptionalField(entry, 'namespace', value => typeof value === 'string'),
   exports: entry =>
     typeof entry.name === 'string' &&
     isFiniteInteger(entry.lineNumber) &&
@@ -233,6 +253,8 @@ export function buildResult(file, totalLines, nonEmptyLines, analysis, callGraph
       startLine: fn.lineRange[0],
       endLine: fn.lineRange[1],
       params: fn.params || [],
+      ...(fn.returnType ? { returnType: fn.returnType } : {}),
+      ...(fn.typedParams ? { typedParams: fn.typedParams } : {}),
     }));
   }
 
@@ -243,6 +265,12 @@ export function buildResult(file, totalLines, nonEmptyLines, analysis, callGraph
       endLine: cls.lineRange[1],
       methods: cls.methods || [],
       properties: cls.properties || [],
+      ...(cls.kind ? { kind: cls.kind } : {}),
+      ...(cls.namespace ? { namespace: cls.namespace } : {}),
+      ...(cls.fullName ? { fullName: cls.fullName } : {}),
+      ...(cls.baseTypes ? { baseTypes: cls.baseTypes } : {}),
+      ...(cls.primaryConstructorParams ? { primaryConstructorParams: cls.primaryConstructorParams } : {}),
+      ...(cls.fields ? { fields: cls.fields } : {}),
     }));
   }
 
@@ -251,6 +279,18 @@ export function buildResult(file, totalLines, nonEmptyLines, analysis, callGraph
       name: exp.name,
       line: exp.lineNumber,
       isDefault: exp.isDefault === true,
+    }));
+  }
+
+  if (file.language === 'csharp' && analysis.imports && analysis.imports.length > 0) {
+    base.imports = analysis.imports.map(imp => ({
+      source: imp.source,
+      specifiers: imp.specifiers || [],
+      line: imp.lineNumber,
+      ...(imp.kind ? { kind: imp.kind } : {}),
+      ...(imp.alias ? { alias: imp.alias } : {}),
+      ...(imp.isGlobal ? { isGlobal: imp.isGlobal } : {}),
+      ...(imp.namespace ? { namespace: imp.namespace } : {}),
     }));
   }
 

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -1058,6 +1058,505 @@ def recover_imports_from_scan(
     return recovered, lines
 
 
+# ── Deterministic C# linker from extraction artifacts ─────────────────────
+
+_CS_BUILTIN_TYPES = {
+    "bool", "byte", "sbyte", "char", "decimal", "double", "float",
+    "int", "uint", "long", "ulong", "object", "short", "ushort",
+    "string", "void", "dynamic",
+}
+
+_CS_MEMBER_CALL_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$")
+_CS_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _cs_line_range(entry: dict[str, Any]) -> tuple[int, int] | None:
+    start = entry.get("startLine")
+    end = entry.get("endLine")
+    if isinstance(start, int) and isinstance(end, int):
+        return start, end
+    rng = entry.get("lineRange")
+    if (
+        isinstance(rng, list)
+        and len(rng) == 2
+        and isinstance(rng[0], int)
+        and isinstance(rng[1], int)
+    ):
+        return rng[0], rng[1]
+    return None
+
+
+def _cs_strip_type(type_text: Any) -> str:
+    out = str(type_text or "").strip()
+    while out.endswith("?"):
+        out = out[:-1].strip()
+    while out.endswith("[]"):
+        out = out[:-2].strip()
+    generic_start = out.find("<")
+    if generic_start != -1:
+        out = out[:generic_start].strip()
+    return out
+
+
+def _cs_dir_of(path: str) -> str:
+    return path.rsplit("/", 1)[0] if "/" in path else ""
+
+
+def _cs_is_project_path(path: str) -> bool:
+    return path.lower().endswith(".csproj")
+
+
+def _cs_project_dirs(paths: list[str]) -> list[str]:
+    return sorted({_cs_dir_of(path) for path in paths if _cs_is_project_path(path)})
+
+
+def _cs_path_inside_dir(path: str, directory: str) -> bool:
+    return directory == "" or path == directory or path.startswith(f"{directory}/")
+
+
+def _cs_project_key_for_path(file_path: str, project_dirs: list[str]) -> str | None:
+    if len(project_dirs) <= 1:
+        return project_dirs[0] if project_dirs else "__implicit_csharp_project__"
+    matches = [
+        directory
+        for directory in project_dirs
+        if _cs_path_inside_dir(file_path, directory)
+    ]
+    if not matches:
+        return None
+    return sorted(matches, key=lambda directory: (-len(directory.split("/")), directory))[0]
+
+
+def _cs_project_paths_from_assembled(assembled: dict[str, Any]) -> list[str]:
+    paths: list[str] = []
+    for node in assembled.get("nodes", []):
+        if not isinstance(node, dict):
+            continue
+        path = node.get("filePath")
+        if not isinstance(path, str) or not path:
+            node_id = node.get("id")
+            if isinstance(node_id, str) and node_id.startswith("file:"):
+                path = node_id[len("file:"):]
+        if isinstance(path, str) and _cs_is_project_path(path):
+            paths.append(path)
+    return paths
+
+
+def _load_csharp_extract_results(tmp_dir: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    if not tmp_dir.is_dir():
+        return [], []
+
+    results: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for path in sorted(tmp_dir.glob("ua-file-extract-results-*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            warnings.append(f"  Skipped {path.name}: {e}")
+            continue
+        entries = data.get("results")
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict) and entry.get("language") == "csharp":
+                results.append(entry)
+    return results, warnings
+
+
+def _cs_build_indexes(
+    results: list[dict[str, Any]],
+    project_paths: list[str] | None = None,
+) -> dict[str, Any]:
+    files: dict[str, dict[str, Any]] = {}
+    full_name_index: dict[str, list[dict[str, Any]]] = {}
+    project_dirs = _cs_project_dirs(
+        [result.get("path", "") for result in results if isinstance(result.get("path"), str)]
+        + (project_paths or [])
+    )
+
+    for result in results:
+        file_path = result.get("path")
+        if not isinstance(file_path, str) or not file_path:
+            continue
+        imports = []
+        for imp in result.get("imports", []):
+            if not isinstance(imp, dict) or not isinstance(imp.get("source"), str):
+                continue
+            imports.append({
+                "source": imp.get("source"),
+                "kind": imp.get("kind", "namespace"),
+                "namespace": imp.get("namespace", ""),
+                "isGlobal": imp.get("isGlobal") is True,
+            })
+        file_info = {
+            "path": file_path,
+            "imports": imports,
+            "classes": [],
+            "functions": [],
+            "functionNameCounts": Counter(),
+            "callGraph": result.get("callGraph", [])
+            if isinstance(result.get("callGraph"), list)
+            else [],
+        }
+        files[file_path] = file_info
+
+        for raw_fn in result.get("functions", []) or []:
+            if not isinstance(raw_fn, dict):
+                continue
+            rng = _cs_line_range(raw_fn)
+            if rng is None or not isinstance(raw_fn.get("name"), str):
+                continue
+            fn = dict(raw_fn)
+            fn["lineRange"] = rng
+            file_info["functions"].append(fn)
+            file_info["functionNameCounts"][fn["name"]] += 1
+
+        for raw_cls in result.get("classes", []) or []:
+            if not isinstance(raw_cls, dict):
+                continue
+            rng = _cs_line_range(raw_cls)
+            name = raw_cls.get("name")
+            if rng is None or not isinstance(name, str):
+                continue
+            namespace = raw_cls.get("namespace") if isinstance(raw_cls.get("namespace"), str) else ""
+            full_name = raw_cls.get("fullName") if isinstance(raw_cls.get("fullName"), str) else ""
+            if not full_name:
+                full_name = f"{namespace}.{name}" if namespace else name
+            cls = dict(raw_cls)
+            cls["lineRange"] = rng
+            cls["namespace"] = namespace
+            cls["fullName"] = full_name
+            cls["filePath"] = file_path
+            file_info["classes"].append(cls)
+            full_name_index.setdefault(full_name, []).append(cls)
+
+    global_using_namespaces_by_project: dict[str, list[str]] = {}
+    global_using_namespace_sets: dict[str, set[str]] = {}
+    for file_info in files.values():
+        project_key = _cs_project_key_for_path(file_info["path"], project_dirs)
+        if project_key is None:
+            continue
+        namespace_set = global_using_namespace_sets.setdefault(project_key, set())
+        for imp in file_info["imports"]:
+            if (
+                imp.get("isGlobal") is True
+                and imp.get("kind", "namespace") == "namespace"
+                and isinstance(imp.get("source"), str)
+                and imp.get("source")
+            ):
+                namespace_set.add(imp["source"])
+    for project_key, namespaces in global_using_namespace_sets.items():
+        global_using_namespaces_by_project[project_key] = sorted(namespaces)
+
+    return {
+        "files": files,
+        "fullNameIndex": full_name_index,
+        "projectDirs": project_dirs,
+        "globalUsingNamespacesByProject": global_using_namespaces_by_project,
+    }
+
+
+def _cs_resolve_type(
+    type_text: Any,
+    namespace: str,
+    using_namespaces: list[str],
+    indexes: dict[str, Any],
+) -> tuple[str, dict[str, Any] | None]:
+    type_name = _cs_strip_type(type_text)
+    if not type_name or type_name in _CS_BUILTIN_TYPES:
+        return "unresolved", None
+
+    candidates: list[str]
+    if "." in type_name:
+        candidates = [type_name]
+    else:
+        candidates = [f"{namespace}.{type_name}" if namespace else type_name]
+        candidates.extend(f"{using_namespace}.{type_name}" for using_namespace in using_namespaces)
+
+    matches: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for candidate in candidates:
+        for decl in indexes["fullNameIndex"].get(candidate, []):
+            key = (decl.get("fullName", ""), decl.get("filePath", ""))
+            if key in seen:
+                continue
+            seen.add(key)
+            matches.append(decl)
+
+    if len(matches) == 1:
+        return "resolved", matches[0]
+    if len(matches) > 1:
+        return "ambiguous", None
+    return "unresolved", None
+
+
+def _cs_containing_class(classes: list[dict[str, Any]], line_number: int) -> dict[str, Any] | None:
+    matches = [
+        cls for cls in classes
+        if cls["lineRange"][0] <= line_number <= cls["lineRange"][1]
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _cs_containing_function(functions: list[dict[str, Any]], line_number: int) -> dict[str, Any] | None:
+    matches = [
+        fn for fn in functions
+        if fn["lineRange"][0] <= line_number <= fn["lineRange"][1]
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _cs_using_applies_to_namespace(using_entry: dict[str, Any], namespace: str) -> bool:
+    using_namespace = using_entry.get("namespace") if isinstance(using_entry.get("namespace"), str) else ""
+    if not using_namespace:
+        return True
+    return namespace == using_namespace or namespace.startswith(f"{using_namespace}.")
+
+
+def _cs_using_namespaces_for(
+    file_info: dict[str, Any],
+    namespace: str,
+    indexes: dict[str, Any],
+) -> list[str]:
+    project_key = _cs_project_key_for_path(file_info["path"], indexes.get("projectDirs", []))
+    global_namespaces = (
+        indexes.get("globalUsingNamespacesByProject", {}).get(project_key, [])
+        if project_key is not None
+        else []
+    )
+    namespaces: set[str] = set(global_namespaces)
+    for imp in file_info.get("imports", []):
+        if not isinstance(imp, dict):
+            continue
+        if imp.get("isGlobal") is True:
+            continue
+        if imp.get("kind", "namespace") != "namespace":
+            continue
+        source = imp.get("source")
+        if not isinstance(source, str) or not source:
+            continue
+        if not _cs_using_applies_to_namespace(imp, namespace):
+            continue
+        namespaces.add(source)
+    return sorted(namespaces)
+
+
+def _cs_target_method_function(
+    target_class: dict[str, Any],
+    method_name: str,
+    indexes: dict[str, Any],
+    node_ids: set[str],
+) -> str | None:
+    file_path = target_class.get("filePath", "")
+    file_info = indexes["files"].get(file_path)
+    if file_info is None:
+        return None
+
+    matches = [
+        fn for fn in file_info["functions"]
+        if fn.get("name") == method_name
+        and target_class["lineRange"][0] <= fn["lineRange"][0] <= target_class["lineRange"][1]
+    ]
+    if len(matches) != 1:
+        return None
+    if file_info["functionNameCounts"].get(method_name, 0) != 1:
+        return None
+
+    target_id = f"function:{file_path}:{method_name}"
+    return target_id if target_id in node_ids else None
+
+
+def _cs_add_edge(
+    edges: list[dict[str, Any]],
+    existing: set[tuple[str, str, str]],
+    source: str,
+    target: str,
+    edge_type: str,
+    weight: float,
+) -> bool:
+    if source == target:
+        return False
+    key = (source, target, edge_type)
+    if key in existing:
+        return False
+    edges.append({
+        "source": source,
+        "target": target,
+        "type": edge_type,
+        "direction": "forward",
+        "weight": weight,
+        "deterministic": True,
+    })
+    existing.add(key)
+    return True
+
+
+def link_csharp_deterministic_edges(
+    assembled: dict[str, Any],
+    tmp_dir: Path,
+) -> tuple[dict[str, int], list[str]]:
+    """Add deterministic C# calls/implements/inherits edges from extraction output."""
+    results, warnings = _load_csharp_extract_results(tmp_dir)
+    stats = {
+        "filesScanned": len(results),
+        "identifierMemberCalls": 0,
+        "receiverTypesFound": 0,
+        "receiverTypesResolved": 0,
+        "targetMethodsResolved": 0,
+        "callsAdded": 0,
+        "callsSkipped": 0,
+        "baseTypesScanned": 0,
+        "inheritanceAdded": 0,
+        "inheritanceSkipped": 0,
+    }
+    if not results:
+        return stats, warnings
+
+    indexes = _cs_build_indexes(results, _cs_project_paths_from_assembled(assembled))
+    node_ids = {
+        node.get("id")
+        for node in assembled.get("nodes", [])
+        if isinstance(node, dict) and isinstance(node.get("id"), str)
+    }
+    existing_edges = {
+        (edge.get("source", ""), edge.get("target", ""), edge.get("type", ""))
+        for edge in assembled.get("edges", [])
+        if isinstance(edge, dict)
+    }
+
+    for file_info in indexes["files"].values():
+        for cls in file_info["classes"]:
+            source_id = f"class:{file_info['path']}:{cls.get('name', '')}"
+            if source_id not in node_ids:
+                continue
+            source_kind = cls.get("kind")
+            using_namespaces = _cs_using_namespaces_for(file_info, cls.get("namespace", ""), indexes)
+            for base_type in cls.get("baseTypes", []) or []:
+                stats["baseTypesScanned"] += 1
+                status, target = _cs_resolve_type(
+                    base_type,
+                    cls.get("namespace", ""),
+                    using_namespaces,
+                    indexes,
+                )
+                if status != "resolved" or target is None:
+                    stats["inheritanceSkipped"] += 1
+                    continue
+                target_id = f"class:{target.get('filePath', '')}:{target.get('name', '')}"
+                if target_id not in node_ids:
+                    stats["inheritanceSkipped"] += 1
+                    continue
+                target_kind = target.get("kind")
+                if target_kind == "interface" and source_kind in {"class", "record", "struct"}:
+                    edge_type = "implements"
+                elif source_kind in {"class", "record"} and target_kind in {"class", "record"}:
+                    edge_type = "inherits"
+                elif source_kind == "interface" and target_kind == "interface":
+                    edge_type = "inherits"
+                else:
+                    stats["inheritanceSkipped"] += 1
+                    continue
+                if _cs_add_edge(assembled["edges"], existing_edges, source_id, target_id, edge_type, 0.8):
+                    stats["inheritanceAdded"] += 1
+
+        for call in file_info["callGraph"]:
+            if not isinstance(call, dict):
+                continue
+            callee = call.get("callee")
+            line_number = call.get("lineNumber")
+            if not isinstance(callee, str) or not isinstance(line_number, int):
+                continue
+
+            caller_fn = _cs_containing_function(file_info["functions"], line_number)
+            caller_cls = _cs_containing_class(file_info["classes"], line_number)
+            if caller_fn is None or caller_cls is None:
+                stats["callsSkipped"] += 1
+                continue
+            caller_id = f"function:{file_info['path']}:{caller_fn.get('name', '')}"
+            if (
+                caller_id not in node_ids
+                or file_info["functionNameCounts"].get(caller_fn.get("name", ""), 0) != 1
+            ):
+                stats["callsSkipped"] += 1
+                continue
+            using_namespaces = _cs_using_namespaces_for(file_info, caller_cls.get("namespace", ""), indexes)
+
+            member_match = _CS_MEMBER_CALL_RE.match(callee)
+            if member_match:
+                stats["identifierMemberCalls"] += 1
+                receiver, method_name = member_match.groups()
+                receiver_type = None
+                for param in caller_fn.get("typedParams", []) or []:
+                    if isinstance(param, dict) and param.get("name") == receiver:
+                        receiver_type = param.get("type")
+                        break
+                if receiver_type is None:
+                    for param in caller_cls.get("primaryConstructorParams", []) or []:
+                        if isinstance(param, dict) and param.get("name") == receiver:
+                            receiver_type = param.get("type")
+                            break
+                if receiver_type is None:
+                    for field in caller_cls.get("fields", []) or []:
+                        if isinstance(field, dict) and field.get("name") == receiver:
+                            receiver_type = field.get("type")
+                            break
+                if receiver_type is None:
+                    stats["callsSkipped"] += 1
+                    continue
+
+                stats["receiverTypesFound"] += 1
+                status, target_class = _cs_resolve_type(
+                    receiver_type,
+                    caller_cls.get("namespace", ""),
+                    using_namespaces,
+                    indexes,
+                )
+                if status != "resolved" or target_class is None:
+                    stats["callsSkipped"] += 1
+                    continue
+                stats["receiverTypesResolved"] += 1
+                target_id = _cs_target_method_function(target_class, method_name, indexes, node_ids)
+                if target_id is None:
+                    stats["callsSkipped"] += 1
+                    continue
+                stats["targetMethodsResolved"] += 1
+                if _cs_add_edge(assembled["edges"], existing_edges, caller_id, target_id, "calls", 0.8):
+                    stats["callsAdded"] += 1
+                continue
+
+            if _CS_IDENTIFIER_RE.match(callee):
+                containing_methods = [
+                    fn for fn in file_info["functions"]
+                    if fn.get("name") == callee
+                    and caller_cls["lineRange"][0] <= fn["lineRange"][0] <= caller_cls["lineRange"][1]
+                ]
+                target_id = f"function:{file_info['path']}:{callee}"
+                if (
+                    len(containing_methods) == 1
+                    and target_id in node_ids
+                    and file_info["functionNameCounts"].get(callee, 0) == 1
+                ):
+                    if _cs_add_edge(assembled["edges"], existing_edges, caller_id, target_id, "calls", 0.8):
+                        stats["callsAdded"] += 1
+                else:
+                    stats["callsSkipped"] += 1
+                continue
+
+            stats["callsSkipped"] += 1
+
+    lines = [
+        f"  C# files scanned: {stats['filesScanned']}",
+        f"  identifier.Method calls: {stats['identifierMemberCalls']}",
+        f"  receiver types found: {stats['receiverTypesFound']}",
+        f"  receiver types uniquely resolved: {stats['receiverTypesResolved']}",
+        f"  target methods uniquely resolved: {stats['targetMethodsResolved']}",
+        f"  calls added: {stats['callsAdded']}",
+        f"  base types scanned: {stats['baseTypesScanned']}",
+        f"  implements/inherits added: {stats['inheritanceAdded']}",
+    ]
+    return stats, warnings + lines
+
+
 # ── Main ──────────────────────────────────────────────────────────────────
 
 def main() -> None:
@@ -1230,6 +1729,14 @@ def main() -> None:
         report.append("")
         report.append("Imports edge recovery:")
         report.extend(recovery_report)
+
+    csharp_stats, csharp_report = link_csharp_deterministic_edges(
+        assembled, resolve_ua_dir(project_root) / "tmp"
+    )
+    if csharp_report:
+        report.append("")
+        report.append("C# deterministic linker:")
+        report.extend(csharp_report)
 
     # Print report
     print("", file=sys.stderr)

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -1192,6 +1192,7 @@ def _cs_build_indexes(
             "path": file_path,
             "imports": imports,
             "classes": [],
+            "classNameCounts": Counter(),
             "functions": [],
             "functionNameCounts": Counter(),
             "callGraph": result.get("callGraph", [])
@@ -1228,6 +1229,7 @@ def _cs_build_indexes(
             cls["fullName"] = full_name
             cls["filePath"] = file_path
             file_info["classes"].append(cls)
+            file_info["classNameCounts"][name] += 1
             full_name_index.setdefault(full_name, []).append(cls)
 
     global_using_namespaces_by_project: dict[str, list[str]] = {}
@@ -1290,22 +1292,6 @@ def _cs_resolve_type(
     return "unresolved", None
 
 
-def _cs_containing_class(classes: list[dict[str, Any]], line_number: int) -> dict[str, Any] | None:
-    matches = [
-        cls for cls in classes
-        if cls["lineRange"][0] <= line_number <= cls["lineRange"][1]
-    ]
-    return matches[0] if len(matches) == 1 else None
-
-
-def _cs_containing_function(functions: list[dict[str, Any]], line_number: int) -> dict[str, Any] | None:
-    matches = [
-        fn for fn in functions
-        if fn["lineRange"][0] <= line_number <= fn["lineRange"][1]
-    ]
-    return matches[0] if len(matches) == 1 else None
-
-
 def _cs_using_applies_to_namespace(using_entry: dict[str, Any], namespace: str) -> bool:
     using_namespace = using_entry.get("namespace") if isinstance(using_entry.get("namespace"), str) else ""
     if not using_namespace:
@@ -1345,25 +1331,74 @@ def _cs_target_method_function(
     target_class: dict[str, Any],
     method_name: str,
     indexes: dict[str, Any],
-    node_ids: set[str],
-) -> str | None:
+) -> tuple[str, dict[str, Any] | None]:
     file_path = target_class.get("filePath", "")
     file_info = indexes["files"].get(file_path)
     if file_info is None:
-        return None
+        return "missing", None
 
     matches = [
         fn for fn in file_info["functions"]
         if fn.get("name") == method_name
         and target_class["lineRange"][0] <= fn["lineRange"][0] <= target_class["lineRange"][1]
     ]
+    if not matches:
+        return "missing", None
     if len(matches) != 1:
-        return None
+        return "ambiguous", None
     if file_info["functionNameCounts"].get(method_name, 0) != 1:
-        return None
+        return "ambiguous", None
+    return "resolved", matches[0]
 
-    target_id = f"function:{file_path}:{method_name}"
-    return target_id if target_id in node_ids else None
+
+def _cs_declared_dependency_types(
+    cls: dict[str, Any],
+    file_info: dict[str, Any],
+) -> list[str]:
+    references: list[str] = []
+
+    def append_types(entries: Any) -> None:
+        if not isinstance(entries, list):
+            return
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            type_text = entry.get("type")
+            if isinstance(type_text, str) and type_text:
+                references.append(type_text)
+
+    append_types(cls.get("primaryConstructorParams"))
+
+    class_name = cls.get("name", "")
+    for function in file_info["functions"]:
+        if not (
+            cls["lineRange"][0]
+            <= function["lineRange"][0]
+            <= cls["lineRange"][1]
+        ):
+            continue
+        function_kind = function.get("kind")
+        is_constructor = function_kind == "constructor" or (
+            function_kind is None and function.get("name") == class_name
+        )
+        if is_constructor:
+            append_types(function.get("typedParams"))
+
+    instance_fields = [
+        field for field in cls.get("fields", []) or []
+        if isinstance(field, dict) and field.get("isStatic") is not True
+    ]
+    append_types(instance_fields)
+
+    unique: list[str] = []
+    seen: set[str] = set()
+    for reference in references:
+        normalized = _cs_strip_type(reference)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        unique.append(reference)
+    return unique
 
 
 def _cs_add_edge(
@@ -1391,23 +1426,165 @@ def _cs_add_edge(
     return True
 
 
+def _cs_synthesized_complexity(line_range: tuple[int, int]) -> str:
+    line_count = max(1, line_range[1] - line_range[0] + 1)
+    if line_count <= 10:
+        return "simple"
+    if line_count <= 50:
+        return "moderate"
+    return "complex"
+
+
+def _cs_ensure_endpoint_node(
+    assembled: dict[str, Any],
+    node_ids: set[str],
+    existing_edges: set[tuple[str, str, str]],
+    node_type: str,
+    file_path: str,
+    name: str,
+    line_range: tuple[int, int],
+    summary: str,
+    tags: list[str],
+    stats: dict[str, int],
+) -> str:
+    node_id = f"{node_type}:{file_path}:{name}"
+    if node_id in node_ids:
+        return node_id
+
+    assembled["nodes"].append({
+        "id": node_id,
+        "type": node_type,
+        "name": name,
+        "filePath": file_path,
+        "lineRange": [line_range[0], line_range[1]],
+        "summary": summary,
+        "tags": tags + ["auto-linked"],
+        "complexity": _cs_synthesized_complexity(line_range),
+        "deterministic": True,
+    })
+    node_ids.add(node_id)
+    stats[f"{node_type}NodesSynthesized"] += 1
+
+    file_id = f"file:{file_path}"
+    if file_id in node_ids:
+        if _cs_add_edge(
+            assembled["edges"], existing_edges, file_id, node_id, "contains", 1.0
+        ):
+            stats["containsEdgesAdded"] += 1
+    else:
+        stats["synthesizedEndpointsMissingFileNode"] += 1
+    return node_id
+
+
+def _cs_has_unique_class_endpoint(
+    cls: dict[str, Any],
+    indexes: dict[str, Any],
+) -> bool:
+    file_path = cls.get("filePath", "")
+    name = cls.get("name", "")
+    file_info = indexes["files"].get(file_path)
+    return not (
+        file_info is None
+        or not isinstance(name, str)
+        or not name
+        or file_info["classNameCounts"].get(name, 0) != 1
+    )
+
+
+def _cs_ensure_class_endpoint(
+    assembled: dict[str, Any],
+    node_ids: set[str],
+    existing_edges: set[tuple[str, str, str]],
+    cls: dict[str, Any],
+    stats: dict[str, int],
+) -> str:
+    file_path = cls.get("filePath", "")
+    name = cls.get("name", "")
+
+    kind = cls.get("kind") if isinstance(cls.get("kind"), str) else "type"
+    full_name = cls.get("fullName") if isinstance(cls.get("fullName"), str) else name
+    return _cs_ensure_endpoint_node(
+        assembled,
+        node_ids,
+        existing_edges,
+        "class",
+        file_path,
+        name,
+        cls["lineRange"],
+        f"C# {kind} {full_name}.",
+        ["csharp", kind],
+        stats,
+    )
+
+
+def _cs_ensure_function_endpoint(
+    assembled: dict[str, Any],
+    node_ids: set[str],
+    existing_edges: set[tuple[str, str, str]],
+    function: dict[str, Any],
+    containing_class: dict[str, Any],
+    file_path: str,
+    stats: dict[str, int],
+) -> str:
+    name = function.get("name", "")
+    class_name = containing_class.get("fullName") or containing_class.get("name") or "type"
+    return _cs_ensure_endpoint_node(
+        assembled,
+        node_ids,
+        existing_edges,
+        "function",
+        file_path,
+        name,
+        function["lineRange"],
+        f"C# method {class_name}.{name}.",
+        ["csharp", "method"],
+        stats,
+    )
+
+
 def link_csharp_deterministic_edges(
     assembled: dict[str, Any],
     tmp_dir: Path,
 ) -> tuple[dict[str, int], list[str]]:
-    """Add deterministic C# calls/implements/inherits edges from extraction output."""
+    """Add C# edges and synthesize uniquely proven endpoints from extraction output."""
     results, warnings = _load_csharp_extract_results(tmp_dir)
     stats = {
         "filesScanned": len(results),
+        "classNodesSynthesized": 0,
+        "functionNodesSynthesized": 0,
+        "containsEdgesAdded": 0,
+        "synthesizedEndpointsMissingFileNode": 0,
         "identifierMemberCalls": 0,
         "receiverTypesFound": 0,
         "receiverTypesResolved": 0,
         "targetMethodsResolved": 0,
         "callsAdded": 0,
         "callsSkipped": 0,
+        "callsNoContainingFunction": 0,
+        "callsAmbiguousContainingFunction": 0,
+        "callsNoContainingClass": 0,
+        "callsAmbiguousContainingClass": 0,
+        "callsAmbiguousCallerId": 0,
+        "callsNoReceiverType": 0,
+        "callsReceiverTypeUnresolved": 0,
+        "callsReceiverTypeAmbiguous": 0,
+        "callsTargetMethodMissing": 0,
+        "callsTargetMethodAmbiguous": 0,
+        "callsUnsupportedCallee": 0,
         "baseTypesScanned": 0,
         "inheritanceAdded": 0,
         "inheritanceSkipped": 0,
+        "inheritanceTypeUnresolved": 0,
+        "inheritanceTypeAmbiguous": 0,
+        "inheritanceEndpointAmbiguous": 0,
+        "inheritanceKindUnsupported": 0,
+        "declaredDependenciesScanned": 0,
+        "dependsOnAdded": 0,
+        "dependsOnSkipped": 0,
+        "dependsOnTypeUnresolved": 0,
+        "dependsOnTypeAmbiguous": 0,
+        "dependsOnEndpointAmbiguous": 0,
+        "dependsOnSelfReference": 0,
     }
     if not results:
         return stats, warnings
@@ -1424,11 +1601,24 @@ def link_csharp_deterministic_edges(
         if isinstance(edge, dict)
     }
 
-    for file_info in indexes["files"].values():
-        for cls in file_info["classes"]:
-            source_id = f"class:{file_info['path']}:{cls.get('name', '')}"
-            if source_id not in node_ids:
-                continue
+    def skip_call(reason: str) -> None:
+        stats["callsSkipped"] += 1
+        stats[reason] += 1
+
+    def skip_inheritance(reason: str) -> None:
+        stats["inheritanceSkipped"] += 1
+        stats[reason] += 1
+
+    def skip_dependency(reason: str) -> None:
+        stats["dependsOnSkipped"] += 1
+        stats[reason] += 1
+
+    for file_path in sorted(indexes["files"]):
+        file_info = indexes["files"][file_path]
+        for cls in sorted(
+            file_info["classes"],
+            key=lambda item: (item["lineRange"][0], item.get("name", "")),
+        ):
             source_kind = cls.get("kind")
             using_namespaces = _cs_using_namespaces_for(file_info, cls.get("namespace", ""), indexes)
             for base_type in cls.get("baseTypes", []) or []:
@@ -1439,12 +1629,16 @@ def link_csharp_deterministic_edges(
                     using_namespaces,
                     indexes,
                 )
-                if status != "resolved" or target is None:
-                    stats["inheritanceSkipped"] += 1
+                if status == "ambiguous":
+                    skip_inheritance("inheritanceTypeAmbiguous")
                     continue
-                target_id = f"class:{target.get('filePath', '')}:{target.get('name', '')}"
-                if target_id not in node_ids:
-                    stats["inheritanceSkipped"] += 1
+                if status != "resolved" or target is None:
+                    skip_inheritance("inheritanceTypeUnresolved")
+                    continue
+                if not _cs_has_unique_class_endpoint(cls, indexes) or not _cs_has_unique_class_endpoint(
+                    target, indexes
+                ):
+                    skip_inheritance("inheritanceEndpointAmbiguous")
                     continue
                 target_kind = target.get("kind")
                 if target_kind == "interface" and source_kind in {"class", "record", "struct"}:
@@ -1454,12 +1648,64 @@ def link_csharp_deterministic_edges(
                 elif source_kind == "interface" and target_kind == "interface":
                     edge_type = "inherits"
                 else:
-                    stats["inheritanceSkipped"] += 1
+                    skip_inheritance("inheritanceKindUnsupported")
                     continue
+                source_id = _cs_ensure_class_endpoint(
+                    assembled, node_ids, existing_edges, cls, stats
+                )
+                target_id = _cs_ensure_class_endpoint(
+                    assembled, node_ids, existing_edges, target, stats
+                )
                 if _cs_add_edge(assembled["edges"], existing_edges, source_id, target_id, edge_type, 0.8):
                     stats["inheritanceAdded"] += 1
 
-        for call in file_info["callGraph"]:
+            for dependency_type in _cs_declared_dependency_types(cls, file_info):
+                stats["declaredDependenciesScanned"] += 1
+                status, target = _cs_resolve_type(
+                    dependency_type,
+                    cls.get("namespace", ""),
+                    using_namespaces,
+                    indexes,
+                )
+                if status == "ambiguous":
+                    skip_dependency("dependsOnTypeAmbiguous")
+                    continue
+                if status != "resolved" or target is None:
+                    skip_dependency("dependsOnTypeUnresolved")
+                    continue
+                if (
+                    cls.get("filePath") == target.get("filePath")
+                    and cls.get("name") == target.get("name")
+                ):
+                    skip_dependency("dependsOnSelfReference")
+                    continue
+                if not _cs_has_unique_class_endpoint(cls, indexes) or not _cs_has_unique_class_endpoint(
+                    target, indexes
+                ):
+                    skip_dependency("dependsOnEndpointAmbiguous")
+                    continue
+                source_id = _cs_ensure_class_endpoint(
+                    assembled, node_ids, existing_edges, cls, stats
+                )
+                target_id = _cs_ensure_class_endpoint(
+                    assembled, node_ids, existing_edges, target, stats
+                )
+                if _cs_add_edge(
+                    assembled["edges"], existing_edges, source_id, target_id, "depends_on", 0.6
+                ):
+                    stats["dependsOnAdded"] += 1
+
+        for call in sorted(
+            file_info["callGraph"],
+            key=lambda item: (
+                item.get("lineNumber", -1)
+                if isinstance(item, dict) and isinstance(item.get("lineNumber"), int)
+                else -1,
+                item.get("callee", "")
+                if isinstance(item, dict) and isinstance(item.get("callee"), str)
+                else "",
+            ),
+        ):
             if not isinstance(call, dict):
                 continue
             callee = call.get("callee")
@@ -1467,17 +1713,32 @@ def link_csharp_deterministic_edges(
             if not isinstance(callee, str) or not isinstance(line_number, int):
                 continue
 
-            caller_fn = _cs_containing_function(file_info["functions"], line_number)
-            caller_cls = _cs_containing_class(file_info["classes"], line_number)
-            if caller_fn is None or caller_cls is None:
-                stats["callsSkipped"] += 1
+            caller_functions = [
+                fn for fn in file_info["functions"]
+                if fn["lineRange"][0] <= line_number <= fn["lineRange"][1]
+            ]
+            if not caller_functions:
+                skip_call("callsNoContainingFunction")
                 continue
-            caller_id = f"function:{file_info['path']}:{caller_fn.get('name', '')}"
-            if (
-                caller_id not in node_ids
-                or file_info["functionNameCounts"].get(caller_fn.get("name", ""), 0) != 1
-            ):
-                stats["callsSkipped"] += 1
+            if len(caller_functions) != 1:
+                skip_call("callsAmbiguousContainingFunction")
+                continue
+            caller_fn = caller_functions[0]
+
+            caller_classes = [
+                cls for cls in file_info["classes"]
+                if cls["lineRange"][0] <= line_number <= cls["lineRange"][1]
+            ]
+            if not caller_classes:
+                skip_call("callsNoContainingClass")
+                continue
+            if len(caller_classes) != 1:
+                skip_call("callsAmbiguousContainingClass")
+                continue
+            caller_cls = caller_classes[0]
+
+            if file_info["functionNameCounts"].get(caller_fn.get("name", ""), 0) != 1:
+                skip_call("callsAmbiguousCallerId")
                 continue
             using_namespaces = _cs_using_namespaces_for(file_info, caller_cls.get("namespace", ""), indexes)
 
@@ -1501,7 +1762,7 @@ def link_csharp_deterministic_edges(
                             receiver_type = field.get("type")
                             break
                 if receiver_type is None:
-                    stats["callsSkipped"] += 1
+                    skip_call("callsNoReceiverType")
                     continue
 
                 stats["receiverTypesFound"] += 1
@@ -1511,15 +1772,41 @@ def link_csharp_deterministic_edges(
                     using_namespaces,
                     indexes,
                 )
+                if status == "ambiguous":
+                    skip_call("callsReceiverTypeAmbiguous")
+                    continue
                 if status != "resolved" or target_class is None:
-                    stats["callsSkipped"] += 1
+                    skip_call("callsReceiverTypeUnresolved")
                     continue
                 stats["receiverTypesResolved"] += 1
-                target_id = _cs_target_method_function(target_class, method_name, indexes, node_ids)
-                if target_id is None:
-                    stats["callsSkipped"] += 1
+                target_status, target_fn = _cs_target_method_function(
+                    target_class, method_name, indexes
+                )
+                if target_status == "ambiguous":
+                    skip_call("callsTargetMethodAmbiguous")
+                    continue
+                if target_status != "resolved" or target_fn is None:
+                    skip_call("callsTargetMethodMissing")
                     continue
                 stats["targetMethodsResolved"] += 1
+                caller_id = _cs_ensure_function_endpoint(
+                    assembled,
+                    node_ids,
+                    existing_edges,
+                    caller_fn,
+                    caller_cls,
+                    file_info["path"],
+                    stats,
+                )
+                target_id = _cs_ensure_function_endpoint(
+                    assembled,
+                    node_ids,
+                    existing_edges,
+                    target_fn,
+                    target_class,
+                    target_class.get("filePath", ""),
+                    stats,
+                )
                 if _cs_add_edge(assembled["edges"], existing_edges, caller_id, target_id, "calls", 0.8):
                     stats["callsAdded"] += 1
                 continue
@@ -1530,19 +1817,38 @@ def link_csharp_deterministic_edges(
                     if fn.get("name") == callee
                     and caller_cls["lineRange"][0] <= fn["lineRange"][0] <= caller_cls["lineRange"][1]
                 ]
-                target_id = f"function:{file_info['path']}:{callee}"
+                if not containing_methods:
+                    skip_call("callsTargetMethodMissing")
+                    continue
                 if (
-                    len(containing_methods) == 1
-                    and target_id in node_ids
-                    and file_info["functionNameCounts"].get(callee, 0) == 1
+                    len(containing_methods) != 1
+                    or file_info["functionNameCounts"].get(callee, 0) != 1
                 ):
-                    if _cs_add_edge(assembled["edges"], existing_edges, caller_id, target_id, "calls", 0.8):
-                        stats["callsAdded"] += 1
-                else:
-                    stats["callsSkipped"] += 1
+                    skip_call("callsTargetMethodAmbiguous")
+                    continue
+                caller_id = _cs_ensure_function_endpoint(
+                    assembled,
+                    node_ids,
+                    existing_edges,
+                    caller_fn,
+                    caller_cls,
+                    file_info["path"],
+                    stats,
+                )
+                target_id = _cs_ensure_function_endpoint(
+                    assembled,
+                    node_ids,
+                    existing_edges,
+                    containing_methods[0],
+                    caller_cls,
+                    file_info["path"],
+                    stats,
+                )
+                if _cs_add_edge(assembled["edges"], existing_edges, caller_id, target_id, "calls", 0.8):
+                    stats["callsAdded"] += 1
                 continue
 
-            stats["callsSkipped"] += 1
+            skip_call("callsUnsupportedCallee")
 
     lines = [
         f"  C# files scanned: {stats['filesScanned']}",
@@ -1551,9 +1857,68 @@ def link_csharp_deterministic_edges(
         f"  receiver types uniquely resolved: {stats['receiverTypesResolved']}",
         f"  target methods uniquely resolved: {stats['targetMethodsResolved']}",
         f"  calls added: {stats['callsAdded']}",
+        f"  calls skipped: {stats['callsSkipped']}",
         f"  base types scanned: {stats['baseTypesScanned']}",
         f"  implements/inherits added: {stats['inheritanceAdded']}",
+        f"  implements/inherits skipped: {stats['inheritanceSkipped']}",
+        f"  constructor/field dependencies scanned: {stats['declaredDependenciesScanned']}",
+        f"  class-level depends_on added: {stats['dependsOnAdded']}",
+        f"  class-level depends_on skipped: {stats['dependsOnSkipped']}",
+        (
+            "  endpoint nodes synthesized: "
+            f"{stats['classNodesSynthesized']} class, "
+            f"{stats['functionNodesSynthesized']} function"
+        ),
     ]
+    call_skip_reasons = [
+        ("no containing function", "callsNoContainingFunction"),
+        ("ambiguous containing function", "callsAmbiguousContainingFunction"),
+        ("no containing class", "callsNoContainingClass"),
+        ("ambiguous containing class", "callsAmbiguousContainingClass"),
+        ("ambiguous caller ID", "callsAmbiguousCallerId"),
+        ("no receiver type", "callsNoReceiverType"),
+        ("unresolved receiver type", "callsReceiverTypeUnresolved"),
+        ("ambiguous receiver type", "callsReceiverTypeAmbiguous"),
+        ("missing target method", "callsTargetMethodMissing"),
+        ("ambiguous target method", "callsTargetMethodAmbiguous"),
+        ("unsupported callee", "callsUnsupportedCallee"),
+    ]
+    call_parts = [f"{label}: {stats[key]}" for label, key in call_skip_reasons if stats[key]]
+    if call_parts:
+        lines.append(f"  call skip reasons: {', '.join(call_parts)}")
+
+    inheritance_skip_reasons = [
+        ("unresolved type", "inheritanceTypeUnresolved"),
+        ("ambiguous type", "inheritanceTypeAmbiguous"),
+        ("ambiguous endpoint ID", "inheritanceEndpointAmbiguous"),
+        ("unsupported kind", "inheritanceKindUnsupported"),
+    ]
+    inheritance_parts = [
+        f"{label}: {stats[key]}"
+        for label, key in inheritance_skip_reasons
+        if stats[key]
+    ]
+    if inheritance_parts:
+        lines.append(f"  inheritance skip reasons: {', '.join(inheritance_parts)}")
+
+    dependency_skip_reasons = [
+        ("unresolved type", "dependsOnTypeUnresolved"),
+        ("ambiguous type", "dependsOnTypeAmbiguous"),
+        ("ambiguous endpoint ID", "dependsOnEndpointAmbiguous"),
+        ("self reference", "dependsOnSelfReference"),
+    ]
+    dependency_parts = [
+        f"{label}: {stats[key]}"
+        for label, key in dependency_skip_reasons
+        if stats[key]
+    ]
+    if dependency_parts:
+        lines.append(f"  depends_on skip reasons: {', '.join(dependency_parts)}")
+    if stats["synthesizedEndpointsMissingFileNode"]:
+        lines.append(
+            "  synthesized endpoints without file nodes: "
+            f"{stats['synthesizedEndpointsMissingFileNode']}"
+        )
     return stats, warnings + lines
 
 


### PR DESCRIPTION
## Summary

Fixes missing C# cross-file dependencies caused by treating `using Namespace;` as a file path, preserving declared type metadata and resolving only uniquely evidenced types into the existing `importMap`. It also deterministically links unambiguous C# calls, `implements`, and `inherits` relationships while preserving existing LLM edges, graph schemas, and non-C# behavior.

## Linked issue(s)

Closes #645
Refs #635
Refs #580

## How I tested this

Ran `/understand --full` on a repository containing 516 C# files.

C# `importMap` dependencies increased from 0 to 367. In the resulting graph, `imports` edges increased from 63 to 430, `calls` from 28 to 342, `implements` from 56 to 76, and `inherits` from 0 to 26.

Verified that the resulting graph had no dangling, self-referential, or duplicate edges, and that ambiguous types, overloads, inherited methods, extension methods, and same-named methods in other classes were not incorrectly linked.

Member-call linking remains intentionally conservative: unresolved or ambiguous calls are skipped rather than guessed.

- [x] `pnpm lint`
- [x] `pnpm --filter @understand-anything/core test`
- [x] `pnpm test`
- [x] Manual smoke test (described above)

Additional test results:

- Core Vitest: 981/981 passed
- Root Vitest: 516 passed, 4 skipped
- Python merge tests: 92/92 passed
- Import-map and structure-outcome tests: 137/137 passed

## Versioning

- [ ] Version bumped in all five manifests, OR
- [ ] N/A - internal/docs-only change

Version bump is pending. The PR template says five manifests, but the current `CLAUDE.md` requires all six version manifests to remain synchronized.