### PR TITLE
Make domain scan depth limit overridable via UA_MAX_FILE_TREE_DEPTH

### DIFF
--- a/understand-anything-plugin/skills/understand-domain/extract-domain-context.py
+++ b/understand-anything-plugin/skills/understand-domain/extract-domain-context.py
@@ -28,7 +28,7 @@ def resolve_ua_dir(root: Path) -> Path:
 
 # ── Configuration ──────────────────────────────────────────────────────────
 
-MAX_FILE_TREE_DEPTH = 6
+MAX_FILE_TREE_DEPTH = int(os.environ.get("UA_MAX_FILE_TREE_DEPTH", "6"))
 MAX_FILES_PER_DIR = 50
 MAX_FILES_TOTAL = 5000
 MAX_SAMPLED_FILES = 40


### PR DESCRIPTION
## Summary

scan_file_tree() accepts max_depth as a keyword, but main() never passes it, so the MAX_FILE_TREE_DEPTH constant is the only reachable value.  I have some legacy java projects where max  the depth is 7-9

## Linked issue(s)

N/A

## How I tested this

Measured on a 193-file Java/Maven repository:

  depth 6  (default):  68 source files,   1 .java file,   2 entry points
  depth 12:           260 source files, 193 .java files, 32 entry points

## Versioning

