### PR TITLE
fix(skills): make incremental auto-update fingerprint checks deterministic

### DIFF
--- a/tests/skill/understand/test_fingerprint_scripts.test.mjs
+++ b/tests/skill/understand/test_fingerprint_scripts.test.mjs
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILL_DIR = resolve(__dirname, '../../../understand-anything-plugin/skills/understand');
+const BUILD_SCRIPT = join(SKILL_DIR, 'build-fingerprints.mjs');
+const CHECK_SCRIPT = join(SKILL_DIR, 'check-fingerprints.mjs');
+const UPDATE_SCRIPT = join(SKILL_DIR, 'update-fingerprints.mjs');
+
+function runNode(script, args) {
+  return spawnSync('node', [script, ...args], { encoding: 'utf-8' });
+}
+
+function writeInput(root, name, data) {
+  const p = join(root, '.ua', 'intermediate', name);
+  writeFileSync(p, JSON.stringify(data));
+  return p;
+}
+
+function readChangeAnalysis(root) {
+  return JSON.parse(
+    readFileSync(join(root, '.ua', 'intermediate', 'change-analysis.json'), 'utf-8'),
+  );
+}
+
+function readStore(root) {
+  return JSON.parse(readFileSync(join(root, '.ua', 'fingerprints.json'), 'utf-8'));
+}
+
+const UTILS_TS =
+  "import { helper } from './helper';\n" +
+  '\n' +
+  'export function formatDate(d: Date): string {\n' +
+  '  const iso = d.toISOString();\n' +
+  '  return iso.slice(0, 10);\n' +
+  '}\n' +
+  '\n' +
+  'export function sanitize(s: string): string {\n' +
+  '  return s.trim().toLowerCase();\n' +
+  '}\n';
+
+const HELPER_TS =
+  'export function helper(x: number): number {\n' +
+  '  return x * 2;\n' +
+  '}\n';
+
+/** Seed a two-file TS project with a fingerprint baseline built by the
+ *  bundled builder — the same pipeline auto-update compares against. */
+function setupBaselinedProject() {
+  const root = mkdtempSync(join(tmpdir(), 'ua-fp-test-'));
+  mkdirSync(join(root, 'src'), { recursive: true });
+  mkdirSync(join(root, '.ua', 'intermediate'), { recursive: true });
+  writeFileSync(join(root, 'src', 'utils.ts'), UTILS_TS);
+  writeFileSync(join(root, 'src', 'helper.ts'), HELPER_TS);
+
+  const input = writeInput(root, 'fp-input.json', {
+    projectRoot: root,
+    sourceFilePaths: ['src/utils.ts', 'src/helper.ts'],
+    gitCommitHash: 'baseline-commit',
+  });
+  const result = runNode(BUILD_SCRIPT, [input]);
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain('Fingerprints baseline: 2 files');
+  return root;
+}
+
+describe('check-fingerprints.mjs', () => {
+  let root;
+
+  beforeEach(() => {
+    root = setupBaselinedProject();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('classifies an unchanged file as NONE and skips', () => {
+    const input = writeInput(root, 'check-input.json', {
+      projectRoot: root,
+      changedFilePaths: ['src/utils.ts'],
+    });
+    const result = runNode(CHECK_SCRIPT, [input]);
+    expect(result.status).toBe(0);
+
+    const analysis = readChangeAnalysis(root);
+    expect(analysis.action).toBe('SKIP');
+    expect(analysis.unchangedFiles).toEqual(['src/utils.ts']);
+  });
+
+  it('classifies an internal-logic-only edit as COSMETIC → SKIP (the zero-token path)', () => {
+    // Reformat formatDate's body without touching any signature/import/export.
+    writeFileSync(
+      join(root, 'src', 'utils.ts'),
+      UTILS_TS.replace(
+        '  const iso = d.toISOString();\n  return iso.slice(0, 10);\n',
+        '  // reformatted internals only\n  const iso = d.toISOString();\n  const day = iso.slice(0, 10);\n  return day;\n',
+      ),
+    );
+
+    const input = writeInput(root, 'check-input.json', {
+      projectRoot: root,
+      changedFilePaths: ['src/utils.ts'],
+    });
+    const result = runNode(CHECK_SCRIPT, [input]);
+    expect(result.status).toBe(0);
+
+    const analysis = readChangeAnalysis(root);
+    expect(analysis.action).toBe('SKIP');
+    expect(analysis.cosmeticOnlyFiles).toEqual(['src/utils.ts']);
+    expect(analysis.structurallyChangedFiles).toEqual([]);
+  });
+
+  it('classifies a new exported function as STRUCTURAL', () => {
+    appendFileSync(
+      join(root, 'src', 'utils.ts'),
+      "\nexport function slugify(s: string): string {\n  return s.replace(/\\s+/g, '-');\n}\n",
+    );
+
+    const input = writeInput(root, 'check-input.json', {
+      projectRoot: root,
+      changedFilePaths: ['src/utils.ts'],
+    });
+    const result = runNode(CHECK_SCRIPT, [input]);
+    expect(result.status).toBe(0);
+
+    const analysis = readChangeAnalysis(root);
+    expect(analysis.structurallyChangedFiles).toEqual(['src/utils.ts']);
+    expect(analysis.filesToReanalyze).toEqual(['src/utils.ts']);
+    const change = analysis.fileChanges.find((c) => c.filePath === 'src/utils.ts');
+    expect(change.changeLevel).toBe('STRUCTURAL');
+    expect(change.details.join(' ')).toContain('slugify');
+  });
+
+  it('classifies new and deleted files as STRUCTURAL', () => {
+    writeFileSync(join(root, 'src', 'extra.ts'), 'export const extra = 1;\n');
+    rmSync(join(root, 'src', 'helper.ts'));
+
+    const input = writeInput(root, 'check-input.json', {
+      projectRoot: root,
+      changedFilePaths: ['src/extra.ts', 'src/helper.ts'],
+    });
+    const result = runNode(CHECK_SCRIPT, [input]);
+    expect(result.status).toBe(0);
+
+    const analysis = readChangeAnalysis(root);
+    expect(analysis.newFiles).toEqual(['src/extra.ts']);
+    expect(analysis.deletedFiles).toEqual(['src/helper.ts']);
+  });
+
+  it('degrades to all-STRUCTURAL when the baseline is missing (no crash)', () => {
+    rmSync(join(root, '.ua', 'fingerprints.json'));
+
+    const input = writeInput(root, 'check-input.json', {
+      projectRoot: root,
+      changedFilePaths: ['src/utils.ts'],
+    });
+    const result = runNode(CHECK_SCRIPT, [input]);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('fingerprints.json missing or empty');
+
+    const analysis = readChangeAnalysis(root);
+    expect(analysis.baselineMissing).toBe(true);
+    // Without a baseline every changed file is "new" → STRUCTURAL.
+    expect(analysis.newFiles).toEqual(['src/utils.ts']);
+  });
+});
+
+describe('update-fingerprints.mjs', () => {
+  let root;
+
+  beforeEach(() => {
+    root = setupBaselinedProject();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('LOAD-PATCH-SAVEs into store.files and converges the next check to SKIP', () => {
+    appendFileSync(
+      join(root, 'src', 'utils.ts'),
+      "\nexport function slugify(s: string): string {\n  return s.replace(/\\s+/g, '-');\n}\n",
+    );
+    rmSync(join(root, 'src', 'helper.ts'));
+
+    const input = writeInput(root, 'update-input.json', {
+      projectRoot: root,
+      changedFilePaths: ['src/utils.ts', 'src/helper.ts'],
+      gitCommitHash: 'next-commit',
+    });
+    const result = runNode(UPDATE_SCRIPT, [input]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('patched 1, removed 1');
+
+    // The patch must land inside store.files (the FingerprintStore shape),
+    // preserving the envelope — not as top-level keys next to it.
+    const store = readStore(root);
+    expect(store.gitCommitHash).toBe('next-commit');
+    expect(Object.keys(store.files)).toEqual(['src/utils.ts']);
+    expect(store.files['src/utils.ts'].functions.map((f) => f.name)).toContain('slugify');
+
+    // Re-checking the same paths now finds nothing new — no permanent
+    // STRUCTURAL escalation (issue #152 regression guard).
+    const checkInput = writeInput(root, 'check-input.json', {
+      projectRoot: root,
+      changedFilePaths: ['src/utils.ts', 'src/helper.ts'],
+    });
+    const check = runNode(CHECK_SCRIPT, [checkInput]);
+    expect(check.status).toBe(0);
+    expect(readChangeAnalysis(root).action).toBe('SKIP');
+  });
+
+  it('refuses to write a partial baseline when the store is missing', () => {
+    rmSync(join(root, '.ua', 'fingerprints.json'));
+
+    const input = writeInput(root, 'update-input.json', {
+      projectRoot: root,
+      changedFilePaths: ['src/utils.ts'],
+      gitCommitHash: 'next-commit',
+    });
+    const result = runNode(UPDATE_SCRIPT, [input]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('refusing to write a partial baseline');
+  });
+});

--- a/understand-anything-plugin/hooks/auto-update-prompt.md
+++ b/understand-anything-plugin/hooks/auto-update-prompt.md
@@ -97,35 +97,31 @@ Incrementally update the knowledge graph using deterministic structural fingerpr
 
 ## Phase 1 — Structural Fingerprint Check (Zero LLM Tokens)
 
-This phase runs a deterministic Node.js script that compares file structures against stored fingerprints. It costs **zero LLM tokens** — only the script execution cost.
+This phase runs the bundled deterministic script that compares file structures against stored fingerprints. It costs **zero LLM tokens** — only the script execution cost.
 
-1. Write and execute a Node.js script (`$UA_DIR/intermediate/fingerprint-check.mjs`):
+**Do NOT hand-write a fingerprint-check script.** The baseline in `fingerprints.json` is produced with tree-sitter (core `fingerprint.ts`); an ad-hoc regex extraction systematically disagrees with it, so cosmetic changes get misclassified as STRUCTURAL and the zero-token path never triggers. The bundled script uses the exact same extraction pipeline as the baseline builder.
 
-```javascript
-// The script should:
-// 1. Read fingerprints.json from the data directory (.ua/fingerprints.json, or .understand-anything/fingerprints.json when that legacy directory is present — resolve UA_DIR the same way as the other scripts)
-// 2. For each changed source file:
-//    a. Read the file content
-//    b. Compute SHA-256 content hash
-//    c. If content hash matches stored hash → NONE (skip)
-//    d. Extract structural elements via regex:
-//       - Functions: match patterns like `function NAME(`, `const NAME = (`, `export function NAME(`
-//       - Classes: match `class NAME`, `export class NAME`
-//       - Imports: match `import ... from '...'`, `import '...'`
-//       - Exports: match `export { ... }`, `export default`, `export function`, `export class`, `export const`
-//    e. Compare extracted elements against stored fingerprint
-//    f. Classify as NONE, COSMETIC, or STRUCTURAL
-// 3. For new files (not in fingerprints.json): classify as STRUCTURAL
-// 4. For deleted files (in fingerprints.json but not on disk): classify as STRUCTURAL
-// 5. Determine overall decision:
-//    - All NONE/COSMETIC → action: "SKIP"
-//    - Some STRUCTURAL, ≤10 files, same directories → action: "PARTIAL_UPDATE"
-//    - New/deleted directories or >10 structural files → action: "ARCHITECTURE_UPDATE"
-//    - >30 structural files or >50% of graph → action: "FULL_UPDATE"
-// 6. Write result to <UA_DIR>/intermediate/change-analysis.json (.ua/, or .understand-anything/ when that legacy directory is present)
-```
+1. Resolve the skill directory from `$PLUGIN_ROOT` (resolved in Phase 0 step 10.3; if that step was skipped because no `.understandignore` exists, resolve `$PLUGIN_ROOT` the same way now):
+   ```bash
+   SKILL_DIR="$PLUGIN_ROOT/skills/understand"
+   ```
 
-The output JSON should have this shape:
+2. Write the input file `$UA_DIR/intermediate/fingerprint-check-input.json`:
+   ```json
+   {
+     "projectRoot": "<absolute $PROJECT_ROOT>",
+     "changedFilePaths": [<the filtered changed-file list from Phase 0 (the `kept` array when step 10 ran, otherwise the step 8 list), as a JSON array of relative paths>]
+   }
+   ```
+
+3. Run the bundled script:
+   ```bash
+   node "$SKILL_DIR/check-fingerprints.mjs" \
+     "$UA_DIR/intermediate/fingerprint-check-input.json"
+   ```
+   It loads `fingerprints.json`, compares each changed file with tree-sitter extraction (content-hash fast path for unchanged files), classifies NONE / COSMETIC / STRUCTURAL, handles new and deleted files, and writes the decision to `$UA_DIR/intermediate/change-analysis.json` via core's `analyzeChanges` + `classifyUpdate`. If the baseline is missing it degrades conservatively (all changed files STRUCTURAL, `baselineMissing: true`).
+
+The output JSON has this shape:
 ```json
 {
   "action": "SKIP | PARTIAL_UPDATE | ARCHITECTURE_UPDATE | FULL_UPDATE",
@@ -136,7 +132,13 @@ The output JSON should have this shape:
   "fileChanges": [
     { "filePath": "src/utils.ts", "changeLevel": "COSMETIC", "details": ["internal logic changed"] },
     { "filePath": "src/new-feature.ts", "changeLevel": "STRUCTURAL", "details": ["new function: handleRequest"] }
-  ]
+  ],
+  "newFiles": ["src/new-feature.ts"],
+  "deletedFiles": [],
+  "structurallyChangedFiles": [],
+  "cosmeticOnlyFiles": ["src/utils.ts"],
+  "unchangedFiles": [],
+  "baselineMissing": false
 }
 ```
 
@@ -246,59 +248,34 @@ Perform lightweight validation (no graph-reviewer agent):
 
 3. **Update fingerprints (LOAD-PATCH-SAVE, not OVERWRITE).**
 
-   The most common failure mode here: writing only the freshly-computed batch entries to `fingerprints.json`, discarding every other file's fingerprint. The next auto-update then sees all those files as new (no stored fingerprint), classifies them as STRUCTURAL, and escalates to FULL_UPDATE permanently (issue #152). The script must LOAD ALL existing entries, PATCH only the re-analyzed ones, and SAVE the full dict back.
+   The most common failure mode here: writing only the freshly-computed batch entries to `fingerprints.json`, discarding every other file's fingerprint. The next auto-update then sees all those files as new (no stored fingerprint), classifies them as STRUCTURAL, and escalates to FULL_UPDATE permanently (issue #152). A second failure mode: patching entries at the top level of the JSON instead of inside the store's `files` map — the real store shape is `{ version, gitCommitHash, generatedAt, files: { <path>: <fingerprint> } }`, so top-level patches are invisible to the next check and every re-analyzed file looks "new" forever.
 
-   Write and execute a Node.js script in this exact ordering:
+   **Do NOT hand-write this script.** Run the bundled one, which loads the full store, patches only the changed paths with the same tree-sitter extraction as the baseline, removes deleted files, and saves the full store back:
 
-   ```javascript
-   import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-   import { createHash } from 'node:crypto';
-   import path from 'node:path';
+   1. Write `$UA_DIR/intermediate/fingerprint-update-input.json`:
+      ```json
+      {
+        "projectRoot": "<absolute $PROJECT_ROOT>",
+        "changedFilePaths": [<`filesToReanalyze` plus `deletedFiles` from change-analysis.json, as a JSON array>],
+        "gitCommitHash": "<current commit hash>"
+      }
+      ```
 
-   const UA_DIR = existsSync(path.join(PROJECT_ROOT, '.understand-anything')) ? '.understand-anything' : '.ua';
-   const fpPath = path.join(PROJECT_ROOT, UA_DIR, 'fingerprints.json');
-   const existedAndNonEmpty = existsSync(fpPath) && readFileSync(fpPath, 'utf-8').trim().length > 0;
+   2. Run it:
+      ```bash
+      node "$SKILL_DIR/update-fingerprints.mjs" \
+        "$UA_DIR/intermediate/fingerprint-update-input.json"
+      ```
 
-   // 1. LOAD ALL existing entries (NEVER skip — preserves un-analyzed files)
-   const all = existedAndNonEmpty
-     ? JSON.parse(readFileSync(fpPath, 'utf-8'))
-     : {};
-   const before = Object.keys(all).length;
+   The script refuses to run when no baseline exists (writing a partial baseline would reproduce issue #152); in that case report that `/understand` must be re-run to re-baseline, and continue with the remaining steps.
 
-   // 2. PATCH (file still exists) or REMOVE (file deleted) for each re-analyzed path.
-   //    `filesToReanalyze` may include paths that were deleted in this commit —
-   //    handle both branches inline rather than expecting a separate deleted list.
-   for (const filePath of filesToReanalyze) {
-     const fullPath = path.join(PROJECT_ROOT, filePath);
-     if (!existsSync(fullPath)) {
-       delete all[filePath];
-       continue;
-     }
-     const content = readFileSync(fullPath, 'utf-8');
-     const contentHash = createHash('sha256').update(content).digest('hex');
-     // Extract functions, classes, imports, exports via the same regex as Phase 1.
-     all[filePath] = { contentHash, functions, classes, imports, exports };
-   }
-
-   // 3. GUARD against silent load failure: if fingerprints.json existed and was
-   //    non-empty but `before` came out as 0, refuse to overwrite — something
-   //    went wrong reading the file and writing now would clobber every entry.
-   if (existedAndNonEmpty && before === 0) {
-     throw new Error('fingerprints.json existed and was non-empty but loaded as {} — refusing to overwrite');
-   }
-
-   // 4. SAVE ALL entries back (full dict — not just the patched subset)
-   writeFileSync(fpPath, JSON.stringify(all, null, 2));
-   console.log(`Fingerprints: ${before} → ${Object.keys(all).length}`);
-   ```
-
-   The `existedAndNonEmpty && before === 0` guard catches the silent-load-failure case before it corrupts the store. If the count shrinks from N to a small number that matches the batch size, the LOAD step was skipped — abort the write rather than persist the wrong dict.
-
-4. Clean up intermediate files:
+4. Clean up intermediate files — **preserving `scan-result.json`**. `/understand` Phase 7 deliberately keeps `scan-result.json` in the intermediate dir so future incremental runs can skip the ~157k-token Phase 1 re-scan (issue #293); deleting the whole directory here silently destroys that optimization on the very next commit. Use the same trash-based move as `/understand` Phase 7 (avoids `rm -rf` on just-created dirs, issue #301):
    ```bash
-   INTERMEDIATE_DIR="$UA_DIR/intermediate"
-   if [ -n "$PROJECT_ROOT" ] && [ -d "$INTERMEDIATE_DIR" ]; then
-     rm -rf "$INTERMEDIATE_DIR"
+   TRASH="$UA_DIR/.trash-$(date +%s)"
+   mkdir -p "$TRASH"
+   INTER="$UA_DIR/intermediate"
+   if [ -d "$INTER" ]; then
+     find "$INTER" -mindepth 1 -maxdepth 1 -not -name 'scan-result.json' -exec mv {} "$TRASH/" \; 2>/dev/null || true
    fi
    ```
 
@@ -315,7 +292,7 @@ Perform lightweight validation (no graph-reviewer agent):
 ## Error Handling
 
 - If the fingerprint check script fails: fall back to treating all changed files as STRUCTURAL (conservative approach).
-- If `fingerprints.json` doesn't exist: treat all changed files as STRUCTURAL and regenerate fingerprints after the update.
+- If `fingerprints.json` doesn't exist: the check script degrades to all-STRUCTURAL on its own (`baselineMissing: true`). Do NOT write a partial baseline from just the changed files — report that `/understand` should be re-run to rebuild the full baseline.
 - If a subagent dispatch fails: retry once. If it fails again, save partial results and report the error.
 - ALWAYS save partial results — a partially updated graph is better than no update.
 
@@ -324,5 +301,5 @@ Perform lightweight validation (no graph-reviewer agent):
 ## Notes
 
 - This skill reuses the same `file-analyzer` and `architecture-analyzer` agent definitions as `/understand` — no separate agent prompts needed.
-- The fingerprint comparison in Phase 1 uses regex-based extraction (not tree-sitter) because it runs as a temporary Node.js script and doesn't need full AST accuracy — just signature-level detection.
+- The fingerprint comparison in Phase 1 (`check-fingerprints.mjs`) and the patch in Phase 3 (`update-fingerprints.mjs`) use the SAME core tree-sitter pipeline as the baseline builder (`build-fingerprints.mjs`). Never substitute regex-based extraction: mixing regex-extracted fingerprints with the tree-sitter baseline misclassifies cosmetic changes as STRUCTURAL and defeats the zero-token path.
 - The authoritative fingerprints stored in `fingerprints.json` are generated by `/understand` Phase 7 using the core `fingerprint.ts` module (which uses tree-sitter for precise extraction).

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -739,6 +739,8 @@ Report to the user: `[Phase 7/7] Saving knowledge graph...`
 
 2. **Generate structural fingerprints baseline.** This creates the basis for future automatic incremental updates and **must succeed before `meta.json` is written** — otherwise auto-update sees a fresh commit hash with no fingerprints to compare against, classifies every file as STRUCTURAL, and escalates to `FULL_UPDATE` on every subsequent commit (issue #152).
 
+   **`sourceFilePaths` MUST be the FULL project file inventory, never just the changed files.** On a full run that is the Phase 1 file list. On an **incremental run** (where Phase 1 was skipped), read the preserved `$UA_DIR/intermediate/scan-result.json` and use its complete `files[].path` list. `build-fingerprints.mjs` overwrites `fingerprints.json` wholesale — passing only the changed files writes a partial baseline, so every OTHER file looks "new" (STRUCTURAL) to the next auto-update and the action escalates to `FULL_UPDATE` on every subsequent commit (the same issue #152 spiral, reintroduced). If `scan-result.json` is missing on an incremental run, run the bundled `scan-project.mjs` (deterministic, zero LLM tokens) to regenerate the inventory before building fingerprints.
+
    Write the input file:
    ```bash
    node - "$PROJECT_ROOT" "$UA_DIR/intermediate/fingerprint-input.json" <<'NODE'
@@ -747,7 +749,7 @@ Report to the user: `[Phase 7/7] Saving knowledge graph...`
    const outputPath = process.argv[3];
    const input = {
      projectRoot,
-     sourceFilePaths: [<all source file paths from Phase 1, as JSON array>],
+     sourceFilePaths: [<ALL source file paths — Phase 1 list on a full run, scan-result.json files[].path on an incremental run; never only the changed files>],
      gitCommitHash: "<current commit hash>",
    };
    fs.writeFileSync(outputPath, JSON.stringify(input, null, 2));

--- a/understand-anything-plugin/skills/understand/check-fingerprints.mjs
+++ b/understand-anything-plugin/skills/understand/check-fingerprints.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * check-fingerprints.mjs
+ *
+ * Deterministic incremental change detection for auto-update Phase 1.
+ * Compares the changed files against the stored fingerprint baseline
+ * (fingerprints.json, written by build-fingerprints.mjs) using the SAME
+ * tree-sitter extraction pipeline that built the baseline, then classifies
+ * the update action via core's classifyUpdate().
+ *
+ * Replaces the LLM-written regex fingerprint-check script that
+ * auto-update-prompt.md used to describe. That regex extraction
+ * systematically disagreed with the tree-sitter baseline (different
+ * function/import/export shapes), so changed files were almost never
+ * classified COSMETIC — nearly every commit escalated to STRUCTURAL and
+ * burned LLM tokens the "zero-token" path was designed to avoid.
+ *
+ * Usage:
+ *   node check-fingerprints.mjs <input.json>
+ *
+ * Input JSON:
+ *   {
+ *     projectRoot: string,
+ *     changedFilePaths: string[],   // project-relative, already ignore-filtered
+ *     output?: string               // default: <ua-dir>/intermediate/change-analysis.json
+ *   }
+ *
+ * Output JSON (change-analysis.json):
+ *   {
+ *     action: "SKIP" | "PARTIAL_UPDATE" | "ARCHITECTURE_UPDATE" | "FULL_UPDATE",
+ *     filesToReanalyze: string[],
+ *     rerunArchitecture: boolean,
+ *     rerunTour: boolean,
+ *     reason: string,
+ *     fileChanges: [{ filePath, changeLevel, details }],
+ *     newFiles: string[],
+ *     deletedFiles: string[],
+ *     structurallyChangedFiles: string[],
+ *     cosmeticOnlyFiles: string[],
+ *     unchangedFiles: string[],
+ *     baselineMissing: boolean
+ *   }
+ *
+ * Exit code: 0 on success (including a missing baseline, which degrades to
+ * the conservative all-STRUCTURAL classification); non-zero on error.
+ */
+
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// skills/understand/ -> plugin root is two dirs up
+const pluginRoot = resolve(__dirname, '../..');
+const require = createRequire(resolve(pluginRoot, 'package.json'));
+
+// pathToFileURL() is required for Windows: dynamic import() of a raw
+// "C:\..." path throws ERR_UNSUPPORTED_ESM_URL_SCHEME.
+let core;
+try {
+  core = await import(pathToFileURL(require.resolve('@understand-anything/core')).href);
+} catch {
+  core = await import(pathToFileURL(resolve(pluginRoot, 'packages/core/dist/index.js')).href);
+}
+
+const {
+  TreeSitterPlugin,
+  PluginRegistry,
+  builtinLanguageConfigs,
+  registerAllParsers,
+  analyzeChanges,
+  classifyUpdate,
+  loadFingerprints,
+  loadGraph,
+  resolveUaDir,
+} = core;
+
+const FILE_LEVEL_TYPES = new Set([
+  'file', 'config', 'document', 'service', 'pipeline',
+  'table', 'schema', 'resource', 'endpoint',
+]);
+
+async function main() {
+  const [, , inputPath] = process.argv;
+  if (!inputPath) {
+    process.stderr.write('Usage: node check-fingerprints.mjs <input.json>\n');
+    process.exit(1);
+  }
+
+  const { projectRoot, changedFilePaths, output } = JSON.parse(
+    readFileSync(inputPath, 'utf-8'),
+  );
+  if (!projectRoot || !Array.isArray(changedFilePaths)) {
+    throw new Error(
+      'Invalid input: requires { projectRoot: string, changedFilePaths: string[] }',
+    );
+  }
+
+  // Same registry construction as build-fingerprints.mjs so the comparison
+  // uses the exact extraction pipeline that produced the baseline.
+  const tsConfigs = builtinLanguageConfigs.filter((c) => c.treeSitter);
+  const tsPlugin = new TreeSitterPlugin(tsConfigs);
+  await tsPlugin.init();
+  const registry = new PluginRegistry();
+  registry.register(tsPlugin);
+  registerAllParsers(registry);
+
+  let store = loadFingerprints(projectRoot);
+  const baselineMissing = !store || !store.files || Object.keys(store.files).length === 0;
+  if (baselineMissing) {
+    // Conservative degrade: with no baseline every changed file is "new"
+    // (STRUCTURAL). analyzeChanges against an empty store produces exactly
+    // that, so we just synthesize one instead of special-casing below.
+    process.stderr.write(
+      'Warning: check-fingerprints: fingerprints.json missing or empty — ' +
+      'treating all changed files as STRUCTURAL. Run /understand to rebuild ' +
+      'the baseline.\n',
+    );
+    store = { version: '1.0.0', gitCommitHash: '', generatedAt: '', files: {} };
+  }
+
+  const analysis = analyzeChanges(projectRoot, changedFilePaths, store, registry);
+
+  // Baseline for classifyUpdate: total graph size + known file paths (for
+  // new/removed top-level directory detection).
+  let totalFilesInGraph = Object.keys(store.files).length;
+  let allKnownFiles = Object.keys(store.files);
+  try {
+    const graph = loadGraph(projectRoot, { validate: false });
+    if (graph && Array.isArray(graph.nodes)) {
+      const fileNodes = graph.nodes.filter((n) => FILE_LEVEL_TYPES.has(n.type));
+      if (fileNodes.length > 0) {
+        totalFilesInGraph = fileNodes.length;
+        if (allKnownFiles.length === 0) {
+          allKnownFiles = fileNodes.map((n) => n.filePath).filter(Boolean);
+        }
+      }
+    }
+  } catch {
+    // Graph unreadable — fingerprint-store fallback above is sufficient.
+  }
+
+  const decision = classifyUpdate(analysis, totalFilesInGraph, allKnownFiles);
+
+  const result = {
+    ...decision,
+    fileChanges: analysis.fileChanges,
+    newFiles: analysis.newFiles,
+    deletedFiles: analysis.deletedFiles,
+    structurallyChangedFiles: analysis.structurallyChangedFiles,
+    cosmeticOnlyFiles: analysis.cosmeticOnlyFiles,
+    unchangedFiles: analysis.unchangedFiles,
+    baselineMissing,
+  };
+
+  const outPath = output
+    ? resolve(output)
+    : join(resolveUaDir(projectRoot), 'intermediate', 'change-analysis.json');
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(result, null, 2), 'utf-8');
+
+  process.stdout.write(
+    `Change analysis: action=${decision.action} ` +
+    `(${changedFilePaths.length} checked, ` +
+    `${analysis.structurallyChangedFiles.length} structural, ` +
+    `${analysis.cosmeticOnlyFiles.length} cosmetic, ` +
+    `${analysis.newFiles.length} new, ${analysis.deletedFiles.length} deleted) ` +
+    `— ${outPath}\n`,
+  );
+}
+
+await main();

--- a/understand-anything-plugin/skills/understand/compute-batches.mjs
+++ b/understand-anything-plugin/skills/understand/compute-batches.mjs
@@ -598,10 +598,10 @@ async function main() {
     return { batchIndex: b.batchIndex, files: analysisFiles, batchImportData, neighborMap };
   };
 
-  const batches = mergedBareBatches.map(b => buildBatchPayload(b));
-
-  let finalBatches = batches;
-  if (changedFiles) {
+  let finalBatches;
+  if (!changedFiles) {
+    finalBatches = mergedBareBatches.map(b => buildBatchPayload(b));
+  } else {
     finalBatches = mergedBareBatches
       .map(b => {
         const changedBatchFiles = b.files.filter(f =>

--- a/understand-anything-plugin/skills/understand/update-fingerprints.mjs
+++ b/understand-anything-plugin/skills/understand/update-fingerprints.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * update-fingerprints.mjs
+ *
+ * LOAD-PATCH-SAVE fingerprint update for auto-update Phase 3. Loads the FULL
+ * fingerprint store, re-fingerprints only the given changed paths with the
+ * same tree-sitter pipeline as build-fingerprints.mjs, removes deleted files,
+ * and saves the full store back.
+ *
+ * Replaces the LLM-written patch script that auto-update-prompt.md used to
+ * embed. That script treated fingerprints.json as a flat
+ * { path: fingerprint } dict, but the real store shape (see core
+ * fingerprint.ts FingerprintStore) nests per-file entries under `files`.
+ * Patched entries therefore landed OUTSIDE `files`, so every re-analyzed
+ * file looked "new" (no stored fingerprint) on the next auto-update and was
+ * re-classified STRUCTURAL forever — the exact permanent-escalation spiral
+ * of issue #152, burning tokens on every subsequent commit.
+ *
+ * Usage:
+ *   node update-fingerprints.mjs <input.json>
+ *
+ * Input JSON:
+ *   {
+ *     projectRoot: string,
+ *     changedFilePaths: string[],  // re-analyzed + deleted paths, project-relative
+ *     gitCommitHash: string
+ *   }
+ *
+ * Exit code: 0 on success. Non-zero when no baseline exists — a partial
+ * baseline must never be written (it would reproduce issue #152); the
+ * caller should re-baseline via /understand instead.
+ */
+
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { existsSync, readFileSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// skills/understand/ -> plugin root is two dirs up
+const pluginRoot = resolve(__dirname, '../..');
+const require = createRequire(resolve(pluginRoot, 'package.json'));
+
+// pathToFileURL() is required for Windows: dynamic import() of a raw
+// "C:\..." path throws ERR_UNSUPPORTED_ESM_URL_SCHEME.
+let core;
+try {
+  core = await import(pathToFileURL(require.resolve('@understand-anything/core')).href);
+} catch {
+  core = await import(pathToFileURL(resolve(pluginRoot, 'packages/core/dist/index.js')).href);
+}
+
+const {
+  TreeSitterPlugin,
+  PluginRegistry,
+  builtinLanguageConfigs,
+  registerAllParsers,
+  extractFileFingerprint,
+  contentHash,
+  loadFingerprints,
+  saveFingerprints,
+} = core;
+
+async function main() {
+  const [, , inputPath] = process.argv;
+  if (!inputPath) {
+    process.stderr.write('Usage: node update-fingerprints.mjs <input.json>\n');
+    process.exit(1);
+  }
+
+  const { projectRoot, changedFilePaths, gitCommitHash } = JSON.parse(
+    readFileSync(inputPath, 'utf-8'),
+  );
+  if (!projectRoot || !Array.isArray(changedFilePaths) || typeof gitCommitHash !== 'string') {
+    throw new Error(
+      'Invalid input: requires { projectRoot: string, changedFilePaths: string[], gitCommitHash: string }',
+    );
+  }
+
+  // 1. LOAD the full existing store. Refuse to proceed without one — writing
+  //    a store containing only the changed files would clobber the baseline
+  //    and force STRUCTURAL/FULL_UPDATE on every later commit (issue #152).
+  const store = loadFingerprints(projectRoot);
+  if (!store || !store.files || Object.keys(store.files).length === 0) {
+    process.stderr.write(
+      'Error: update-fingerprints: fingerprints.json missing, unreadable, or empty — ' +
+      'refusing to write a partial baseline. Run /understand to re-baseline.\n',
+    );
+    process.exit(1);
+  }
+  const before = Object.keys(store.files).length;
+
+  // Same registry construction as build-fingerprints.mjs.
+  const tsConfigs = builtinLanguageConfigs.filter((c) => c.treeSitter);
+  const tsPlugin = new TreeSitterPlugin(tsConfigs);
+  await tsPlugin.init();
+  const registry = new PluginRegistry();
+  registry.register(tsPlugin);
+  registerAllParsers(registry);
+
+  // 2. PATCH (file still exists) or REMOVE (file deleted) each changed path.
+  let patched = 0;
+  let removed = 0;
+  for (const filePath of changedFilePaths) {
+    const absolutePath = join(projectRoot, filePath);
+    if (!existsSync(absolutePath)) {
+      if (filePath in store.files) {
+        delete store.files[filePath];
+        removed++;
+      }
+      continue;
+    }
+    const content = readFileSync(absolutePath, 'utf-8');
+    const analysis = registry.analyzeFile(filePath, content);
+    store.files[filePath] = analysis
+      ? extractFileFingerprint(filePath, content, analysis)
+      : {
+          // No tree-sitter support: content hash only (conservative) —
+          // mirrors buildFingerprintStore's fallback.
+          filePath,
+          contentHash: contentHash(content),
+          functions: [],
+          classes: [],
+          imports: [],
+          exports: [],
+          totalLines: content.split('\n').length,
+          hasStructuralAnalysis: false,
+        };
+    patched++;
+  }
+
+  // 3. SAVE the FULL store back (never just the patched subset).
+  store.gitCommitHash = gitCommitHash;
+  store.generatedAt = new Date().toISOString();
+  saveFingerprints(projectRoot, store);
+
+  process.stdout.write(
+    `Fingerprints: ${before} → ${Object.keys(store.files).length} files ` +
+    `(patched ${patched}, removed ${removed})\n`,
+  );
+}
+
+await main();


### PR DESCRIPTION
## Problem

The auto-update "zero-token" path (the whole point of the fingerprint system) almost never triggered, so nearly every commit with `autoUpdate: true` escalated to a paid LLM re-analysis:

1. **Regex check vs tree-sitter baseline.** `auto-update-prompt.md` Phase 1 had the session hand-write a regex-based fingerprint-check script each run, and compare its output against the baseline that `build-fingerprints.mjs` produced with the core tree-sitter pipeline. The two extractions systematically disagree (different function/import/export shapes), so cosmetic-only edits were misclassified as `STRUCTURAL` and `SKIP` was effectively unreachable.

2. **Fingerprint patches landed outside `files`.** The Phase 3 patch snippet treated `fingerprints.json` as a flat `{ path: fingerprint }` dict, but the real `FingerprintStore` nests entries under `files` (`{ version, gitCommitHash, generatedAt, files }`). Patches were written next to `files`, not inside it, so every re-analyzed file looked "new" (`STRUCTURAL`) again on the next commit — the permanent-escalation spiral of #152, reintroduced.

3. **Cleanup deleted `scan-result.json`.** Phase 3 cleanup `rm -rf`'ed the whole intermediate dir, destroying the `scan-result.json` that `/understand` Phase 7 deliberately preserves (#293). The next incremental `/understand` run then has to re-pay the ~157k-token Phase 1 re-scan.

4. **Partial-baseline hazard on incremental runs.** SKILL.md Phase 7 says to rebuild fingerprints from "all source file paths from Phase 1", but incremental runs skip Phase 1 — following the text literally overwrites the full baseline with only the changed files (`saveFingerprints` writes wholesale), which also reproduces the #152 spiral.

## Fix

- **New `skills/understand/check-fingerprints.mjs`** — deterministic change detection via core's `analyzeChanges` + `classifyUpdate`, using the *same* tree-sitter registry as `build-fingerprints.mjs`. Writes `change-analysis.json`; degrades conservatively (all-`STRUCTURAL`, `baselineMissing: true`) when no baseline exists.
- **New `skills/understand/update-fingerprints.mjs`** — LOAD-PATCH-SAVE into `store.files` with deleted-file removal; refuses to write a partial baseline when the store is missing.
- **`hooks/auto-update-prompt.md`** — Phases 1/3 now invoke the bundled scripts instead of instructing the session to hand-write them; cleanup switched to the same `scan-result.json`-preserving trash move as `/understand` Phase 7 (consistent with #301).
- **`skills/understand/SKILL.md`** — Phase 7 now states the fingerprint input must be the full inventory (`scan-result.json` on incremental runs), never just the changed files.
- **`skills/understand/compute-batches.mjs`** — minor: skip building full batch payloads that `--changed-files` mode immediately discards (CPU only, output unchanged).

## Verification

**Unit/regression tests.** New test file `tests/skill/understand/test_fingerprint_scripts.test.mjs` (7 tests): unchanged→`NONE`, internal-logic-only edit→`COSMETIC`→`SKIP`, new exported function→`STRUCTURAL`, new/deleted file handling, missing-baseline degradation, store-shape patching (`store.files`, envelope preserved), and check→update→check convergence back to `SKIP` (regression guard for the #152 spiral). Full suite: 504 passed / 12 skipped; `pnpm lint` clean.

**Field test on real commits (SWE-bench).** Gold patches from 9 SWE-bench instances (flask, sphinx) were replayed as developer commits against tree-sitter baselines built at each `base_commit`:

- Old path (reproduced faithfully from the previous prompt spec, both plausible implementation variants): **9/9 commits misclassified as STRUCTURAL** → paid re-analysis every time.
- New path: **6/9 cosmetic-only commits → SKIP (zero tokens)**; 3/9 correctly flagged structural (new function, import changes) — spot-checked against the actual diffs, no missed updates.

**Real LLM billing measurement.** All dispatches were then executed for real — actual file-analyzer subagents running the bundled tree-sitter extraction and producing validated node/edge output — with per-agent token usage recorded:

| 9 real commits | old path | new path |
|---|---|---|
| analyzer dispatches | 9 (479,308 tok) | 3 (147,837 tok) |
| per-commit script rewriting | 25,164 tok × 9 | 0 (bundled scripts) |
| **total** | **705,784 tok** | **147,837 tok (−79%)** |

For scale: a real median batch (23 files) of a full `/understand` build on sphinx measured **123,576 tok**, extrapolating to ~3.6–4.9M tok for Phase 2 of one full rebuild — the cost the old path's escalation spiral (#152) periodically forced users back into. Absolute numbers vary by model; the dispatch counts (9→3, cosmetic→0) are deterministic.

## Possible follow-up (not in this PR)

`batches.json` carries a top-level `exportsByPath` dump for the whole project that nothing downstream reads (each batch's `neighborMap[].symbols` already carries the needed exports), while the orchestrating session loads `batches.json` into context every run — on incremental runs it dwarfs the actual batch payload. Removing it would save further tokens but changes a tested output contract, so I left it out of this fix.
