### PR TITLE
feat(demo): publish graph data through AWS CDN

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+demo-data/*.json -text

--- a/.github/workflows/publish-demo-data.yml
+++ b/.github/workflows/publish-demo-data.yml
@@ -1,0 +1,271 @@
+name: Publish demo data to AWS
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Exact current main SHA to publish
+        required: true
+        type: string
+      confirmation:
+        description: "Type PUBLISH_UA_DEMO_DATA_PROD:<candidate_sha>"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-understand-anything-demo-data-prod
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-east-1
+  AWS_ROLE_ARN: arn:aws:iam::309965488466:role/egonex-prod-understand-anything-demo-publisher
+  AWS_ACCOUNT_ID: "309965488466"
+  S3_BUCKET: egonex-prod-understand-anything-demo
+  DATA_DIR: demo-data
+  MANIFEST_PATH: demo-data/manifest.json
+  EXPECTED_ORIGIN: https://understand-anything.com
+  CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.DEMO_CLOUDFRONT_DISTRIBUTION_ID }}
+  CLOUDFRONT_DOMAIN: ${{ vars.DEMO_CLOUDFRONT_DOMAIN }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out the dispatched revision
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 1
+
+      - name: Authorize exact current main and validate data
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "candidate_sha must be a lowercase 40-character Git SHA" >&2
+            exit 1
+          fi
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "This workflow may only publish from refs/heads/main" >&2
+            exit 1
+          fi
+
+          local_sha="$(git rev-parse HEAD)"
+          remote_main_sha="$(git ls-remote --exit-code "https://github.com/${GITHUB_REPOSITORY}.git" refs/heads/main | awk '{print $1}')"
+          if ! [[ "$CANDIDATE_SHA" == "$GITHUB_SHA" && "$CANDIDATE_SHA" == "$local_sha" && "$CANDIDATE_SHA" == "$remote_main_sha" ]]; then
+            echo "candidate_sha must equal GITHUB_SHA, checked-out HEAD, and live origin/main" >&2
+            exit 1
+          fi
+          if [[ "$CONFIRMATION" != "PUBLISH_UA_DEMO_DATA_PROD:${CANDIDATE_SHA}" ]]; then
+            echo "confirmation does not match the required production phrase" >&2
+            exit 1
+          fi
+          if [[ ! "$CLOUDFRONT_DISTRIBUTION_ID" =~ ^[A-Z0-9]+$ ]]; then
+            echo "DEMO_CLOUDFRONT_DISTRIBUTION_ID is missing or invalid" >&2
+            exit 1
+          fi
+          if [[ ! "$CLOUDFRONT_DOMAIN" =~ ^d[a-z0-9]+\.cloudfront\.net$ ]]; then
+            echo "DEMO_CLOUDFRONT_DOMAIN must be a CloudFront hostname without a scheme or path" >&2
+            exit 1
+          fi
+
+          node scripts/validate-demo-data.mjs
+
+      - name: Configure dedicated AWS publisher credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+          role-session-name: ua-demo-data-${{ github.run_id }}
+
+      - name: Verify the dedicated AWS targets
+        run: |
+          set -euo pipefail
+
+          actual_account="$(aws sts get-caller-identity --query Account --output text)"
+          if [[ "$actual_account" != "$AWS_ACCOUNT_ID" ]]; then
+            echo "AWS account mismatch" >&2
+            exit 1
+          fi
+
+          bucket_region="$(aws s3api get-bucket-location --bucket "$S3_BUCKET" --query 'LocationConstraint' --output text)"
+          if [[ "$bucket_region" != "None" && "$bucket_region" != "$AWS_REGION" ]]; then
+            echo "S3 bucket region mismatch: ${bucket_region}" >&2
+            exit 1
+          fi
+          bucket_versioning="$(aws s3api get-bucket-versioning --bucket "$S3_BUCKET" --query 'Status' --output text)"
+          if [[ "$bucket_versioning" != "Enabled" ]]; then
+            echo "S3 bucket versioning must be Enabled" >&2
+            exit 1
+          fi
+
+          distribution_json="$(aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID")"
+          actual_domain="$(jq -r '.Distribution.DomainName' <<<"$distribution_json")"
+          distribution_enabled="$(jq -r '.Distribution.DistributionConfig.Enabled' <<<"$distribution_json")"
+          expected_origin="${S3_BUCKET}.s3.${AWS_REGION}.amazonaws.com"
+          origin_quantity="$(jq -r '.Distribution.DistributionConfig.Origins.Quantity' <<<"$distribution_json")"
+          bucket_origin_count="$(jq --arg origin "$expected_origin" '[.Distribution.DistributionConfig.Origins.Items[] | select(.DomainName == $origin and (.OriginAccessControlId | length) > 0)] | length' <<<"$distribution_json")"
+          if [[ "$actual_domain" != "$CLOUDFRONT_DOMAIN" || "$distribution_enabled" != "true" || "$origin_quantity" != "1" || "$bucket_origin_count" != "1" ]]; then
+            echo "CloudFront ID/domain/origin mismatch or distribution is disabled" >&2
+            exit 1
+          fi
+
+      - name: Reconfirm current main before mutation
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          remote_main_sha="$(git ls-remote --exit-code "https://github.com/${GITHUB_REPOSITORY}.git" refs/heads/main | awk '{print $1}')"
+          if ! [[ "$CANDIDATE_SHA" == "$(git rev-parse HEAD)" && "$CANDIDATE_SHA" == "$remote_main_sha" ]]; then
+            echo "main moved after authorization; refusing to upload" >&2
+            exit 1
+          fi
+
+      - name: Upload and read back the three versioned objects
+        id: upload
+        run: |
+          set -euo pipefail
+
+          uploaded_versions="$RUNNER_TEMP/demo-data-uploaded-versions.tsv"
+          : > "$uploaded_versions"
+          source_repository="$(jq -r '.dataset.repository' "$MANIFEST_PATH")"
+          source_commit="$(jq -r '.dataset.commit' "$MANIFEST_PATH")"
+          analyzed_commit="$(jq -r '.dataset.analyzedCommit' "$MANIFEST_PATH")"
+          {
+            echo "### Demo data S3 versions"
+            echo
+            echo '| Object | Version ID | SHA-256 |'
+            echo '| --- | --- | --- |'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          while IFS=$'\t' read -r filename expected_bytes expected_sha content_type cache_control; do
+            put_json="$(aws s3api put-object \
+              --bucket "$S3_BUCKET" \
+              --key "$filename" \
+              --body "$DATA_DIR/$filename" \
+              --content-type "$content_type" \
+              --cache-control "$cache_control" \
+              --server-side-encryption AES256 \
+              --metadata "sha256=$expected_sha,source-repository=$source_repository,source-commit=$source_commit,analyzed-commit=$analyzed_commit")"
+            version_id="$(jq -r '.VersionId // empty' <<<"$put_json")"
+            if [[ -z "$version_id" ]]; then
+              echo "S3 did not return a VersionId for ${filename}" >&2
+              exit 1
+            fi
+            printf '%s\t%s\n' "$filename" "$version_id" >> "$uploaded_versions"
+
+            head_json="$(aws s3api head-object --bucket "$S3_BUCKET" --key "$filename")"
+            actual_bytes="$(jq -r '.ContentLength' <<<"$head_json")"
+            actual_type="$(jq -r '.ContentType' <<<"$head_json")"
+            actual_cache="$(jq -r '.CacheControl' <<<"$head_json")"
+            actual_sse="$(jq -r '.ServerSideEncryption' <<<"$head_json")"
+            metadata_sha="$(jq -r '.Metadata.sha256' <<<"$head_json")"
+            metadata_source="$(jq -r '.Metadata["source-commit"]' <<<"$head_json")"
+            metadata_analyzed="$(jq -r '.Metadata["analyzed-commit"]' <<<"$head_json")"
+            if [[ "$actual_bytes" != "$expected_bytes" || "$actual_type" != "$content_type" || "$actual_cache" != "$cache_control" || "$actual_sse" != "AES256" || "$metadata_sha" != "$expected_sha" || "$metadata_source" != "$source_commit" || "$metadata_analyzed" != "$analyzed_commit" ]]; then
+              echo "S3 metadata verification failed for ${filename}" >&2
+              exit 1
+            fi
+
+            stored_sha="$(aws s3 cp "s3://${S3_BUCKET}/${filename}" - --only-show-errors | sha256sum | awk '{print $1}')"
+            if [[ "$stored_sha" != "$expected_sha" ]]; then
+              echo "S3 content hash mismatch for ${filename}" >&2
+              exit 1
+            fi
+            echo "| \`${filename}\` | \`${version_id}\` | \`${stored_sha}\` |" >> "$GITHUB_STEP_SUMMARY"
+          done < <(jq -r '.files[] | [.filename, .bytes, .sha256, .contentType, .cacheControl] | @tsv' "$MANIFEST_PATH")
+
+      - name: Reconfirm main after mutation
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+        run: |
+          set -euo pipefail
+          remote_main_sha="$(git ls-remote --exit-code "https://github.com/${GITHUB_REPOSITORY}.git" refs/heads/main | awk '{print $1}')"
+          if ! [[ "$CANDIDATE_SHA" == "$(git rev-parse HEAD)" && "$CANDIDATE_SHA" == "$remote_main_sha" ]]; then
+            echo "main moved during upload; triggering version rollback" >&2
+            exit 1
+          fi
+
+      - name: Invalidate the exact CloudFront paths and wait
+        id: invalidate
+        run: |
+          set -euo pipefail
+          invalidation_id="$(aws cloudfront create-invalidation \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths '/knowledge-graph.json' '/domain-graph.json' '/meta.json' \
+            --query 'Invalidation.Id' \
+            --output text)"
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --id "$invalidation_id"
+          echo "invalidation_id=$invalidation_id" >> "$GITHUB_OUTPUT"
+          echo "CloudFront invalidation: \`${invalidation_id}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify public CloudFront bytes, CORS, and metadata
+        run: |
+          set -euo pipefail
+
+          while IFS=$'\t' read -r filename expected_bytes expected_sha content_type cache_control; do
+            headers="$RUNNER_TEMP/${filename}.headers"
+            body="$RUNNER_TEMP/${filename}.body"
+            status="$(curl --silent --show-error --location \
+              --connect-timeout 10 \
+              --max-time 60 \
+              --header "Origin: $EXPECTED_ORIGIN" \
+              --dump-header "$headers" \
+              --output "$body" \
+              --write-out '%{http_code}' \
+              "https://${CLOUDFRONT_DOMAIN}/${filename}")"
+            response_origin="$(awk 'BEGIN { IGNORECASE=1 } /^access-control-allow-origin:/ { sub(/\r$/, ""); value=substr($0, index($0, ":") + 1); sub(/^[ \t]+/, "", value) } END { print value }' "$headers")"
+            response_type="$(awk 'BEGIN { IGNORECASE=1 } /^content-type:/ { sub(/\r$/, ""); value=substr($0, index($0, ":") + 1); sub(/^[ \t]+/, "", value) } END { print value }' "$headers")"
+            response_cache="$(awk 'BEGIN { IGNORECASE=1 } /^cache-control:/ { sub(/\r$/, ""); value=substr($0, index($0, ":") + 1); sub(/^[ \t]+/, "", value) } END { print value }' "$headers")"
+            actual_bytes="$(wc -c < "$body" | tr -d ' ')"
+            actual_sha="$(sha256sum "$body" | awk '{print $1}')"
+
+            if [[ "$status" != "200" || "$response_origin" != "$EXPECTED_ORIGIN" || "$response_type" != "$content_type"* || "$response_cache" != "$cache_control" || "$actual_bytes" != "$expected_bytes" || "$actual_sha" != "$expected_sha" ]]; then
+              echo "CloudFront verification failed for ${filename}" >&2
+              exit 1
+            fi
+            node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))' "$body"
+          done < <(jq -r '.files[] | [.filename, .bytes, .sha256, .contentType, .cacheControl] | @tsv' "$MANIFEST_PATH")
+
+          {
+            echo
+            echo "Published source: \`$(jq -r '.dataset.repository + \"@\" + .dataset.commit' "$MANIFEST_PATH")\`"
+            echo "CloudFront domain: \`${CLOUDFRONT_DOMAIN}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Roll back versions after any publication failure
+        if: ${{ failure() }}
+        run: |
+          set -euo pipefail
+          uploaded_versions="$RUNNER_TEMP/demo-data-uploaded-versions.tsv"
+          if [[ ! -s "$uploaded_versions" ]]; then
+            echo "No uploaded S3 versions to roll back" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          while IFS=$'\t' read -r filename version_id; do
+            aws s3api delete-object \
+              --bucket "$S3_BUCKET" \
+              --key "$filename" \
+              --version-id "$version_id" >/dev/null
+          done < <(tac "$uploaded_versions")
+
+          rollback_invalidation_id="$(aws cloudfront create-invalidation \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths '/knowledge-graph.json' '/domain-graph.json' '/meta.json' \
+            --query 'Invalidation.Id' \
+            --output text)"
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --id "$rollback_invalidation_id"
+          echo "Rolled back newly uploaded S3 versions; rollback invalidation: \`${rollback_invalidation_id}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/demo-data/domain-graph.json
+++ b/demo-data/domain-graph.json
@@ -1,0 +1,856 @@
+{
+  "version": "1.0.0",
+  "project": {
+    "name": "microservices-demo",
+    "languages": ["Go", "C#", "Java", "Python", "Node.js"],
+    "frameworks": ["gRPC", "Gorilla Mux", "ASP.NET", "Flask", "Locust", "Jinja2", "LangChain"],
+    "description": "Online Boutique is a cloud-first microservices e-commerce demo application by Google, featuring 11 microservices that communicate over gRPC. Users can browse products, add them to a cart, and complete purchases with simulated payment processing, shipping, and email confirmation.",
+    "analyzedAt": "2026-04-14T00:00:00Z",
+    "gitCommitHash": "c9857ee54fba10486013f15ba6b31411986f530c"
+  },
+  "nodes": [
+    {
+      "id": "domain:product-catalog",
+      "type": "domain",
+      "name": "Product Catalog",
+      "summary": "Manages the product inventory including listing, searching, and retrieving individual product details. Serves as one of the most depended-upon services, referenced by the frontend, checkout, and recommendation services.",
+      "tags": ["catalog", "products", "inventory"],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entities": ["Product", "ListProductsResponse", "SearchProductsResponse"],
+        "businessRules": ["Products loaded from JSON file or AlloyDB", "Search matches against product names and descriptions", "Returns NOT_FOUND for missing product IDs"],
+        "crossDomainInteractions": ["Checkout service retrieves product prices during order placement", "Recommendation service queries full catalog to generate suggestions", "Frontend fetches product listings and details for display"]
+      }
+    },
+    {
+      "id": "domain:shopping-cart",
+      "type": "domain",
+      "name": "Shopping Cart",
+      "summary": "Handles cart state management for users, supporting adding items, retrieving cart contents, and emptying the cart. Supports multiple storage backends (Redis, Spanner, AlloyDB) via a strategy pattern.",
+      "tags": ["cart", "shopping", "state-management"],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entities": ["Cart", "CartItem", "ICartStore"],
+        "businessRules": ["Cart items identified by user session ID and product ID", "Quantity constraints enforced (1-10 per add)", "Cart emptied after successful checkout"],
+        "crossDomainInteractions": ["Frontend adds/removes items and displays cart", "Checkout service retrieves cart contents during order placement"]
+      }
+    },
+    {
+      "id": "domain:checkout-and-ordering",
+      "type": "domain",
+      "name": "Checkout and Ordering",
+      "summary": "Orchestrates the entire purchase flow by coordinating six downstream microservices: cart retrieval, product lookup, currency conversion, shipping calculation, payment charging, and email confirmation. This is the most complex business logic in the system.",
+      "tags": ["checkout", "ordering", "orchestration", "purchase"],
+      "complexity": "complex",
+      "domainMeta": {
+        "entities": ["Order", "OrderResult", "OrderItem", "PlaceOrderRequest"],
+        "businessRules": ["All downstream calls must succeed for order to complete", "Cart is emptied after successful order", "Shipping cost and item prices converted to user's preferred currency"],
+        "crossDomainInteractions": ["Calls cart service to retrieve items", "Calls product catalog for prices", "Calls currency service for conversion", "Calls shipping service for quote", "Calls payment service to charge", "Calls email service for confirmation"]
+      }
+    },
+    {
+      "id": "domain:payment-processing",
+      "type": "domain",
+      "name": "Payment Processing",
+      "summary": "Provides simulated credit card payment processing. Validates card numbers (VISA/MasterCard only), checks expiration dates, and returns a UUID transaction ID for successful charges.",
+      "tags": ["payment", "credit-card", "transaction"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entities": ["CreditCardInfo", "ChargeRequest", "ChargeResponse"],
+        "businessRules": ["Only VISA and MasterCard numbers accepted", "Card expiration date must be in the future", "Returns UUID transaction ID on success"],
+        "crossDomainInteractions": ["Called by checkout service during order placement"]
+      }
+    },
+    {
+      "id": "domain:shipping",
+      "type": "domain",
+      "name": "Shipping",
+      "summary": "Calculates shipping quotes based on item count and simulates order shipment by generating tracking IDs. Uses a flat-rate pricing model ($8.99 for any non-empty order).",
+      "tags": ["shipping", "logistics", "tracking"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entities": ["ShipOrderRequest", "ShipOrderResponse", "ShippingQuote"],
+        "businessRules": ["Flat $8.99 shipping for any non-zero item count", "$0 shipping for empty orders", "Tracking ID generated from address hash with random components"],
+        "crossDomainInteractions": ["Called by checkout service for shipping cost and shipment", "Called by frontend to display shipping estimate in cart view"]
+      }
+    },
+    {
+      "id": "domain:currency-conversion",
+      "type": "domain",
+      "name": "Currency Conversion",
+      "summary": "Converts monetary amounts between supported currencies using exchange rate data. Normalizes all conversions through EUR as an intermediate currency.",
+      "tags": ["currency", "conversion", "money", "internationalization"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entities": ["Money", "CurrencyConversionRequest", "GetSupportedCurrenciesResponse"],
+        "businessRules": ["All conversions normalize through EUR first", "Supports listing all available currencies", "Proper handling of nanos overflow in money arithmetic"],
+        "crossDomainInteractions": ["Called by frontend to display prices in user's preferred currency", "Called by checkout service during order total calculation"]
+      }
+    },
+    {
+      "id": "domain:email-notifications",
+      "type": "domain",
+      "name": "Email Notifications",
+      "summary": "Sends order confirmation emails using Jinja2 HTML templates. Supports a dummy mode for development that logs confirmation details instead of sending real emails.",
+      "tags": ["email", "notifications", "order-confirmation"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entities": ["SendOrderConfirmationRequest", "OrderResult"],
+        "businessRules": ["Renders order confirmation using Jinja2 templates", "DummyEmailService logs instead of sending in development", "Cloud mail client for production (currently unimplemented)"],
+        "crossDomainInteractions": ["Called by checkout service after successful payment"]
+      }
+    },
+    {
+      "id": "domain:recommendations",
+      "type": "domain",
+      "name": "Recommendations",
+      "summary": "Provides product recommendations by querying the full product catalog, filtering out items the user has already viewed, and returning a random sample of up to 5 alternatives.",
+      "tags": ["recommendations", "personalization", "discovery"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entities": ["ListRecommendationsRequest", "ListRecommendationsResponse"],
+        "businessRules": ["Excludes products the user has already viewed", "Returns up to 5 random product recommendations", "Read-only service that does not modify state"],
+        "crossDomainInteractions": ["Queries product catalog service for full product list", "Called by frontend for home page and product detail page suggestions"]
+      }
+    },
+    {
+      "id": "domain:advertising",
+      "type": "domain",
+      "name": "Advertising",
+      "summary": "Serves contextual advertisements based on product category keys. Maintains an in-memory map of category-to-ad mappings and falls back to random ads when no category match is found.",
+      "tags": ["ads", "advertising", "contextual"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entities": ["Ad", "AdRequest", "AdResponse"],
+        "businessRules": ["Ads matched by product category context keys", "Falls back to random ads if no category match", "Hardcoded ad entries for known product categories"],
+        "crossDomainInteractions": ["Called by frontend to display ads on home and product pages"]
+      }
+    },
+    {
+      "id": "domain:shopping-assistant",
+      "type": "domain",
+      "name": "Shopping Assistant",
+      "summary": "AI-powered shopping assistant implementing a RAG pipeline that uses Gemini vision to analyze room images, performs vector similarity search against product embeddings in AlloyDB, and returns interior design product recommendations.",
+      "tags": ["ai", "chatbot", "gemini", "rag", "assistant"],
+      "complexity": "complex",
+      "domainMeta": {
+        "entities": ["ChatMessage", "ProductEmbedding", "PackagingInfo"],
+        "businessRules": ["Three-step RAG pipeline: image analysis, vector search, response generation", "Uses Gemini vision model for room image analysis", "Vector similarity search on AlloyDB product embeddings"],
+        "crossDomainInteractions": ["Called by frontend chatbot handler", "Queries AlloyDB for product embeddings"]
+      }
+    },
+
+    {
+      "id": "flow:browse-products",
+      "type": "flow",
+      "name": "Browse Products",
+      "summary": "User browses the product catalog on the home page, viewing product listings with prices converted to their preferred currency, along with contextual ads.",
+      "tags": ["browsing", "home-page", "product-listing"],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entryPoint": "GET /",
+        "entryType": "http"
+      }
+    },
+    {
+      "id": "flow:view-product-details",
+      "type": "flow",
+      "name": "View Product Details",
+      "summary": "User views a specific product's detail page including price in preferred currency, product recommendations, contextual ads, and optionally interacts with the AI shopping assistant.",
+      "tags": ["product-detail", "recommendations"],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entryPoint": "GET /product/{id}",
+        "entryType": "http"
+      }
+    },
+    {
+      "id": "flow:manage-cart",
+      "type": "flow",
+      "name": "Manage Shopping Cart",
+      "summary": "User adds products to their cart, views cart contents with resolved product details and shipping estimates, and can empty the cart.",
+      "tags": ["cart", "add-to-cart", "view-cart"],
+      "complexity": "moderate",
+      "domainMeta": {
+        "entryPoint": "POST /cart and GET /cart",
+        "entryType": "http"
+      }
+    },
+    {
+      "id": "flow:checkout-purchase",
+      "type": "flow",
+      "name": "Checkout and Purchase",
+      "summary": "User submits payment and shipping information to complete a purchase. The checkout service orchestrates cart retrieval, price lookup, currency conversion, shipping calculation, payment charging, cart emptying, and email confirmation.",
+      "tags": ["checkout", "purchase", "order", "payment"],
+      "complexity": "complex",
+      "domainMeta": {
+        "entryPoint": "POST /cart/checkout",
+        "entryType": "http"
+      }
+    },
+    {
+      "id": "flow:set-currency",
+      "type": "flow",
+      "name": "Set Currency Preference",
+      "summary": "User selects a preferred display currency which is stored as a cookie and applied to all subsequent price displays across the application.",
+      "tags": ["currency", "preference", "internationalization"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entryPoint": "POST /setCurrency",
+        "entryType": "http"
+      }
+    },
+    {
+      "id": "flow:get-recommendations",
+      "type": "flow",
+      "name": "Get Product Recommendations",
+      "summary": "Recommendation service fetches the full product catalog, excludes already-viewed products, and returns a random sample of up to 5 suggestions displayed on home and product pages.",
+      "tags": ["recommendations", "personalization"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entryPoint": "gRPC ListRecommendations",
+        "entryType": "event"
+      }
+    },
+    {
+      "id": "flow:serve-ads",
+      "type": "flow",
+      "name": "Serve Contextual Ads",
+      "summary": "Ad service receives context keys from the frontend and returns matching advertisements for product categories, falling back to random ads when no match exists.",
+      "tags": ["advertising", "contextual-ads"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entryPoint": "gRPC GetAds",
+        "entryType": "event"
+      }
+    },
+    {
+      "id": "flow:convert-currency",
+      "type": "flow",
+      "name": "Convert Currency",
+      "summary": "Currency service converts monetary amounts between currencies by normalizing through EUR, supporting both individual conversions and listing all supported currencies.",
+      "tags": ["currency", "conversion"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entryPoint": "gRPC Convert / GetSupportedCurrencies",
+        "entryType": "event"
+      }
+    },
+    {
+      "id": "flow:send-order-confirmation",
+      "type": "flow",
+      "name": "Send Order Confirmation Email",
+      "summary": "Email service renders an order confirmation using Jinja2 templates and sends it to the customer (or logs it in development mode).",
+      "tags": ["email", "confirmation", "notification"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entryPoint": "gRPC SendOrderConfirmation",
+        "entryType": "event"
+      }
+    },
+    {
+      "id": "flow:ai-shopping-assistant",
+      "type": "flow",
+      "name": "AI Shopping Assistant Chat",
+      "summary": "User interacts with a chatbot that analyzes room images via Gemini vision, searches product embeddings for matching items, and returns interior design recommendations.",
+      "tags": ["ai", "chatbot", "rag", "gemini"],
+      "complexity": "complex",
+      "domainMeta": {
+        "entryPoint": "POST /chat (frontend) -> gRPC ShoppingAssistant",
+        "entryType": "http"
+      }
+    },
+    {
+      "id": "flow:calculate-shipping",
+      "type": "flow",
+      "name": "Calculate Shipping Quote",
+      "summary": "Shipping service calculates a flat-rate shipping quote based on item count and generates tracking IDs for shipped orders.",
+      "tags": ["shipping", "quote", "tracking"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entryPoint": "gRPC GetQuote / ShipOrder",
+        "entryType": "event"
+      }
+    },
+    {
+      "id": "flow:process-payment",
+      "type": "flow",
+      "name": "Process Payment",
+      "summary": "Payment service validates credit card details (number format, expiration), and returns a transaction ID for the simulated charge.",
+      "tags": ["payment", "credit-card", "validation"],
+      "complexity": "simple",
+      "domainMeta": {
+        "entryPoint": "gRPC Charge",
+        "entryType": "event"
+      }
+    },
+
+    {
+      "id": "step:browse-products:fetch-products",
+      "type": "step",
+      "name": "Fetch Product List",
+      "summary": "Frontend calls ProductCatalogService.ListProducts to retrieve all available products.",
+      "tags": ["catalog", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:browse-products:fetch-currencies",
+      "type": "step",
+      "name": "Fetch Supported Currencies",
+      "summary": "Frontend calls CurrencyService.GetSupportedCurrencies to populate the currency selector dropdown.",
+      "tags": ["currency", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:browse-products:convert-prices",
+      "type": "step",
+      "name": "Convert Product Prices",
+      "summary": "Frontend converts each product price to the user's preferred currency via CurrencyService.Convert.",
+      "tags": ["currency", "conversion"],
+      "complexity": "simple",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:browse-products:fetch-cart-size",
+      "type": "step",
+      "name": "Fetch Cart Item Count",
+      "summary": "Frontend retrieves the user's cart to display the item count badge in the navigation bar.",
+      "tags": ["cart", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:browse-products:fetch-ads",
+      "type": "step",
+      "name": "Fetch Contextual Ads",
+      "summary": "Frontend calls AdService.GetAds to retrieve advertisements displayed on the home page.",
+      "tags": ["ads", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:browse-products:render-home",
+      "type": "step",
+      "name": "Render Home Page",
+      "summary": "Frontend assembles all fetched data and renders the home page HTML template with products, prices, cart count, and ads.",
+      "tags": ["rendering", "template"],
+      "complexity": "simple",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:view-product-details:fetch-product",
+      "type": "step",
+      "name": "Fetch Product by ID",
+      "summary": "Frontend calls ProductCatalogService.GetProduct to retrieve the specific product details.",
+      "tags": ["catalog", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:view-product-details:convert-price",
+      "type": "step",
+      "name": "Convert Product Price",
+      "summary": "Frontend converts the product price to the user's preferred currency.",
+      "tags": ["currency", "conversion"],
+      "complexity": "simple",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:view-product-details:fetch-recommendations",
+      "type": "step",
+      "name": "Fetch Recommendations",
+      "summary": "Frontend calls RecommendationService.ListRecommendations to get suggested products, then resolves each to full product details.",
+      "tags": ["recommendations", "grpc"],
+      "complexity": "moderate",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:view-product-details:fetch-ads",
+      "type": "step",
+      "name": "Fetch Product Ads",
+      "summary": "Frontend calls AdService.GetAds with the product's category keys for contextual advertisements.",
+      "tags": ["ads", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:view-product-details:render-page",
+      "type": "step",
+      "name": "Render Product Detail Page",
+      "summary": "Frontend assembles product info, converted price, recommendations, and ads into the product detail template.",
+      "tags": ["rendering", "template"],
+      "complexity": "simple",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:manage-cart:validate-input",
+      "type": "step",
+      "name": "Validate Add-to-Cart Input",
+      "summary": "Frontend validates the product ID and quantity (1-10 range) from the add-to-cart form submission.",
+      "tags": ["validation", "input"],
+      "complexity": "simple",
+      "filePath": "src/frontend/validator/validator.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:manage-cart:add-item",
+      "type": "step",
+      "name": "Add Item to Cart",
+      "summary": "Frontend calls CartService.AddItem with the user's session ID, product ID, and quantity.",
+      "tags": ["cart", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:manage-cart:retrieve-cart",
+      "type": "step",
+      "name": "Retrieve Cart Contents",
+      "summary": "Frontend calls CartService.GetCart to load all items in the user's cart with their quantities.",
+      "tags": ["cart", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:manage-cart:resolve-product-details",
+      "type": "step",
+      "name": "Resolve Product Details for Cart Items",
+      "summary": "Frontend calls ProductCatalogService.GetProduct for each cart item to get names, descriptions, and prices.",
+      "tags": ["catalog", "grpc"],
+      "complexity": "moderate",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:manage-cart:convert-cart-prices",
+      "type": "step",
+      "name": "Convert Cart Prices",
+      "summary": "Frontend converts each cart item's price and the total to the user's preferred currency.",
+      "tags": ["currency", "conversion"],
+      "complexity": "simple",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:manage-cart:get-shipping-estimate",
+      "type": "step",
+      "name": "Get Shipping Estimate",
+      "summary": "Frontend calls ShippingService.GetQuote to display the estimated shipping cost in the cart view.",
+      "tags": ["shipping", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:manage-cart:render-cart",
+      "type": "step",
+      "name": "Render Cart View",
+      "summary": "Frontend renders the cart page with item details, converted prices, shipping estimate, and order total.",
+      "tags": ["rendering", "template"],
+      "complexity": "simple",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:checkout-purchase:validate-checkout-input",
+      "type": "step",
+      "name": "Validate Checkout Input",
+      "summary": "Frontend validates email, shipping address, and credit card fields from the checkout form.",
+      "tags": ["validation", "input"],
+      "complexity": "simple",
+      "filePath": "src/frontend/validator/validator.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:checkout-purchase:retrieve-cart-items",
+      "type": "step",
+      "name": "Retrieve Cart Items",
+      "summary": "Checkout service calls CartService.GetCart to get all items in the user's cart.",
+      "tags": ["cart", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:checkout-purchase:lookup-product-prices",
+      "type": "step",
+      "name": "Look Up Product Prices",
+      "summary": "Checkout service calls ProductCatalogService.GetProduct for each cart item to get current prices.",
+      "tags": ["catalog", "grpc"],
+      "complexity": "moderate",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:checkout-purchase:get-shipping-quote",
+      "type": "step",
+      "name": "Get Shipping Quote",
+      "summary": "Checkout service calls ShippingService.GetQuote to calculate the shipping cost for the order.",
+      "tags": ["shipping", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:checkout-purchase:convert-currency",
+      "type": "step",
+      "name": "Convert to User Currency",
+      "summary": "Checkout service calls CurrencyService.Convert to convert all amounts to the user's preferred currency.",
+      "tags": ["currency", "conversion", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:checkout-purchase:charge-payment",
+      "type": "step",
+      "name": "Charge Credit Card",
+      "summary": "Checkout service calls PaymentService.Charge with the total amount and credit card details.",
+      "tags": ["payment", "grpc"],
+      "complexity": "moderate",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:checkout-purchase:ship-order",
+      "type": "step",
+      "name": "Ship Order",
+      "summary": "Checkout service calls ShippingService.ShipOrder to get a tracking ID for the order.",
+      "tags": ["shipping", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:checkout-purchase:empty-cart",
+      "type": "step",
+      "name": "Empty Cart After Purchase",
+      "summary": "Checkout service calls CartService.EmptyCart to clear the user's cart after successful payment.",
+      "tags": ["cart", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:checkout-purchase:send-confirmation",
+      "type": "step",
+      "name": "Send Order Confirmation",
+      "summary": "Checkout service calls EmailService.SendOrderConfirmation with the order details and customer email.",
+      "tags": ["email", "notification", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:checkout-purchase:render-confirmation",
+      "type": "step",
+      "name": "Render Order Confirmation Page",
+      "summary": "Frontend renders the order confirmation page with order ID, tracking ID, and order summary.",
+      "tags": ["rendering", "template"],
+      "complexity": "simple",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:set-currency:select-currency",
+      "type": "step",
+      "name": "Select Currency",
+      "summary": "User selects a currency from the dropdown populated by GetSupportedCurrencies.",
+      "tags": ["currency", "input"],
+      "complexity": "simple",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:set-currency:store-preference",
+      "type": "step",
+      "name": "Store Currency Cookie",
+      "summary": "Frontend sets a cookie with the selected currency code and redirects back to the referring page.",
+      "tags": ["currency", "cookie", "preference"],
+      "complexity": "simple",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:get-recommendations:fetch-catalog",
+      "type": "step",
+      "name": "Fetch Full Product Catalog",
+      "summary": "Recommendation service calls ProductCatalogService.ListProducts to get all available products.",
+      "tags": ["catalog", "grpc"],
+      "complexity": "simple",
+      "filePath": "src/recommendationservice/recommendation_server.py",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:get-recommendations:filter-viewed",
+      "type": "step",
+      "name": "Filter Already-Viewed Products",
+      "summary": "Recommendation service removes products the user has already viewed from the candidate set.",
+      "tags": ["filtering", "personalization"],
+      "complexity": "simple",
+      "filePath": "src/recommendationservice/recommendation_server.py",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:get-recommendations:sample-results",
+      "type": "step",
+      "name": "Sample Random Recommendations",
+      "summary": "Recommendation service randomly selects up to 5 products from the filtered set as recommendations.",
+      "tags": ["randomization", "selection"],
+      "complexity": "simple",
+      "filePath": "src/recommendationservice/recommendation_server.py",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:serve-ads:lookup-by-category",
+      "type": "step",
+      "name": "Look Up Ads by Category",
+      "summary": "Ad service searches its in-memory map for ads matching the provided context category keys.",
+      "tags": ["ads", "lookup"],
+      "complexity": "simple",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdService.java",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:serve-ads:fallback-random",
+      "type": "step",
+      "name": "Fallback to Random Ads",
+      "summary": "If no category match is found, the ad service returns randomly selected ads from the full pool.",
+      "tags": ["ads", "fallback", "random"],
+      "complexity": "simple",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdService.java",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:convert-currency:normalize-to-eur",
+      "type": "step",
+      "name": "Normalize to EUR",
+      "summary": "Currency service converts the source amount to EUR using the source currency's exchange rate.",
+      "tags": ["currency", "normalization"],
+      "complexity": "simple",
+      "filePath": "src/currencyservice/server.js",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:convert-currency:convert-to-target",
+      "type": "step",
+      "name": "Convert EUR to Target Currency",
+      "summary": "Currency service applies the target currency's exchange rate to the EUR-normalized amount.",
+      "tags": ["currency", "conversion"],
+      "complexity": "simple",
+      "filePath": "src/currencyservice/server.js",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:send-order-confirmation:render-template",
+      "type": "step",
+      "name": "Render Email Template",
+      "summary": "Email service renders the order confirmation HTML using Jinja2 templates with order details.",
+      "tags": ["email", "template", "jinja2"],
+      "complexity": "simple",
+      "filePath": "src/emailservice/email_server.py",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:send-order-confirmation:send-email",
+      "type": "step",
+      "name": "Send or Log Confirmation",
+      "summary": "Email service sends the rendered email via cloud mail client (production) or logs it (development).",
+      "tags": ["email", "send", "logging"],
+      "complexity": "simple",
+      "filePath": "src/emailservice/email_server.py",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:ai-shopping-assistant:analyze-room-image",
+      "type": "step",
+      "name": "Analyze Room Image with Gemini",
+      "summary": "Shopping assistant sends the user's room image to the Gemini vision model for interior design analysis.",
+      "tags": ["ai", "gemini", "vision", "image-analysis"],
+      "complexity": "complex",
+      "filePath": "src/shoppingassistantservice/shoppingassistantservice.py",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:ai-shopping-assistant:vector-search",
+      "type": "step",
+      "name": "Search Product Embeddings",
+      "summary": "Shopping assistant performs vector similarity search against product embeddings stored in AlloyDB.",
+      "tags": ["vector-search", "embeddings", "alloydb"],
+      "complexity": "complex",
+      "filePath": "src/shoppingassistantservice/shoppingassistantservice.py",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:ai-shopping-assistant:generate-response",
+      "type": "step",
+      "name": "Generate Recommendation Response",
+      "summary": "Shopping assistant uses Gemini to generate a natural language response with product recommendations based on the analysis and search results.",
+      "tags": ["ai", "gemini", "response-generation"],
+      "complexity": "moderate",
+      "filePath": "src/shoppingassistantservice/shoppingassistantservice.py",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:calculate-shipping:count-items",
+      "type": "step",
+      "name": "Count Total Items",
+      "summary": "Shipping service counts the total number of items in the shipping request.",
+      "tags": ["shipping", "calculation"],
+      "complexity": "simple",
+      "filePath": "src/shippingservice/main.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:calculate-shipping:calculate-quote",
+      "type": "step",
+      "name": "Calculate Flat-Rate Quote",
+      "summary": "Shipping service returns $8.99 for non-empty orders or $0 for empty orders via CreateQuoteFromCount.",
+      "tags": ["shipping", "pricing"],
+      "complexity": "simple",
+      "filePath": "src/shippingservice/quote.go",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:calculate-shipping:generate-tracking-id",
+      "type": "step",
+      "name": "Generate Tracking ID",
+      "summary": "Shipping service generates a tracking ID from address data and random components for shipped orders.",
+      "tags": ["shipping", "tracking"],
+      "complexity": "simple",
+      "filePath": "src/shippingservice/tracker.go",
+      "lineRange": [0, 0]
+    },
+
+    {
+      "id": "step:process-payment:validate-card",
+      "type": "step",
+      "name": "Validate Credit Card",
+      "summary": "Payment service validates the card number format (VISA/MasterCard) and checks the expiration date.",
+      "tags": ["payment", "validation"],
+      "complexity": "simple",
+      "filePath": "src/paymentservice/charge.js",
+      "lineRange": [0, 0]
+    },
+    {
+      "id": "step:process-payment:generate-transaction-id",
+      "type": "step",
+      "name": "Generate Transaction ID",
+      "summary": "Payment service generates a UUID transaction ID representing the successful simulated charge.",
+      "tags": ["payment", "transaction"],
+      "complexity": "simple",
+      "filePath": "src/paymentservice/charge.js",
+      "lineRange": [0, 0]
+    }
+  ],
+  "edges": [
+    { "source": "domain:product-catalog", "target": "flow:browse-products", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:product-catalog", "target": "flow:view-product-details", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:shopping-cart", "target": "flow:manage-cart", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:checkout-and-ordering", "target": "flow:checkout-purchase", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:payment-processing", "target": "flow:process-payment", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:shipping", "target": "flow:calculate-shipping", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:currency-conversion", "target": "flow:convert-currency", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:currency-conversion", "target": "flow:set-currency", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:email-notifications", "target": "flow:send-order-confirmation", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:recommendations", "target": "flow:get-recommendations", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:advertising", "target": "flow:serve-ads", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "domain:shopping-assistant", "target": "flow:ai-shopping-assistant", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:browse-products", "target": "step:browse-products:fetch-products", "type": "flow_step", "direction": "forward", "weight": 0.2 },
+    { "source": "flow:browse-products", "target": "step:browse-products:fetch-currencies", "type": "flow_step", "direction": "forward", "weight": 0.3 },
+    { "source": "flow:browse-products", "target": "step:browse-products:convert-prices", "type": "flow_step", "direction": "forward", "weight": 0.5 },
+    { "source": "flow:browse-products", "target": "step:browse-products:fetch-cart-size", "type": "flow_step", "direction": "forward", "weight": 0.7 },
+    { "source": "flow:browse-products", "target": "step:browse-products:fetch-ads", "type": "flow_step", "direction": "forward", "weight": 0.8 },
+    { "source": "flow:browse-products", "target": "step:browse-products:render-home", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:view-product-details", "target": "step:view-product-details:fetch-product", "type": "flow_step", "direction": "forward", "weight": 0.2 },
+    { "source": "flow:view-product-details", "target": "step:view-product-details:convert-price", "type": "flow_step", "direction": "forward", "weight": 0.4 },
+    { "source": "flow:view-product-details", "target": "step:view-product-details:fetch-recommendations", "type": "flow_step", "direction": "forward", "weight": 0.6 },
+    { "source": "flow:view-product-details", "target": "step:view-product-details:fetch-ads", "type": "flow_step", "direction": "forward", "weight": 0.8 },
+    { "source": "flow:view-product-details", "target": "step:view-product-details:render-page", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:manage-cart", "target": "step:manage-cart:validate-input", "type": "flow_step", "direction": "forward", "weight": 0.1 },
+    { "source": "flow:manage-cart", "target": "step:manage-cart:add-item", "type": "flow_step", "direction": "forward", "weight": 0.2 },
+    { "source": "flow:manage-cart", "target": "step:manage-cart:retrieve-cart", "type": "flow_step", "direction": "forward", "weight": 0.3 },
+    { "source": "flow:manage-cart", "target": "step:manage-cart:resolve-product-details", "type": "flow_step", "direction": "forward", "weight": 0.4 },
+    { "source": "flow:manage-cart", "target": "step:manage-cart:convert-cart-prices", "type": "flow_step", "direction": "forward", "weight": 0.6 },
+    { "source": "flow:manage-cart", "target": "step:manage-cart:get-shipping-estimate", "type": "flow_step", "direction": "forward", "weight": 0.7 },
+    { "source": "flow:manage-cart", "target": "step:manage-cart:render-cart", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:checkout-purchase", "target": "step:checkout-purchase:validate-checkout-input", "type": "flow_step", "direction": "forward", "weight": 0.1 },
+    { "source": "flow:checkout-purchase", "target": "step:checkout-purchase:retrieve-cart-items", "type": "flow_step", "direction": "forward", "weight": 0.2 },
+    { "source": "flow:checkout-purchase", "target": "step:checkout-purchase:lookup-product-prices", "type": "flow_step", "direction": "forward", "weight": 0.3 },
+    { "source": "flow:checkout-purchase", "target": "step:checkout-purchase:get-shipping-quote", "type": "flow_step", "direction": "forward", "weight": 0.4 },
+    { "source": "flow:checkout-purchase", "target": "step:checkout-purchase:convert-currency", "type": "flow_step", "direction": "forward", "weight": 0.5 },
+    { "source": "flow:checkout-purchase", "target": "step:checkout-purchase:charge-payment", "type": "flow_step", "direction": "forward", "weight": 0.6 },
+    { "source": "flow:checkout-purchase", "target": "step:checkout-purchase:ship-order", "type": "flow_step", "direction": "forward", "weight": 0.7 },
+    { "source": "flow:checkout-purchase", "target": "step:checkout-purchase:empty-cart", "type": "flow_step", "direction": "forward", "weight": 0.8 },
+    { "source": "flow:checkout-purchase", "target": "step:checkout-purchase:send-confirmation", "type": "flow_step", "direction": "forward", "weight": 0.9 },
+    { "source": "flow:checkout-purchase", "target": "step:checkout-purchase:render-confirmation", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:set-currency", "target": "step:set-currency:select-currency", "type": "flow_step", "direction": "forward", "weight": 0.5 },
+    { "source": "flow:set-currency", "target": "step:set-currency:store-preference", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:get-recommendations", "target": "step:get-recommendations:fetch-catalog", "type": "flow_step", "direction": "forward", "weight": 0.3 },
+    { "source": "flow:get-recommendations", "target": "step:get-recommendations:filter-viewed", "type": "flow_step", "direction": "forward", "weight": 0.7 },
+    { "source": "flow:get-recommendations", "target": "step:get-recommendations:sample-results", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:serve-ads", "target": "step:serve-ads:lookup-by-category", "type": "flow_step", "direction": "forward", "weight": 0.5 },
+    { "source": "flow:serve-ads", "target": "step:serve-ads:fallback-random", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:convert-currency", "target": "step:convert-currency:normalize-to-eur", "type": "flow_step", "direction": "forward", "weight": 0.5 },
+    { "source": "flow:convert-currency", "target": "step:convert-currency:convert-to-target", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:send-order-confirmation", "target": "step:send-order-confirmation:render-template", "type": "flow_step", "direction": "forward", "weight": 0.5 },
+    { "source": "flow:send-order-confirmation", "target": "step:send-order-confirmation:send-email", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:ai-shopping-assistant", "target": "step:ai-shopping-assistant:analyze-room-image", "type": "flow_step", "direction": "forward", "weight": 0.3 },
+    { "source": "flow:ai-shopping-assistant", "target": "step:ai-shopping-assistant:vector-search", "type": "flow_step", "direction": "forward", "weight": 0.7 },
+    { "source": "flow:ai-shopping-assistant", "target": "step:ai-shopping-assistant:generate-response", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:calculate-shipping", "target": "step:calculate-shipping:count-items", "type": "flow_step", "direction": "forward", "weight": 0.3 },
+    { "source": "flow:calculate-shipping", "target": "step:calculate-shipping:calculate-quote", "type": "flow_step", "direction": "forward", "weight": 0.7 },
+    { "source": "flow:calculate-shipping", "target": "step:calculate-shipping:generate-tracking-id", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "flow:process-payment", "target": "step:process-payment:validate-card", "type": "flow_step", "direction": "forward", "weight": 0.5 },
+    { "source": "flow:process-payment", "target": "step:process-payment:generate-transaction-id", "type": "flow_step", "direction": "forward", "weight": 1.0 },
+
+    { "source": "domain:checkout-and-ordering", "target": "domain:shopping-cart", "type": "cross_domain", "direction": "forward", "description": "Checkout retrieves cart items and empties cart after purchase", "weight": 0.9 },
+    { "source": "domain:checkout-and-ordering", "target": "domain:product-catalog", "type": "cross_domain", "direction": "forward", "description": "Checkout looks up product prices for each cart item", "weight": 0.9 },
+    { "source": "domain:checkout-and-ordering", "target": "domain:currency-conversion", "type": "cross_domain", "direction": "forward", "description": "Checkout converts order amounts to user's preferred currency", "weight": 0.7 },
+    { "source": "domain:checkout-and-ordering", "target": "domain:shipping", "type": "cross_domain", "direction": "forward", "description": "Checkout requests shipping quote and initiates shipment", "weight": 0.8 },
+    { "source": "domain:checkout-and-ordering", "target": "domain:payment-processing", "type": "cross_domain", "direction": "forward", "description": "Checkout charges the customer's credit card via payment service", "weight": 0.9 },
+    { "source": "domain:checkout-and-ordering", "target": "domain:email-notifications", "type": "cross_domain", "direction": "forward", "description": "Checkout sends order confirmation email after successful payment", "weight": 0.7 },
+    { "source": "domain:recommendations", "target": "domain:product-catalog", "type": "cross_domain", "direction": "forward", "description": "Recommendation service queries full product catalog to generate suggestions", "weight": 0.8 },
+    { "source": "domain:product-catalog", "target": "domain:currency-conversion", "type": "cross_domain", "direction": "forward", "description": "Frontend converts product prices to user's preferred currency when displaying catalog", "weight": 0.6 },
+    { "source": "domain:shopping-cart", "target": "domain:product-catalog", "type": "cross_domain", "direction": "forward", "description": "Cart view resolves product details for each cart item", "weight": 0.6 },
+    { "source": "domain:shopping-cart", "target": "domain:shipping", "type": "cross_domain", "direction": "forward", "description": "Cart view displays shipping cost estimate", "weight": 0.5 }
+  ],
+  "layers": [],
+  "tour": []
+}

--- a/demo-data/knowledge-graph.json
+++ b/demo-data/knowledge-graph.json
@@ -1,0 +1,9081 @@
+{
+  "version": "1.0.0",
+  "project": {
+    "name": "microservices-demo",
+    "languages": [
+      "csharp",
+      "css",
+      "dockerfile",
+      "go",
+      "html",
+      "java",
+      "javascript",
+      "json",
+      "markdown",
+      "protobuf",
+      "python",
+      "shell",
+      "terraform",
+      "xml",
+      "yaml"
+    ],
+    "frameworks": [
+      "Docker",
+      "Flask",
+      "GitHub Actions",
+      "Pydantic",
+      "Pytest",
+      "Sqlalchemy",
+      "Terraform"
+    ],
+    "description": "Online Boutique is a cloud-first microservices demo application by Google, featuring 11 microservices written in different languages (Go, C#, Java, Python, Node.js) that communicate over gRPC.",
+    "analyzedAt": "2026-04-14T03:11:46.548Z",
+    "gitCommitHash": "c9857ee54fba10486013f15ba6b31411986f530c"
+  },
+  "nodes": [
+    {
+      "id": "config:.deploystack/deploystack.yaml",
+      "type": "config",
+      "name": "deploystack.yaml",
+      "filePath": ".deploystack/deploystack.yaml",
+      "summary": "DeployStack configuration defining the Online Boutique deployment parameters including project, region, and Kustomize manifest path for GCP Cloud Shell deployment.",
+      "tags": [
+        "configuration",
+        "deployment",
+        "gcp",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.deploystack/messages/description.txt",
+      "type": "document",
+      "name": "description.txt",
+      "filePath": ".deploystack/messages/description.txt",
+      "summary": "Brief description text displayed during DeployStack deployment explaining that Online Boutique is an 11-tier microservices e-commerce demo application.",
+      "tags": [
+        "documentation",
+        "deployment",
+        "description"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.deploystack/messages/success.txt",
+      "type": "document",
+      "name": "success.txt",
+      "filePath": ".deploystack/messages/success.txt",
+      "summary": "Success message displayed after DeployStack completes provisioning a GKE cluster with the Online Boutique microservices and load generator.",
+      "tags": [
+        "documentation",
+        "deployment",
+        "notification"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.deploystack/scripts/preinit.sh",
+      "type": "file",
+      "name": "preinit.sh",
+      "filePath": ".deploystack/scripts/preinit.sh",
+      "summary": "Pre-initialization script for DeployStack that renames 'project_id' to 'gcp_project_id' in the Terraform tfvars file before deployment begins.",
+      "tags": [
+        "script",
+        "deployment",
+        "terraform",
+        "preprocessing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.deploystack/test",
+      "type": "file",
+      "name": "test",
+      "filePath": ".deploystack/test",
+      "summary": "End-to-end integration test script for DeployStack that provisions a temporary GCP project, deploys Online Boutique via Terraform, validates all 11 microservices are running on GKE, tests the frontend HTTP endpoint, then tears everything down.",
+      "tags": [
+        "test",
+        "integration-test",
+        "infrastructure",
+        "terraform",
+        "gke"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Bash test script using gcloud and kubectl to verify Terraform-managed GKE deployments with automatic project creation and cleanup."
+    },
+    {
+      "id": "config:.deploystack/test.yaml",
+      "type": "config",
+      "name": "test.yaml",
+      "filePath": ".deploystack/test.yaml",
+      "summary": "Cloud Build configuration for running the DeployStack integration test, using secrets for credentials and billing account to execute the test script on a high-CPU machine.",
+      "tags": [
+        "configuration",
+        "ci-cd",
+        "cloud-build",
+        "testing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.gitattributes",
+      "type": "file",
+      "name": ".gitattributes",
+      "filePath": ".gitattributes",
+      "summary": "Git configuration file that enforces LF line endings for all text files across all operating systems to maintain consistent formatting.",
+      "tags": [
+        "configuration",
+        "git",
+        "developer-tooling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/auto-approve.yml",
+      "type": "config",
+      "name": "auto-approve.yml",
+      "filePath": ".github/auto-approve.yml",
+      "summary": "Configuration for the auto-approve GitHub bot defining which dependency update processes (Python, Java, Go, Node, Docker) are eligible for automatic PR approval.",
+      "tags": [
+        "configuration",
+        "automation",
+        "dependency-management",
+        "ci-cd"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/CODE_OF_CONDUCT.md",
+      "type": "document",
+      "name": "CODE_OF_CONDUCT.md",
+      "filePath": ".github/CODE_OF_CONDUCT.md",
+      "summary": "Contributor Code of Conduct adapted from the Contributor Covenant v1.2.0, establishing community behavior standards and enforcement guidelines for the project.",
+      "tags": [
+        "documentation",
+        "community",
+        "governance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.github/CODEOWNERS",
+      "type": "file",
+      "name": "CODEOWNERS",
+      "filePath": ".github/CODEOWNERS",
+      "summary": "GitHub CODEOWNERS file assigning the devrel-flagship-app-maintainers team and yoshi-approver as default reviewers for all repository changes.",
+      "tags": [
+        "configuration",
+        "code-review",
+        "governance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/CONTRIBUTING.md",
+      "type": "document",
+      "name": "CONTRIBUTING.md",
+      "filePath": ".github/CONTRIBUTING.md",
+      "summary": "Contribution guidelines requiring CLA signing and describing the process for submitting small bug fixes via PRs or proposing larger changes through GitHub issues first.",
+      "tags": [
+        "documentation",
+        "community",
+        "development",
+        "governance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/header-checker-lint.yml",
+      "type": "config",
+      "name": "header-checker-lint.yml",
+      "filePath": ".github/header-checker-lint.yml",
+      "summary": "Configuration for the License Header Lint GitHub bot that checks PRs for valid Apache 2.0 license headers from Google LLC across all major source file extensions in the project.",
+      "tags": [
+        "configuration",
+        "linting",
+        "compliance",
+        "ci-cd"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/ISSUE_TEMPLATE/bug-report.md",
+      "type": "document",
+      "name": "bug-report.md",
+      "filePath": ".github/ISSUE_TEMPLATE/bug-report.md",
+      "summary": "GitHub issue template for bug reports with structured sections for description, reproduction steps, logs, screenshots, environment details, and exposure assessment.",
+      "tags": [
+        "documentation",
+        "issue-template",
+        "bug-tracking"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/ISSUE_TEMPLATE/feature-request.md",
+      "type": "document",
+      "name": "feature-request.md",
+      "filePath": ".github/ISSUE_TEMPLATE/feature-request.md",
+      "summary": "GitHub issue template for feature requests prompting contributors to describe the request and its intended purpose or environment.",
+      "tags": [
+        "documentation",
+        "issue-template",
+        "feature-request"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/ISSUE_TEMPLATE/other.md",
+      "type": "document",
+      "name": "other.md",
+      "filePath": ".github/ISSUE_TEMPLATE/other.md",
+      "summary": "GitHub issue template for general questions or inquiries that do not fit the bug report or feature request categories.",
+      "tags": [
+        "documentation",
+        "issue-template",
+        "support"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/pull_request_template.md",
+      "type": "document",
+      "name": "pull_request_template.md",
+      "filePath": ".github/pull_request_template.md",
+      "summary": "Pull request template with structured sections for background, fixes, change summary, additional notes, testing procedure, and related PRs or issues.",
+      "tags": [
+        "documentation",
+        "pull-request",
+        "development",
+        "code-review"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/release-cluster/backend-config.yaml",
+      "type": "config",
+      "name": "backend-config.yaml",
+      "filePath": ".github/release-cluster/backend-config.yaml",
+      "summary": "GKE BackendConfig resource that associates a Cloud Armor security policy with the frontend backend to provide WAF and DDoS protection for the release cluster.",
+      "tags": [
+        "configuration",
+        "kubernetes",
+        "security",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/release-cluster/frontend-config.yaml",
+      "type": "config",
+      "name": "frontend-config.yaml",
+      "filePath": ".github/release-cluster/frontend-config.yaml",
+      "summary": "GKE FrontendConfig resource enabling SSL policy and HTTP-to-HTTPS redirect for the Online Boutique release cluster ingress.",
+      "tags": [
+        "configuration",
+        "kubernetes",
+        "ssl",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/release-cluster/frontend-ingress.yaml",
+      "type": "config",
+      "name": "frontend-ingress.yaml",
+      "filePath": ".github/release-cluster/frontend-ingress.yaml",
+      "summary": "Kubernetes Ingress resource routing external traffic on the static IP to the frontend service on port 80, with managed TLS certificate and FrontendConfig annotations.",
+      "tags": [
+        "configuration",
+        "kubernetes",
+        "ingress",
+        "networking"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/release-cluster/frontend-service.yaml",
+      "type": "config",
+      "name": "frontend-service.yaml",
+      "filePath": ".github/release-cluster/frontend-service.yaml",
+      "summary": "Kubernetes ClusterIP Service exposing the frontend deployment on port 80 (targeting 8080), with NEG and BackendConfig annotations for GKE ingress integration.",
+      "tags": [
+        "configuration",
+        "kubernetes",
+        "service",
+        "networking"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/release-cluster/managed-cert.yaml",
+      "type": "config",
+      "name": "managed-cert.yaml",
+      "filePath": ".github/release-cluster/managed-cert.yaml",
+      "summary": "GKE ManagedCertificate resource provisioning a TLS certificate for the cymbal-shops.retail.cymbal.dev domain used by the Online Boutique release cluster.",
+      "tags": [
+        "configuration",
+        "kubernetes",
+        "ssl",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/release-cluster/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": ".github/release-cluster/README.md",
+      "summary": "Operational guide for deploying the release cluster manifests including static IP creation, Cloud Armor setup, SSL policy configuration, and Kubernetes manifest deployment for cymbal-shops.retail.cymbal.dev.",
+      "tags": [
+        "documentation",
+        "deployment",
+        "infrastructure",
+        "operations"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:.github/renovate.json5",
+      "type": "file",
+      "name": "renovate.json5",
+      "filePath": ".github/renovate.json5",
+      "summary": "Renovate bot configuration extending the GCP dee-platform-ops preset with early Monday scheduling, enabling pip-compile for Python requirements, and managing Kubernetes YAML dependencies while excluding release and kustomize base paths.",
+      "tags": [
+        "configuration",
+        "dependency-management",
+        "automation",
+        "ci-cd"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/SECURITY.md",
+      "type": "document",
+      "name": "SECURITY.md",
+      "filePath": ".github/SECURITY.md",
+      "summary": "Security vulnerability reporting policy directing reporters to g.co/vulnz for intake, with a 5-day response SLA from the Google Security Team.",
+      "tags": [
+        "documentation",
+        "security",
+        "governance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:.github/snippet-bot.yml",
+      "type": "config",
+      "name": "snippet-bot.yml",
+      "filePath": ".github/snippet-bot.yml",
+      "summary": "Configuration file for the snippet-bot GitHub bot, containing only the Apache 2.0 license header with no active bot settings.",
+      "tags": [
+        "configuration",
+        "automation",
+        "ci-cd"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:.deploystack/test:evalTest",
+      "type": "function",
+      "name": "evalTest",
+      "filePath": ".deploystack/test",
+      "lineRange": [
+        56,
+        80
+      ],
+      "summary": "Test assertion helper that evaluates a shell command and compares its output against an expected value, supporting an EXPECTERROR mode for commands expected to fail.",
+      "tags": [
+        "test",
+        "utility",
+        "assertion",
+        "shell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:.deploystack/test:generateProject",
+      "type": "function",
+      "name": "generateProject",
+      "filePath": ".deploystack/test",
+      "lineRange": [
+        82,
+        114
+      ],
+      "summary": "Creates a temporary GCP project with a random suffix and date label, links it to a billing account via service account credentials, for use in disposable integration tests.",
+      "tags": [
+        "test",
+        "infrastructure",
+        "gcp",
+        "project-management"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "resource:.github/terraform/main.tf",
+      "type": "resource",
+      "name": "main.tf",
+      "filePath": ".github/terraform/main.tf",
+      "summary": "Provisions GCP infrastructure for CI/CD including a GKE Autopilot cluster for PR staging deployments, a GCS bucket for Terraform state, and a least-privilege IAM service account with monitoring and logging roles.",
+      "tags": [
+        "infrastructure",
+        "terraform",
+        "gke",
+        "iam",
+        "deployment"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses remote GCS backend for state, module for API enablement, and Autopilot mode for hands-off GKE cluster management."
+    },
+    {
+      "id": "document:.github/terraform/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": ".github/terraform/README.md",
+      "summary": "Brief instructions for updating the CI/CD Terraform configuration used by GitHub Actions workflows.",
+      "tags": [
+        "documentation",
+        "terraform",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "resource:.github/terraform/variables.tf",
+      "type": "resource",
+      "name": "variables.tf",
+      "filePath": ".github/terraform/variables.tf",
+      "summary": "Declares the project_id input variable used across the CI/CD Terraform configuration to target the correct GCP project.",
+      "tags": [
+        "infrastructure",
+        "terraform",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "resource:.github/terraform/versions.tf",
+      "type": "resource",
+      "name": "versions.tf",
+      "filePath": ".github/terraform/versions.tf",
+      "summary": "Pins Terraform core and Google provider versions to ensure reproducible CI/CD infrastructure provisioning.",
+      "tags": [
+        "infrastructure",
+        "terraform",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "pipeline:.github/workflows/ci-main.yaml",
+      "type": "pipeline",
+      "name": "ci-main.yaml",
+      "filePath": ".github/workflows/ci-main.yaml",
+      "summary": "GitHub Actions workflow triggered on push to main/release branches that runs code tests and deployment tests for the microservices demo application.",
+      "tags": [
+        "ci-cd",
+        "deployment",
+        "testing",
+        "github-actions"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "pipeline:.github/workflows/ci-pr.yaml",
+      "type": "pipeline",
+      "name": "ci-pr.yaml",
+      "filePath": ".github/workflows/ci-pr.yaml",
+      "summary": "GitHub Actions workflow triggered on pull requests that runs code tests and deploys a staging environment to the GKE PR cluster for deployment testing.",
+      "tags": [
+        "ci-cd",
+        "testing",
+        "staging",
+        "github-actions"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "pipeline:.github/workflows/cleanup.yaml",
+      "type": "pipeline",
+      "name": "cleanup.yaml",
+      "filePath": ".github/workflows/cleanup.yaml",
+      "summary": "GitHub Actions workflow that cleans up the GKE namespace associated with a pull request after it is closed or merged.",
+      "tags": [
+        "ci-cd",
+        "cleanup",
+        "github-actions"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "pipeline:.github/workflows/helm-chart-ci.yaml",
+      "type": "pipeline",
+      "name": "helm-chart-ci.yaml",
+      "filePath": ".github/workflows/helm-chart-ci.yaml",
+      "summary": "GitHub Actions workflow that validates Helm chart changes by running helm lint, template rendering, and kubevious validation on push and pull request events.",
+      "tags": [
+        "ci-cd",
+        "helm",
+        "validation",
+        "github-actions"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:.github/workflows/install-dependencies.sh",
+      "type": "file",
+      "name": "install-dependencies.sh",
+      "filePath": ".github/workflows/install-dependencies.sh",
+      "summary": "Shell script that installs CI workflow dependencies including kustomize, skaffold, kubevious, and helm for use in GitHub Actions runners.",
+      "tags": [
+        "ci-cd",
+        "build-system",
+        "shell",
+        "dependency-management"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "pipeline:.github/workflows/kubevious-manifests-ci.yaml",
+      "type": "pipeline",
+      "name": "kubevious-manifests-ci.yaml",
+      "filePath": ".github/workflows/kubevious-manifests-ci.yaml",
+      "summary": "GitHub Actions workflow that validates Kubernetes manifest YAML files using Kubevious to catch configuration issues before deployment.",
+      "tags": [
+        "ci-cd",
+        "validation",
+        "kubernetes",
+        "github-actions"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "pipeline:.github/workflows/kustomize-build-ci.yaml",
+      "type": "pipeline",
+      "name": "kustomize-build-ci.yaml",
+      "filePath": ".github/workflows/kustomize-build-ci.yaml",
+      "summary": "GitHub Actions workflow that validates all kustomize overlays build successfully on push and pull request events.",
+      "tags": [
+        "ci-cd",
+        "validation",
+        "kustomize",
+        "github-actions"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:.github/workflows/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": ".github/workflows/README.md",
+      "summary": "Documents the GitHub Actions CI/CD infrastructure including GKE cluster setup, workflow descriptions for code tests, deployment tests, and PR cleanup, plus instructions for creating new Actions runners.",
+      "tags": [
+        "documentation",
+        "ci-cd",
+        "github-actions",
+        "infrastructure"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "pipeline:.github/workflows/terraform-validate-ci.yaml",
+      "type": "pipeline",
+      "name": "terraform-validate-ci.yaml",
+      "filePath": ".github/workflows/terraform-validate-ci.yaml",
+      "summary": "GitHub Actions workflow that runs terraform init and validate on the CI/CD Terraform configuration to catch syntax and configuration errors.",
+      "tags": [
+        "ci-cd",
+        "terraform",
+        "validation",
+        "github-actions"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:cloudbuild.yaml",
+      "type": "config",
+      "name": "cloudbuild.yaml",
+      "filePath": "cloudbuild.yaml",
+      "summary": "Google Cloud Build configuration that deploys the application to a GKE cluster using Skaffold, with configurable zone and cluster substitutions.",
+      "tags": [
+        "configuration",
+        "deployment",
+        "cloud-build",
+        "gke"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:docs/adding-new-microservice.md",
+      "type": "document",
+      "name": "adding-new-microservice.md",
+      "filePath": "docs/adding-new-microservice.md",
+      "summary": "Step-by-step guide for adding a new microservice to the Online Boutique project, covering directory creation, Dockerfile, Kubernetes manifests, kustomization, skaffold, and Helm chart updates.",
+      "tags": [
+        "documentation",
+        "development",
+        "microservice",
+        "onboarding"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/cloudshell-tutorial.md",
+      "type": "document",
+      "name": "cloudshell-tutorial.md",
+      "filePath": "docs/cloudshell-tutorial.md",
+      "summary": "Interactive Cloud Shell tutorial that walks users through deploying Online Boutique on Minikube or GKE, accessing the web frontend, and cleaning up resources.",
+      "tags": [
+        "documentation",
+        "tutorial",
+        "gke",
+        "deployment"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/deploystack.md",
+      "type": "document",
+      "name": "deploystack.md",
+      "filePath": "docs/deploystack.md",
+      "summary": "Brief guide for deploying Online Boutique using Google DeployStack, a one-click deployment tool for GCP.",
+      "tags": [
+        "documentation",
+        "deployment",
+        "gcp"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:docs/development-guide.md",
+      "type": "document",
+      "name": "development-guide.md",
+      "filePath": "docs/development-guide.md",
+      "summary": "Comprehensive developer guide covering prerequisites, GKE and local cluster setup with Skaffold, and instructions for building and iterating on the microservices application.",
+      "tags": [
+        "documentation",
+        "development",
+        "onboarding",
+        "deployment"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:docs/product-requirements.md",
+      "type": "document",
+      "name": "product-requirements.md",
+      "filePath": "docs/product-requirements.md",
+      "summary": "Defines three core product requirements for Online Boutique: preserving the Kubernetes beginner journey, demo simplicity, and GKE quickstart simplicity.",
+      "tags": [
+        "documentation",
+        "requirements",
+        "product"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:docs/purpose.md",
+      "type": "document",
+      "name": "purpose.md",
+      "filePath": "docs/purpose.md",
+      "summary": "Defines the project's purpose as Google Cloud's primary microservices demo for showcasing Kubernetes and cloud-native technologies.",
+      "tags": [
+        "documentation",
+        "overview",
+        "product"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:docs/releasing/license_header.txt",
+      "type": "document",
+      "name": "license_header.txt",
+      "filePath": "docs/releasing/license_header.txt",
+      "summary": "Apache License 2.0 header template prepended to auto-generated release artifacts by the release scripts.",
+      "tags": [
+        "documentation",
+        "licensing",
+        "release"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:docs/releasing/make-docker-images.sh",
+      "type": "file",
+      "name": "make-docker-images.sh",
+      "filePath": "docs/releasing/make-docker-images.sh",
+      "summary": "Release script that builds and pushes Docker images for all microservices to the configured container registry with the specified release tag.",
+      "tags": [
+        "release",
+        "containerization",
+        "build-system",
+        "shell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:docs/releasing/make-helm-chart.sh",
+      "type": "file",
+      "name": "make-helm-chart.sh",
+      "filePath": "docs/releasing/make-helm-chart.sh",
+      "summary": "Release script that packages the Helm chart with the specified version tag for distribution.",
+      "tags": [
+        "release",
+        "helm",
+        "build-system",
+        "shell"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:docs/releasing/make-release-artifacts.sh",
+      "type": "file",
+      "name": "make-release-artifacts.sh",
+      "filePath": "docs/releasing/make-release-artifacts.sh",
+      "summary": "Generates release artifacts including compiled Kubernetes manifests, Istio manifests, and Kustomize base files with pinned image tags and license headers.",
+      "tags": [
+        "release",
+        "build-system",
+        "kubernetes",
+        "shell"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses sed pattern replacement to inject versioned image references into manifest templates, with Linux/macOS gsed compatibility shim."
+    },
+    {
+      "id": "file:docs/releasing/make-release.sh",
+      "type": "file",
+      "name": "make-release.sh",
+      "filePath": "docs/releasing/make-release.sh",
+      "summary": "Top-level release orchestrator that invokes make-docker-images.sh, make-release-artifacts.sh, and make-helm-chart.sh in sequence to produce a complete release.",
+      "tags": [
+        "release",
+        "build-system",
+        "orchestration",
+        "shell"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:docs/releasing/make-release-artifacts.sh:mk_kubernetes_manifests",
+      "type": "function",
+      "name": "mk_kubernetes_manifests",
+      "filePath": "docs/releasing/make-release-artifacts.sh",
+      "lineRange": [
+        64,
+        83
+      ],
+      "summary": "Reads all Kubernetes manifest YAMLs and replaces image references with versioned tagged images for each microservice.",
+      "tags": [
+        "release",
+        "manifest-generation",
+        "kubernetes"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:docs/releasing/make-release-artifacts.sh:mk_kustomize_base",
+      "type": "function",
+      "name": "mk_kustomize_base",
+      "filePath": "docs/releasing/make-release-artifacts.sh",
+      "lineRange": [
+        96,
+        119
+      ],
+      "summary": "Copies Kubernetes manifests into the kustomize base directory and updates image references to use release-tagged versions.",
+      "tags": [
+        "release",
+        "kustomize",
+        "manifest-generation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:docs/releasing/make-release-artifacts.sh:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "docs/releasing/make-release-artifacts.sh",
+      "lineRange": [
+        121,
+        135
+      ],
+      "summary": "Entry point that orchestrates generation of Kubernetes manifests, Istio manifests, and Kustomize base files into the release output directory.",
+      "tags": [
+        "release",
+        "entry-point",
+        "orchestration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:docs/releasing/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "docs/releasing/README.md",
+      "summary": "Step-by-step release process guide for Online Boutique covering prerequisites, tagging, PR creation, production deployment, and internal announcements.",
+      "tags": [
+        "documentation",
+        "release-process",
+        "deployment",
+        "operations"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:helm-chart/Chart.yaml",
+      "type": "config",
+      "name": "Chart.yaml",
+      "filePath": "helm-chart/Chart.yaml",
+      "summary": "Helm chart metadata defining the Online Boutique chart name, version, app version, and description for Kubernetes package management.",
+      "tags": [
+        "configuration",
+        "helm",
+        "kubernetes",
+        "packaging"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:helm-chart/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "helm-chart/README.md",
+      "summary": "Documentation for the Online Boutique Helm chart explaining installation, configuration options, and usage with Kubernetes clusters.",
+      "tags": [
+        "documentation",
+        "helm",
+        "kubernetes",
+        "installation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:helm-chart/templates/adservice.yaml",
+      "type": "config",
+      "name": "adservice.yaml",
+      "filePath": "helm-chart/templates/adservice.yaml",
+      "summary": "Helm template defining Kubernetes resources for the ad service microservice including Deployment, Service, ServiceAccount, NetworkPolicy, Istio Sidecar, and AuthorizationPolicy on port 9555.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "orchestration",
+        "microservice"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses Helm templating with conditional blocks for Istio service mesh resources (Sidecar, AuthorizationPolicy)."
+    },
+    {
+      "id": "config:helm-chart/templates/cartservice.yaml",
+      "type": "config",
+      "name": "cartservice.yaml",
+      "filePath": "helm-chart/templates/cartservice.yaml",
+      "summary": "Helm template for the cart service microservice and its Redis database backend, including in-cluster Redis deployment, external Redis TLS origination support, network policies, and Istio mesh configuration on ports 7070 and 6379.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "orchestration",
+        "microservice",
+        "database"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Most complex service template in the chart with 15 K8s resources covering both the cart service and its Redis dependency with multiple deployment strategies."
+    },
+    {
+      "id": "config:helm-chart/templates/checkoutservice.yaml",
+      "type": "config",
+      "name": "checkoutservice.yaml",
+      "filePath": "helm-chart/templates/checkoutservice.yaml",
+      "summary": "Helm template defining Kubernetes resources for the checkout service microservice including Deployment, Service, ServiceAccount, NetworkPolicy, and Istio configuration on port 5050.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "orchestration",
+        "microservice"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:helm-chart/templates/common.yaml",
+      "type": "config",
+      "name": "common.yaml",
+      "filePath": "helm-chart/templates/common.yaml",
+      "summary": "Shared Helm template defining common Kubernetes resources like default-deny NetworkPolicy and AuthorizationPolicy applied across all microservices in the chart.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "security",
+        "networking"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:helm-chart/templates/currencyservice.yaml",
+      "type": "config",
+      "name": "currencyservice.yaml",
+      "filePath": "helm-chart/templates/currencyservice.yaml",
+      "summary": "Helm template defining Kubernetes resources for the currency conversion service including Deployment, Service, ServiceAccount, NetworkPolicy, and Istio configuration on port 7000.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "orchestration",
+        "microservice"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:helm-chart/templates/emailservice.yaml",
+      "type": "config",
+      "name": "emailservice.yaml",
+      "filePath": "helm-chart/templates/emailservice.yaml",
+      "summary": "Helm template defining Kubernetes resources for the email notification service including Deployment, Service, ServiceAccount, NetworkPolicy, and Istio configuration on ports 8080/5000.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "orchestration",
+        "microservice"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:helm-chart/templates/frontend.yaml",
+      "type": "config",
+      "name": "frontend.yaml",
+      "filePath": "helm-chart/templates/frontend.yaml",
+      "summary": "Helm template for the frontend web service including Deployment, internal and external Services, NetworkPolicy, Istio Sidecar, AuthorizationPolicy, and VirtualService routing on ports 8080/80.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "orchestration",
+        "microservice",
+        "frontend"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Includes both ClusterIP and LoadBalancer service types with optional Istio VirtualService for ingress routing."
+    },
+    {
+      "id": "config:helm-chart/templates/loadgenerator.yaml",
+      "type": "config",
+      "name": "loadgenerator.yaml",
+      "filePath": "helm-chart/templates/loadgenerator.yaml",
+      "summary": "Helm template for the load generator deployment that simulates user traffic against the frontend, with NetworkPolicy and Istio Sidecar configuration.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "testing",
+        "load-testing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:helm-chart/templates/NOTES.txt",
+      "type": "document",
+      "name": "NOTES.txt",
+      "filePath": "helm-chart/templates/NOTES.txt",
+      "summary": "Helm post-install notes template displayed after chart installation, providing instructions on how to access the deployed Online Boutique application.",
+      "tags": [
+        "documentation",
+        "helm",
+        "installation",
+        "user-guide"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:helm-chart/templates/opentelemetry-collector.yaml",
+      "type": "config",
+      "name": "opentelemetry-collector.yaml",
+      "filePath": "helm-chart/templates/opentelemetry-collector.yaml",
+      "summary": "Helm template for the OpenTelemetry Collector deployment including ConfigMap with pipeline configuration, Deployment, Service, ServiceAccount, NetworkPolicy, and Istio settings on port 4317.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "observability",
+        "monitoring",
+        "opentelemetry"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Includes embedded OpenTelemetry Collector configuration within a ConfigMap defining receivers, processors, exporters, and telemetry pipelines."
+    },
+    {
+      "id": "config:helm-chart/templates/paymentservice.yaml",
+      "type": "config",
+      "name": "paymentservice.yaml",
+      "filePath": "helm-chart/templates/paymentservice.yaml",
+      "summary": "Helm template defining Kubernetes resources for the payment processing service including Deployment, Service, ServiceAccount, NetworkPolicy, and Istio configuration on port 50051.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "orchestration",
+        "microservice"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:helm-chart/templates/productcatalogservice.yaml",
+      "type": "config",
+      "name": "productcatalogservice.yaml",
+      "filePath": "helm-chart/templates/productcatalogservice.yaml",
+      "summary": "Helm template defining Kubernetes resources for the product catalog service including Deployment, Service, ServiceAccount, NetworkPolicy, and Istio configuration on port 3550.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "orchestration",
+        "microservice"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:helm-chart/templates/recommendationservice.yaml",
+      "type": "config",
+      "name": "recommendationservice.yaml",
+      "filePath": "helm-chart/templates/recommendationservice.yaml",
+      "summary": "Helm template defining Kubernetes resources for the product recommendation service including Deployment, Service, ServiceAccount, NetworkPolicy, and Istio configuration on port 8080.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "orchestration",
+        "microservice"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:helm-chart/templates/shippingservice.yaml",
+      "type": "config",
+      "name": "shippingservice.yaml",
+      "filePath": "helm-chart/templates/shippingservice.yaml",
+      "summary": "Helm template defining Kubernetes resources for the shipping cost calculation service including Deployment, Service, ServiceAccount, NetworkPolicy, and Istio configuration on port 50051.",
+      "tags": [
+        "kubernetes",
+        "helm",
+        "orchestration",
+        "microservice"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:helm-chart/values.yaml",
+      "type": "config",
+      "name": "values.yaml",
+      "filePath": "helm-chart/values.yaml",
+      "summary": "Default Helm values file configuring all 11 microservices with image repository, service names, resource limits, feature flags for Cymbal branding, network policies, Istio sidecars, and cart database options.",
+      "tags": [
+        "configuration",
+        "helm",
+        "kubernetes",
+        "orchestration"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Central configuration hub controlling all service deployments, feature toggles, and infrastructure options for the entire Online Boutique application."
+    },
+    {
+      "id": "config:istio-manifests/allow-egress-googleapis.yaml",
+      "type": "config",
+      "name": "allow-egress-googleapis.yaml",
+      "filePath": "istio-manifests/allow-egress-googleapis.yaml",
+      "summary": "Istio ServiceEntry resources allowing egress traffic to Google APIs (googleapis.com and metadata.google.internal) for services running within the mesh.",
+      "tags": [
+        "kubernetes",
+        "istio",
+        "networking",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:istio-manifests/frontend-gateway.yaml",
+      "type": "config",
+      "name": "frontend-gateway.yaml",
+      "filePath": "istio-manifests/frontend-gateway.yaml",
+      "summary": "Istio Gateway and VirtualService resources defining external ingress routing to the frontend service on port 80 for the Online Boutique application.",
+      "tags": [
+        "kubernetes",
+        "istio",
+        "networking",
+        "ingress"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Defines the Istio ingress gateway as the primary entry point for external HTTP traffic into the service mesh."
+    },
+    {
+      "id": "config:istio-manifests/frontend.yaml",
+      "type": "config",
+      "name": "frontend.yaml",
+      "filePath": "istio-manifests/frontend.yaml",
+      "summary": "Istio VirtualService for internal frontend routing with retry policies and timeout configuration within the service mesh.",
+      "tags": [
+        "kubernetes",
+        "istio",
+        "networking",
+        "resilience"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kubernetes-manifests/adservice.yaml",
+      "type": "config",
+      "name": "adservice.yaml",
+      "filePath": "kubernetes-manifests/adservice.yaml",
+      "summary": "Raw Kubernetes manifests for the ad service microservice defining Deployment with resource limits/probes, ClusterIP Service on port 9555, and ServiceAccount.",
+      "tags": [
+        "kubernetes",
+        "orchestration",
+        "microservice",
+        "deployment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kubernetes-manifests/cartservice.yaml",
+      "type": "config",
+      "name": "cartservice.yaml",
+      "filePath": "kubernetes-manifests/cartservice.yaml",
+      "summary": "Raw Kubernetes manifests for the cart service and its in-cluster Redis database including Deployments, Services on ports 7070/6379, and ServiceAccounts for both components.",
+      "tags": [
+        "kubernetes",
+        "orchestration",
+        "microservice",
+        "database",
+        "deployment"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kubernetes-manifests/checkoutservice.yaml",
+      "type": "config",
+      "name": "checkoutservice.yaml",
+      "filePath": "kubernetes-manifests/checkoutservice.yaml",
+      "summary": "Raw Kubernetes manifests for the checkout service microservice defining Deployment with health probes, ClusterIP Service on port 5050, and ServiceAccount.",
+      "tags": [
+        "kubernetes",
+        "orchestration",
+        "microservice",
+        "deployment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kubernetes-manifests/currencyservice.yaml",
+      "type": "config",
+      "name": "currencyservice.yaml",
+      "filePath": "kubernetes-manifests/currencyservice.yaml",
+      "summary": "Raw Kubernetes manifests for the currency conversion service defining Deployment with health probes, ClusterIP Service on port 7000, and ServiceAccount.",
+      "tags": [
+        "kubernetes",
+        "orchestration",
+        "microservice",
+        "deployment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kubernetes-manifests/emailservice.yaml",
+      "type": "config",
+      "name": "emailservice.yaml",
+      "filePath": "kubernetes-manifests/emailservice.yaml",
+      "summary": "Kubernetes manifest defining Deployment, Service, and ServiceAccount for the email service, exposing gRPC on port 8080 with a ClusterIP service on port 5000.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "email-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kubernetes-manifests/frontend.yaml",
+      "type": "config",
+      "name": "frontend.yaml",
+      "filePath": "kubernetes-manifests/frontend.yaml",
+      "summary": "Kubernetes manifest for the frontend web service with Deployment, internal Service, external LoadBalancer Service, and ServiceAccount. Configures environment variables referencing all backend microservices.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "frontend"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kubernetes-manifests/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kubernetes-manifests/kustomization.yaml",
+      "summary": "Kustomization file aggregating all kubernetes-manifests service YAML files as resources for Skaffold-based deployment.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "kustomize"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kubernetes-manifests/loadgenerator.yaml",
+      "type": "config",
+      "name": "loadgenerator.yaml",
+      "filePath": "kubernetes-manifests/loadgenerator.yaml",
+      "summary": "Kubernetes manifest for the load generator Deployment and ServiceAccount, using an init container to wait for the frontend service before starting Locust-based traffic generation.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "load-testing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kubernetes-manifests/paymentservice.yaml",
+      "type": "config",
+      "name": "paymentservice.yaml",
+      "filePath": "kubernetes-manifests/paymentservice.yaml",
+      "summary": "Kubernetes manifest defining Deployment, Service, and ServiceAccount for the payment service, exposing gRPC on port 50051.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "payment-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kubernetes-manifests/productcatalogservice.yaml",
+      "type": "config",
+      "name": "productcatalogservice.yaml",
+      "filePath": "kubernetes-manifests/productcatalogservice.yaml",
+      "summary": "Kubernetes manifest defining Deployment, Service, and ServiceAccount for the product catalog service, exposing gRPC on port 3550.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "catalog-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:kubernetes-manifests/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kubernetes-manifests/README.md",
+      "summary": "Brief notice explaining that kubernetes-manifests are not directly deployable and are meant for use with Skaffold to inject correct image tags.",
+      "tags": [
+        "documentation",
+        "kubernetes",
+        "deployment-guide"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kubernetes-manifests/recommendationservice.yaml",
+      "type": "config",
+      "name": "recommendationservice.yaml",
+      "filePath": "kubernetes-manifests/recommendationservice.yaml",
+      "summary": "Kubernetes manifest defining Deployment, Service, and ServiceAccount for the recommendation service, which depends on the product catalog service on port 3550.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "recommendation-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kubernetes-manifests/shippingservice.yaml",
+      "type": "config",
+      "name": "shippingservice.yaml",
+      "filePath": "kubernetes-manifests/shippingservice.yaml",
+      "summary": "Kubernetes manifest defining Deployment, Service, and ServiceAccount for the shipping service, exposing gRPC on port 50051.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "shipping-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/base/adservice.yaml",
+      "type": "config",
+      "name": "adservice.yaml",
+      "filePath": "kustomize/base/adservice.yaml",
+      "summary": "Kustomize base manifest for the ad service Deployment, Service, and ServiceAccount with pinned container image from Google Artifact Registry, exposing gRPC on port 9555.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "ad-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/base/cartservice.yaml",
+      "type": "config",
+      "name": "cartservice.yaml",
+      "filePath": "kustomize/base/cartservice.yaml",
+      "summary": "Kustomize base manifest for the cart service and its Redis backing store, defining Deployments, Services, and ServiceAccounts for both cartservice (port 7070) and redis-cart (port 6379).",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "cart-service",
+        "redis"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Includes two separate deployments in one manifest -- the cartservice application and a Redis instance used as its data store."
+    },
+    {
+      "id": "config:kustomize/base/checkoutservice.yaml",
+      "type": "config",
+      "name": "checkoutservice.yaml",
+      "filePath": "kustomize/base/checkoutservice.yaml",
+      "summary": "Kustomize base manifest for the checkout service, which orchestrates calls to six other microservices (product catalog, shipping, payment, email, currency, and cart) during order processing.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "checkout-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/base/currencyservice.yaml",
+      "type": "config",
+      "name": "currencyservice.yaml",
+      "filePath": "kustomize/base/currencyservice.yaml",
+      "summary": "Kustomize base manifest for the currency conversion service Deployment, Service, and ServiceAccount, exposing gRPC on port 7000.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "currency-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/base/emailservice.yaml",
+      "type": "config",
+      "name": "emailservice.yaml",
+      "filePath": "kustomize/base/emailservice.yaml",
+      "summary": "Kustomize base manifest for the email service Deployment, Service, and ServiceAccount with pinned container image, exposing gRPC on port 8080 with ClusterIP service on port 5000.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "email-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/base/frontend.yaml",
+      "type": "config",
+      "name": "frontend.yaml",
+      "filePath": "kustomize/base/frontend.yaml",
+      "summary": "Kustomize base manifest for the frontend web service with Deployment, internal and external Services, and ServiceAccount. Configures environment variables pointing to all backend microservices.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "frontend"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/base/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/base/kustomization.yaml",
+      "summary": "Kustomize base kustomization file aggregating all 11 microservice manifests as resources for composable Kubernetes deployments.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kustomize",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/base/loadgenerator.yaml",
+      "type": "config",
+      "name": "loadgenerator.yaml",
+      "filePath": "kustomize/base/loadgenerator.yaml",
+      "summary": "Kustomize base manifest for the load generator Deployment and ServiceAccount, using a busybox init container to wait for frontend availability before launching Locust traffic.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "load-testing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/base/paymentservice.yaml",
+      "type": "config",
+      "name": "paymentservice.yaml",
+      "filePath": "kustomize/base/paymentservice.yaml",
+      "summary": "Kustomize base manifest for the payment service Deployment, Service, and ServiceAccount with pinned container image, exposing gRPC on port 50051.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "payment-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/base/productcatalogservice.yaml",
+      "type": "config",
+      "name": "productcatalogservice.yaml",
+      "filePath": "kustomize/base/productcatalogservice.yaml",
+      "summary": "Kustomize base manifest for the product catalog service Deployment, Service, and ServiceAccount, exposing gRPC on port 3550.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "catalog-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/base/recommendationservice.yaml",
+      "type": "config",
+      "name": "recommendationservice.yaml",
+      "filePath": "kustomize/base/recommendationservice.yaml",
+      "summary": "Kustomize base manifest for the recommendation service Deployment, Service, and ServiceAccount, depending on product catalog service on port 3550.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "recommendation-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/base/shippingservice.yaml",
+      "type": "config",
+      "name": "shippingservice.yaml",
+      "filePath": "kustomize/base/shippingservice.yaml",
+      "summary": "Kustomize base manifest for the shipping service Deployment, Service, and ServiceAccount, exposing gRPC on port 50051.",
+      "tags": [
+        "orchestration",
+        "infrastructure",
+        "kubernetes",
+        "shipping-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/components/alloydb/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/alloydb/kustomization.yaml",
+      "summary": "Kustomize component that patches the cartservice Deployment to use AlloyDB instead of Redis by injecting AlloyDB connection environment variables and removing the redis-cart resources.",
+      "tags": [
+        "configuration",
+        "infrastructure",
+        "kustomize",
+        "database",
+        "alloydb"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses Kustomize strategic merge patches and JSON patches to swap the cart service backing store from Redis to AlloyDB."
+    },
+    {
+      "id": "document:kustomize/components/alloydb/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/alloydb/README.md",
+      "summary": "Step-by-step guide for provisioning an AlloyDB instance on Google Cloud, configuring credentials, and deploying Online Boutique with AlloyDB as the cart service backing database.",
+      "tags": [
+        "documentation",
+        "database",
+        "alloydb",
+        "deployment-guide",
+        "google-cloud"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/components/container-images-registry/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/container-images-registry/kustomization.yaml",
+      "summary": "Kustomize component that overrides the container image registry for all microservice deployments, enabling use of a custom or private container registry.",
+      "tags": [
+        "configuration",
+        "infrastructure",
+        "kustomize",
+        "container-registry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/container-images-registry/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/container-images-registry/README.md",
+      "summary": "Instructions for using the Kustomize component to override the default container image registry when deploying Online Boutique microservices.",
+      "tags": [
+        "documentation",
+        "container-registry",
+        "kustomize",
+        "deployment-guide"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/container-images-tag-suffix/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/container-images-tag-suffix/kustomization.yaml",
+      "summary": "Kustomize component that appends a configurable suffix to all Online Boutique container image tags, enabling environment-specific image versioning.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "container-images",
+        "deployment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/container-images-tag-suffix/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/container-images-tag-suffix/README.md",
+      "summary": "Documents how to add a suffix to Online Boutique container image tags using the Kustomize component, with usage examples and combination instructions.",
+      "tags": [
+        "documentation",
+        "kustomize",
+        "container-images"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/container-images-tag/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/container-images-tag/kustomization.yaml",
+      "summary": "Kustomize component that overrides the default container image tag for all Online Boutique services, allowing deployment of specific versions.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "container-images",
+        "deployment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/container-images-tag/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/container-images-tag/README.md",
+      "summary": "Documents how to update the container image tag for all Online Boutique apps via the Kustomize component.",
+      "tags": [
+        "documentation",
+        "kustomize",
+        "container-images"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/custom-base-url/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/custom-base-url/kustomization.yaml",
+      "summary": "Kustomize component that patches the frontend deployment to serve Online Boutique under a custom base URL path instead of root.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "frontend",
+        "routing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/custom-base-url/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/custom-base-url/README.md",
+      "summary": "Documents how to customize the base URL for the Online Boutique frontend, with detailed usage instructions and customization options.",
+      "tags": [
+        "documentation",
+        "kustomize",
+        "frontend",
+        "routing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/cymbal-branding/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/cymbal-branding/kustomization.yaml",
+      "summary": "Kustomize component that patches the frontend deployment to use Cymbal Shops branding instead of the default Online Boutique theme.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "branding",
+        "frontend"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/cymbal-branding/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/cymbal-branding/README.md",
+      "summary": "Documents how to switch the Online Boutique frontend to Cymbal Shops branding using the Kustomize component.",
+      "tags": [
+        "documentation",
+        "kustomize",
+        "branding",
+        "frontend"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/google-cloud-operations/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/google-cloud-operations/kustomization.yaml",
+      "summary": "Kustomize component that integrates all Online Boutique microservices with Google Cloud Operations by configuring OpenTelemetry exporters, profilers, and debuggers across service deployments.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "monitoring",
+        "google-cloud",
+        "observability"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "At 173 non-empty lines, this is the most complex Kustomize component, patching environment variables across all 11 microservices for telemetry integration."
+    },
+    {
+      "id": "config:kustomize/components/google-cloud-operations/otel-collector.yaml",
+      "type": "config",
+      "name": "otel-collector.yaml",
+      "filePath": "kustomize/components/google-cloud-operations/otel-collector.yaml",
+      "summary": "Kubernetes manifests defining the OpenTelemetry Collector Deployment, Service, and ConfigMap for receiving and exporting telemetry data to Google Cloud.",
+      "tags": [
+        "configuration",
+        "kubernetes",
+        "monitoring",
+        "opentelemetry",
+        "observability"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Multi-document YAML defining three Kubernetes resources (Deployment, Service, ConfigMap) for the OTel collector sidecar."
+    },
+    {
+      "id": "document:kustomize/components/google-cloud-operations/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/google-cloud-operations/README.md",
+      "summary": "Comprehensive guide for integrating Online Boutique with Google Cloud Operations (Cloud Trace, Cloud Profiler, Cloud Debugger), including OpenTelemetry Collector setup and Workload Identity configuration.",
+      "tags": [
+        "documentation",
+        "monitoring",
+        "google-cloud",
+        "observability"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/components/memorystore/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/memorystore/kustomization.yaml",
+      "summary": "Kustomize component that patches the cartservice deployment to connect to a Google Cloud Memorystore (Redis) instance instead of the in-cluster Redis, and removes the default redis-cart deployment.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "redis",
+        "google-cloud",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/memorystore/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/memorystore/README.md",
+      "summary": "Documents how to provision and connect Online Boutique to a Google Cloud Memorystore (Redis) instance, replacing the in-cluster Redis deployment.",
+      "tags": [
+        "documentation",
+        "redis",
+        "google-cloud",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/network-policies/kustomization.yaml",
+      "summary": "Kustomize component entry point that aggregates all network policy resource files for the Online Boutique microservices.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "network-policies",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-adservice.yaml",
+      "type": "config",
+      "name": "network-policy-adservice.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-adservice.yaml",
+      "summary": "Kubernetes NetworkPolicy restricting adservice ingress to only allow traffic from the frontend service.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-cartservice.yaml",
+      "type": "config",
+      "name": "network-policy-cartservice.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-cartservice.yaml",
+      "summary": "Kubernetes NetworkPolicy restricting cartservice ingress to only allow traffic from frontend and checkoutservice.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-checkoutservice.yaml",
+      "type": "config",
+      "name": "network-policy-checkoutservice.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-checkoutservice.yaml",
+      "summary": "Kubernetes NetworkPolicy restricting checkoutservice ingress to only allow traffic from the frontend service.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-currencyservice.yaml",
+      "type": "config",
+      "name": "network-policy-currencyservice.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-currencyservice.yaml",
+      "summary": "Kubernetes NetworkPolicy restricting currencyservice ingress to only allow traffic from frontend and checkoutservice.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-deny-all.yaml",
+      "type": "config",
+      "name": "network-policy-deny-all.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-deny-all.yaml",
+      "summary": "Default-deny Kubernetes NetworkPolicy that blocks all ingress and egress traffic in the namespace, forming the baseline for the zero-trust network model.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes",
+        "zero-trust"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-emailservice.yaml",
+      "type": "config",
+      "name": "network-policy-emailservice.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-emailservice.yaml",
+      "summary": "Kubernetes NetworkPolicy restricting emailservice ingress to only allow traffic from the checkoutservice.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-frontend.yaml",
+      "type": "config",
+      "name": "network-policy-frontend.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-frontend.yaml",
+      "summary": "Kubernetes NetworkPolicy for the frontend service allowing ingress from any source, as the frontend is the public-facing entry point.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-loadgenerator.yaml",
+      "type": "config",
+      "name": "network-policy-loadgenerator.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-loadgenerator.yaml",
+      "summary": "Kubernetes NetworkPolicy for the loadgenerator allowing egress to the frontend for synthetic traffic generation.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-paymentservice.yaml",
+      "type": "config",
+      "name": "network-policy-paymentservice.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-paymentservice.yaml",
+      "summary": "Kubernetes NetworkPolicy restricting paymentservice ingress to only allow traffic from the checkoutservice.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-productcatalogservice.yaml",
+      "type": "config",
+      "name": "network-policy-productcatalogservice.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-productcatalogservice.yaml",
+      "summary": "Kubernetes NetworkPolicy restricting productcatalogservice ingress to only allow traffic from frontend, checkoutservice, and recommendationservice.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-recommendationservice.yaml",
+      "type": "config",
+      "name": "network-policy-recommendationservice.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-recommendationservice.yaml",
+      "summary": "Kubernetes NetworkPolicy restricting recommendationservice ingress to only allow traffic from the frontend service.",
+      "tags": [
+        "configuration",
+        "network-policies",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-redis.yaml",
+      "type": "config",
+      "name": "network-policy-redis.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-redis.yaml",
+      "summary": "Kubernetes NetworkPolicy restricting ingress to the redis-cart pod to only the cartservice on port 6379, with unrestricted egress.",
+      "tags": [
+        "configuration",
+        "security",
+        "network-policy",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/network-policies/network-policy-shippingservice.yaml",
+      "type": "config",
+      "name": "network-policy-shippingservice.yaml",
+      "filePath": "kustomize/components/network-policies/network-policy-shippingservice.yaml",
+      "summary": "Kubernetes NetworkPolicy restricting ingress to the shippingservice pod to only the frontend and checkoutservice on gRPC port 50051.",
+      "tags": [
+        "configuration",
+        "security",
+        "network-policy",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/network-policies/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/network-policies/README.md",
+      "summary": "Documents how to deploy Online Boutique with fine-grained Kubernetes NetworkPolicies using the Kustomize component, including deployment steps and related resources.",
+      "tags": [
+        "documentation",
+        "security",
+        "network-policy",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/non-public-frontend/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/non-public-frontend/kustomization.yaml",
+      "summary": "Kustomize component that removes the frontend-external LoadBalancer Service, preventing public internet access to the frontend.",
+      "tags": [
+        "configuration",
+        "security",
+        "kubernetes",
+        "kustomize"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/non-public-frontend/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/non-public-frontend/README.md",
+      "summary": "Explains how to remove the public frontend endpoint from Online Boutique using the non-public-frontend Kustomize component.",
+      "tags": [
+        "documentation",
+        "security",
+        "kubernetes"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/service-mesh-istio/allow-egress-googleapis.yaml",
+      "type": "config",
+      "name": "allow-egress-googleapis.yaml",
+      "filePath": "kustomize/components/service-mesh-istio/allow-egress-googleapis.yaml",
+      "summary": "Istio ServiceEntry resources allowing mesh workloads to access googleapis.com and google.api endpoints for GCP service integration.",
+      "tags": [
+        "configuration",
+        "infrastructure",
+        "service-mesh",
+        "istio"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/service-mesh-istio/frontend-gateway.yaml",
+      "type": "config",
+      "name": "frontend-gateway.yaml",
+      "filePath": "kustomize/components/service-mesh-istio/frontend-gateway.yaml",
+      "summary": "Kubernetes Gateway API resources (Gateway and HTTPRoute) that expose the Online Boutique frontend through an Istio-managed ingress on port 80.",
+      "tags": [
+        "configuration",
+        "infrastructure",
+        "service-mesh",
+        "ingress"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/service-mesh-istio/frontend.yaml",
+      "type": "config",
+      "name": "frontend.yaml",
+      "filePath": "kustomize/components/service-mesh-istio/frontend.yaml",
+      "summary": "Istio VirtualService routing all HTTP traffic from the frontend-gateway to the frontend service on port 80.",
+      "tags": [
+        "configuration",
+        "service-mesh",
+        "istio",
+        "routing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/service-mesh-istio/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/service-mesh-istio/kustomization.yaml",
+      "summary": "Kustomize component that bundles Istio service mesh resources (egress rules, gateway, virtual service) and removes the frontend-external LoadBalancer Service.",
+      "tags": [
+        "configuration",
+        "service-mesh",
+        "kustomize",
+        "istio"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/service-mesh-istio/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/service-mesh-istio/README.md",
+      "summary": "Comprehensive guide for deploying Online Boutique with Istio service mesh, covering GKE cluster provisioning, managed Cloud Service Mesh and istioctl setup options, deployment verification, and additional service mesh demos.",
+      "tags": [
+        "documentation",
+        "service-mesh",
+        "istio",
+        "deployment",
+        "infrastructure"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "config:kustomize/components/shopping-assistant/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/shopping-assistant/kustomization.yaml",
+      "summary": "Kustomize component that adds the shoppingassistantservice Deployment and patches the frontend to enable the SHOPPING_ASSISTANT_SERVICE environment variable.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "shopping-assistant",
+        "feature-flag"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/shopping-assistant/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/shopping-assistant/README.md",
+      "summary": "Setup guide for the Shopping Assistant feature using RAG with AlloyDB, covering AlloyDB infrastructure deployment, database population, vector embeddings, and Kustomize component activation.",
+      "tags": [
+        "documentation",
+        "shopping-assistant",
+        "database",
+        "alloydb"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:kustomize/components/shopping-assistant/scripts/1_deploy_alloydb_infra.sh",
+      "type": "file",
+      "name": "1_deploy_alloydb_infra.sh",
+      "filePath": "kustomize/components/shopping-assistant/scripts/1_deploy_alloydb_infra.sh",
+      "summary": "Infrastructure provisioning script that creates AlloyDB cluster, instances (primary and read replicas), VPC peering, secrets, service accounts, and IAM bindings for the shopping assistant and cart services.",
+      "tags": [
+        "infrastructure",
+        "database",
+        "alloydb",
+        "provisioning",
+        "gcloud"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:kustomize/components/shopping-assistant/scripts/2_create_populate_alloydb_tables.sh",
+      "type": "file",
+      "name": "2_create_populate_alloydb_tables.sh",
+      "filePath": "kustomize/components/shopping-assistant/scripts/2_create_populate_alloydb_tables.sh",
+      "summary": "Database setup script that creates carts and products databases in AlloyDB, provisions tables with vector embedding support, populates product data from JSON, and generates text embeddings using Google's textembedding-gecko model.",
+      "tags": [
+        "database",
+        "migration",
+        "alloydb",
+        "vector-embeddings",
+        "setup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:kustomize/components/shopping-assistant/scripts/generate_sql_from_products.py",
+      "type": "file",
+      "name": "generate_sql_from_products.py",
+      "filePath": "kustomize/components/shopping-assistant/scripts/generate_sql_from_products.py",
+      "summary": "Python script that reads a products.json catalog file and generates SQL INSERT statements for the AlloyDB catalog_items table, including price and category fields.",
+      "tags": [
+        "utility",
+        "database",
+        "data-pipeline",
+        "sql-generation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/shopping-assistant/shoppingassistantservice.yaml",
+      "type": "config",
+      "name": "shoppingassistantservice.yaml",
+      "filePath": "kustomize/components/shopping-assistant/shoppingassistantservice.yaml",
+      "summary": "Kubernetes Deployment, Service, and ServiceAccount manifests for the shoppingassistantservice, configured with AlloyDB connection parameters, Google API key, and Workload Identity for GCP access.",
+      "tags": [
+        "configuration",
+        "kubernetes",
+        "deployment",
+        "shopping-assistant",
+        "alloydb"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/components/single-shared-session/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/single-shared-session/kustomization.yaml",
+      "summary": "Kustomize component that patches the frontend Deployment to enable a single shared session across all users by setting the ENABLE_SINGLE_SHARED_SESSION environment variable.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "feature-flag",
+        "session-management"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/single-shared-session/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/single-shared-session/README.md",
+      "summary": "Documents how to enable a single shared session for all Online Boutique users, useful for demos and kiosk setups.",
+      "tags": [
+        "documentation",
+        "session-management",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/spanner/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/spanner/kustomization.yaml",
+      "summary": "Kustomize component that replaces the Redis cart backend with Cloud Spanner by patching cartservice environment variables, adding GCP service account annotations, and removing redis-cart Deployment and Service.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "database",
+        "spanner",
+        "infrastructure"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:kustomize/components/spanner/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/spanner/README.md",
+      "summary": "Step-by-step guide for integrating Online Boutique's cartservice with Cloud Spanner, covering database provisioning, IAM configuration, Kustomize deployment, and connection string configuration.",
+      "tags": [
+        "documentation",
+        "database",
+        "spanner",
+        "deployment"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/components/without-loadgenerator/delete-loadgenerator.patch.yaml",
+      "type": "config",
+      "name": "delete-loadgenerator.patch.yaml",
+      "filePath": "kustomize/components/without-loadgenerator/delete-loadgenerator.patch.yaml",
+      "summary": "Kustomize strategic merge patch that deletes the loadgenerator Deployment from the Online Boutique deployment.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "patch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/components/without-loadgenerator/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/components/without-loadgenerator/kustomization.yaml",
+      "summary": "Kustomize component that removes the loadgenerator from deployment by applying the delete-loadgenerator patch.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "deployment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/components/without-loadgenerator/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/components/without-loadgenerator/README.md",
+      "summary": "Explains how to exclude the loadgenerator service from the Online Boutique deployment using the without-loadgenerator Kustomize component.",
+      "tags": [
+        "documentation",
+        "deployment",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/kustomization.yaml",
+      "summary": "Root Kustomization file for Online Boutique that references the base resources and lists all available optional Kustomize components (branding, monitoring, database backends, network policies, service mesh, etc.) as commented-out entries.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "entry-point",
+        "orchestration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/README.md",
+      "summary": "Primary documentation for deploying Online Boutique with Kustomize, covering prerequisites, default deployment steps, all available component variations (branding, monitoring, database backends, network policies, service mesh), and remote Kustomize targets.",
+      "tags": [
+        "documentation",
+        "entry-point",
+        "deployment",
+        "kustomize",
+        "overview"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:kustomize/tests/memorystore-with-all-components/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/tests/memorystore-with-all-components/kustomization.yaml",
+      "summary": "Kustomize test overlay that combines the base Online Boutique resources with all available components including Memorystore (Redis) as the cart database backend.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "testing",
+        "memorystore"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:kustomize/tests/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "kustomize/tests/README.md",
+      "summary": "Brief README for the kustomize tests directory explaining the purpose of test overlay configurations.",
+      "tags": [
+        "documentation",
+        "kustomize",
+        "testing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/tests/service-mesh-istio-with-all-components/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/tests/service-mesh-istio-with-all-components/kustomization.yaml",
+      "summary": "Kustomize test overlay combining the base resources with all components plus Istio service mesh configuration for integration testing.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "testing",
+        "istio",
+        "service-mesh"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:kustomize/tests/spanner-with-all-components/kustomization.yaml",
+      "type": "config",
+      "name": "kustomization.yaml",
+      "filePath": "kustomize/tests/spanner-with-all-components/kustomization.yaml",
+      "summary": "Kustomize test overlay combining the base resources with all components plus Cloud Spanner as the cart database backend.",
+      "tags": [
+        "configuration",
+        "kustomize",
+        "testing",
+        "spanner"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "schema:protos/demo.proto",
+      "type": "schema",
+      "name": "demo.proto",
+      "filePath": "protos/demo.proto",
+      "summary": "Master protobuf schema defining all 9 gRPC service interfaces (Cart, Recommendation, ProductCatalog, Shipping, Currency, Payment, Email, Checkout, Ad) and their 32 message types for inter-service communication across the Online Boutique.",
+      "tags": [
+        "schema-definition",
+        "grpc",
+        "api-schema",
+        "protobuf",
+        "core"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Defines the full service mesh contract; all microservices generate language-specific stubs from this single proto file."
+    },
+    {
+      "id": "schema:protos/grpc/health/v1/health.proto",
+      "type": "schema",
+      "name": "health.proto",
+      "filePath": "protos/grpc/health/v1/health.proto",
+      "summary": "Standard gRPC health checking protocol definition with HealthCheckRequest/Response messages and Health service, used by all microservices for liveness and readiness probes.",
+      "tags": [
+        "schema-definition",
+        "grpc",
+        "health-check",
+        "protobuf"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "README.md",
+      "summary": "Top-level project documentation for Online Boutique covering architecture overview with all 11 microservices, GKE quickstart deployment instructions, screenshots, and links to additional deployment options and demos.",
+      "tags": [
+        "documentation",
+        "entry-point",
+        "overview",
+        "architecture"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:release/istio-manifests.yaml",
+      "type": "config",
+      "name": "istio-manifests.yaml",
+      "filePath": "release/istio-manifests.yaml",
+      "summary": "Istio service mesh configuration defining a Gateway, HTTPRoute for the frontend, ServiceEntry rules for Google API egress, and a VirtualService for frontend routing.",
+      "tags": [
+        "configuration",
+        "istio",
+        "service-mesh",
+        "networking",
+        "infrastructure"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:release/kubernetes-manifests.yaml",
+      "type": "config",
+      "name": "kubernetes-manifests.yaml",
+      "filePath": "release/kubernetes-manifests.yaml",
+      "summary": "Complete Kubernetes manifest bundle containing Deployments and Services for all 11 Online Boutique microservices, defining container images, ports, environment variables, resource limits, and health checks for production deployment.",
+      "tags": [
+        "configuration",
+        "kubernetes",
+        "deployment",
+        "infrastructure",
+        "orchestration"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Single-file manifest with 980 lines covering all microservices; typically generated from Kustomize overlays for release."
+    },
+    {
+      "id": "config:skaffold.yaml",
+      "type": "config",
+      "name": "skaffold.yaml",
+      "filePath": "skaffold.yaml",
+      "summary": "Skaffold development workflow configuration defining build artifacts for all 11 microservices using Docker, with profiles for GCB cloud builds and separate config modules for the main app and load generator.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "development",
+        "skaffold",
+        "ci-cd"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/adservice/build.gradle",
+      "type": "file",
+      "name": "build.gradle",
+      "filePath": "src/adservice/build.gradle",
+      "summary": "Gradle build configuration for the Ad Service Java application, declaring dependencies on gRPC, OpenTelemetry tracing, and protobuf code generation plugins for the hipstershop proto definitions.",
+      "tags": [
+        "build-system",
+        "configuration",
+        "gradle",
+        "java"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "service:src/adservice/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/adservice/Dockerfile",
+      "summary": "Multi-stage Docker build for the Ad Service: compiles the Java application with Gradle in a build stage, then copies the installation to a minimal Eclipse Temurin JRE Alpine image exposing port 9555.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "java",
+        "deployment"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses multi-platform build support via BUILDPLATFORM ARG and a slim JRE-only runtime image for minimal container size."
+    },
+    {
+      "id": "file:src/adservice/genproto.sh",
+      "type": "file",
+      "name": "genproto.sh",
+      "filePath": "src/adservice/genproto.sh",
+      "summary": "Shell script that invokes the protobuf compiler (protoc) to generate Java gRPC stubs from the demo.proto service definitions for the Ad Service.",
+      "tags": [
+        "script",
+        "code-generation",
+        "protobuf",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/adservice/gradle/wrapper/gradle-wrapper.jar",
+      "type": "file",
+      "name": "gradle-wrapper.jar",
+      "filePath": "src/adservice/gradle/wrapper/gradle-wrapper.jar",
+      "summary": "Gradle wrapper JAR binary that bootstraps the correct Gradle version for building the Ad Service without requiring a pre-installed Gradle distribution.",
+      "tags": [
+        "build-system",
+        "gradle",
+        "binary"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/adservice/gradle/wrapper/gradle-wrapper.properties",
+      "type": "file",
+      "name": "gradle-wrapper.properties",
+      "filePath": "src/adservice/gradle/wrapper/gradle-wrapper.properties",
+      "summary": "Gradle wrapper properties specifying the Gradle distribution URL and version to download for consistent builds of the Ad Service.",
+      "tags": [
+        "configuration",
+        "gradle",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/adservice/gradlew",
+      "type": "file",
+      "name": "gradlew",
+      "filePath": "src/adservice/gradlew",
+      "summary": "Unix shell wrapper script for Gradle that locates a JDK, configures JVM options, and delegates to the Gradle wrapper JAR to execute build tasks.",
+      "tags": [
+        "build-system",
+        "gradle",
+        "script"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/adservice/gradlew.bat",
+      "type": "file",
+      "name": "gradlew.bat",
+      "filePath": "src/adservice/gradlew.bat",
+      "summary": "Windows batch wrapper script for Gradle that performs the same JDK discovery and Gradle delegation as the Unix gradlew script.",
+      "tags": [
+        "build-system",
+        "gradle",
+        "script"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:src/adservice/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "src/adservice/README.md",
+      "summary": "Documentation for the Ad Service microservice describing its role in serving contextual advertisements, build instructions, and development setup.",
+      "tags": [
+        "documentation",
+        "adservice",
+        "development"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/adservice/settings.gradle",
+      "type": "file",
+      "name": "settings.gradle",
+      "filePath": "src/adservice/settings.gradle",
+      "summary": "Gradle settings file declaring the root project name as 'hipstershop' for the Ad Service build.",
+      "tags": [
+        "configuration",
+        "gradle",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "type": "file",
+      "name": "AdService.java",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdService.java",
+      "summary": "Main Ad Service gRPC server implementation that serves contextual advertisements based on product category keys, with OpenTelemetry tracing and OpenCensus stats integration for observability.",
+      "tags": [
+        "api-handler",
+        "grpc",
+        "service",
+        "entry-point",
+        "java"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Implements gRPC AdServiceImplBase with a hardcoded ads map, OpenTelemetry tracer, and OpenCensus stats for request metrics."
+    },
+    {
+      "id": "class:src/adservice/src/main/java/hipstershop/AdService.java:AdService",
+      "type": "class",
+      "name": "AdService",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdService.java",
+      "lineRange": [
+        41,
+        238
+      ],
+      "summary": "Core gRPC server class managing the Ad Service lifecycle (start, stop, shutdown), implementing the GetAds RPC handler, and providing ad lookup by category with random fallback.",
+      "tags": [
+        "service",
+        "grpc",
+        "entry-point",
+        "singleton"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/adservice/src/main/java/hipstershop/AdService.java:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdService.java",
+      "lineRange": [
+        223,
+        237
+      ],
+      "summary": "Application entry point that initializes OpenTelemetry tracing, OpenCensus stats, creates the ads map, starts the gRPC server, and blocks until shutdown.",
+      "tags": [
+        "entry-point",
+        "initialization",
+        "main"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/adservice/src/main/java/hipstershop/AdService.java:getAds",
+      "type": "function",
+      "name": "getAds",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdService.java",
+      "lineRange": [
+        94,
+        118
+      ],
+      "summary": "gRPC handler for GetAds RPC that looks up ads matching context keys from the request, falls back to random ads if no matches found, and returns them via the response observer.",
+      "tags": [
+        "api-handler",
+        "grpc",
+        "business-logic"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/adservice/src/main/java/hipstershop/AdService.java:createAdsMap",
+      "type": "function",
+      "name": "createAdsMap",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdService.java",
+      "lineRange": [
+        149,
+        193
+      ],
+      "summary": "Builds the in-memory map of product category keys to advertisement objects, populating hardcoded ad entries for categories like clothing, accessories, and footwear.",
+      "tags": [
+        "data-model",
+        "initialization",
+        "static-data"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/adservice/src/main/java/hipstershop/AdService.java:start",
+      "type": "function",
+      "name": "start",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdService.java",
+      "lineRange": [
+        53,
+        75
+      ],
+      "summary": "Starts the gRPC server on the configured port with health check and server reflection services, adds a JVM shutdown hook for graceful termination.",
+      "tags": [
+        "lifecycle",
+        "server",
+        "initialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/adservice/src/main/java/hipstershop/AdService.java:initStats",
+      "type": "function",
+      "name": "initStats",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdService.java",
+      "lineRange": [
+        195,
+        207
+      ],
+      "summary": "Configures OpenCensus stats views for gRPC metrics collection including client/server latency, message counts, and error tracking.",
+      "tags": [
+        "monitoring",
+        "observability",
+        "opencensus"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/adservice/src/main/java/hipstershop/AdService.java:initTracing",
+      "type": "function",
+      "name": "initTracing",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdService.java",
+      "lineRange": [
+        209,
+        220
+      ],
+      "summary": "Initializes OpenTelemetry distributed tracing by obtaining a tracer from the global tracer provider for the Ad Service.",
+      "tags": [
+        "monitoring",
+        "observability",
+        "opentelemetry"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+      "type": "file",
+      "name": "AdServiceClient.java",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+      "summary": "Test client for the Ad Service that connects to the gRPC server and issues GetAds requests, useful for manual testing and debugging of the ad serving pipeline.",
+      "tags": [
+        "test",
+        "grpc",
+        "client",
+        "java"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/adservice/src/main/java/hipstershop/AdServiceClient.java:AdServiceClient",
+      "type": "class",
+      "name": "AdServiceClient",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+      "lineRange": [
+        32,
+        116
+      ],
+      "summary": "gRPC client class that connects to the Ad Service, sends GetAds requests with context keys, and prints the returned advertisements for testing purposes.",
+      "tags": [
+        "client",
+        "grpc",
+        "test-utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/adservice/src/main/java/hipstershop/AdServiceClient.java:getAds",
+      "type": "function",
+      "name": "getAds",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+      "lineRange": [
+        60,
+        74
+      ],
+      "summary": "Sends a GetAds gRPC request with a context key and logs the returned ad list, handling RPC errors with status code reporting.",
+      "tags": [
+        "grpc",
+        "client",
+        "test-utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/adservice/src/main/java/hipstershop/AdServiceClient.java:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+      "lineRange": [
+        101,
+        115
+      ],
+      "summary": "Entry point for the test client that parses host/port from command-line arguments, creates a client instance, and requests ads for a sample context key.",
+      "tags": [
+        "entry-point",
+        "main",
+        "test-utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "schema:src/adservice/src/main/proto/demo.proto",
+      "type": "schema",
+      "name": "demo.proto",
+      "filePath": "src/adservice/src/main/proto/demo.proto",
+      "summary": "Local copy of the master protobuf schema used by the Ad Service's Gradle build to generate Java gRPC stubs, defining all 9 service interfaces and their message types.",
+      "tags": [
+        "schema-definition",
+        "grpc",
+        "protobuf",
+        "code-generation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "config:src/adservice/src/main/resources/log4j2.xml",
+      "type": "config",
+      "name": "log4j2.xml",
+      "filePath": "src/adservice/src/main/resources/log4j2.xml",
+      "summary": "Log4j2 logging configuration for the Ad Service defining console appender format, root logger level, and package-specific log levels for gRPC and Netty libraries.",
+      "tags": [
+        "configuration",
+        "logging",
+        "java",
+        "observability"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/cartservice/cartservice.sln",
+      "type": "file",
+      "name": "cartservice.sln",
+      "filePath": "src/cartservice/cartservice.sln",
+      "summary": ".NET solution file for the Cart Service defining project references and build configurations (Debug/Release) for the C# cartservice project.",
+      "tags": [
+        "build-system",
+        "configuration",
+        "dotnet",
+        "csharp"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/cartservice/src/.dockerignore",
+      "type": "file",
+      "name": ".dockerignore",
+      "filePath": "src/cartservice/src/.dockerignore",
+      "summary": "Docker ignore file for the Cart Service excluding bin/obj build output directories from the Docker build context to reduce image size and build time.",
+      "tags": [
+        "configuration",
+        "docker",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:src/cartservice/src/appsettings.json",
+      "type": "config",
+      "name": "appsettings.json",
+      "filePath": "src/cartservice/src/appsettings.json",
+      "summary": "ASP.NET Core application settings for the cart service, configuring logging levels, allowed hosts, and Kestrel web server to listen on port 7070 with HTTP/2.",
+      "tags": [
+        "configuration",
+        "asp-net-core",
+        "kestrel",
+        "cart-service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/cartservice/src/cartservice.csproj",
+      "type": "file",
+      "name": "cartservice.csproj",
+      "filePath": "src/cartservice/src/cartservice.csproj",
+      "summary": ".NET project file for the cart service defining target framework, NuGet package dependencies including gRPC, Redis, Spanner, AlloyDB, and OpenTelemetry instrumentation.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "dotnet",
+        "cart-service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/cartservice/src/cartstore/AlloyDBCartStore.cs",
+      "type": "file",
+      "name": "AlloyDBCartStore.cs",
+      "filePath": "src/cartservice/src/cartstore/AlloyDBCartStore.cs",
+      "summary": "Implements the ICartStore interface using AlloyDB (PostgreSQL-compatible) as the backing store, supporting add item, get cart, empty cart, and health ping operations via Npgsql.",
+      "tags": [
+        "data-model",
+        "service",
+        "alloydb",
+        "cart-service",
+        "database"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses Npgsql for PostgreSQL/AlloyDB connections with parameterized SQL queries and upsert logic via ON CONFLICT."
+    },
+    {
+      "id": "class:src/cartservice/src/cartstore/AlloyDBCartStore.cs:AlloyDBCartStore",
+      "type": "class",
+      "name": "AlloyDBCartStore",
+      "filePath": "src/cartservice/src/cartstore/AlloyDBCartStore.cs",
+      "lineRange": [
+        25,
+        175
+      ],
+      "summary": "Cart storage implementation backed by AlloyDB, managing cart items through SQL queries with connection pooling via NpgsqlDataSource.",
+      "tags": [
+        "service",
+        "database",
+        "alloydb",
+        "cart-store"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/cartservice/src/cartstore/ICartStore.cs",
+      "type": "file",
+      "name": "ICartStore.cs",
+      "filePath": "src/cartservice/src/cartstore/ICartStore.cs",
+      "summary": "Defines the ICartStore interface contract with methods for adding items, getting carts, emptying carts, and health checking, serving as the abstraction layer for all cart storage backends.",
+      "tags": [
+        "type-definition",
+        "interface",
+        "cart-service",
+        "abstraction"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/cartservice/src/cartstore/ICartStore.cs:ICartStore",
+      "type": "class",
+      "name": "ICartStore",
+      "filePath": "src/cartservice/src/cartstore/ICartStore.cs",
+      "lineRange": [
+        19,
+        25
+      ],
+      "summary": "Interface defining the contract for cart storage backends with AddItemAsync, GetCartAsync, EmptyCartAsync, and Ping methods.",
+      "tags": [
+        "interface",
+        "type-definition",
+        "cart-store",
+        "abstraction"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/cartservice/src/cartstore/RedisCartStore.cs",
+      "type": "file",
+      "name": "RedisCartStore.cs",
+      "filePath": "src/cartservice/src/cartstore/RedisCartStore.cs",
+      "summary": "Implements ICartStore using Redis as the backing store, serializing cart data with Protocol Buffers and using StackExchange.Redis for connection management.",
+      "tags": [
+        "data-model",
+        "service",
+        "redis",
+        "cart-service",
+        "database"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses Google.Protobuf serialization to store cart data as byte arrays in Redis hash sets."
+    },
+    {
+      "id": "class:src/cartservice/src/cartstore/RedisCartStore.cs:RedisCartStore",
+      "type": "class",
+      "name": "RedisCartStore",
+      "filePath": "src/cartservice/src/cartstore/RedisCartStore.cs",
+      "lineRange": [
+        24,
+        117
+      ],
+      "summary": "Redis-backed cart store implementation that serializes cart items using Protobuf and stores them as Redis hash values.",
+      "tags": [
+        "service",
+        "redis",
+        "cart-store",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/cartservice/src/cartstore/SpannerCartStore.cs",
+      "type": "file",
+      "name": "SpannerCartStore.cs",
+      "filePath": "src/cartservice/src/cartstore/SpannerCartStore.cs",
+      "summary": "Implements ICartStore using Google Cloud Spanner as the backing store, with DML-based CRUD operations for cart items in a globally distributed database.",
+      "tags": [
+        "data-model",
+        "service",
+        "spanner",
+        "cart-service",
+        "database"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/cartservice/src/cartstore/SpannerCartStore.cs:SpannerCartStore",
+      "type": "class",
+      "name": "SpannerCartStore",
+      "filePath": "src/cartservice/src/cartstore/SpannerCartStore.cs",
+      "lineRange": [
+        23,
+        183
+      ],
+      "summary": "Spanner-backed cart store implementation using Google Cloud Spanner client library with DML statements for cart item management.",
+      "tags": [
+        "service",
+        "spanner",
+        "cart-store",
+        "google-cloud"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "service:src/cartservice/src/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/cartservice/src/Dockerfile",
+      "summary": "Multi-stage Docker build for the cart service that compiles the .NET application with self-contained publishing and produces a minimal chiseled Ubuntu runtime image exposing port 7070.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "dotnet",
+        "cart-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "service:src/cartservice/src/Dockerfile.debug",
+      "type": "service",
+      "name": "Dockerfile.debug",
+      "filePath": "src/cartservice/src/Dockerfile.debug",
+      "summary": "Debug-oriented Docker build for the cart service with three stages (build, publish, final) using the full ASP.NET runtime image for debugging support.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "debugging",
+        "cart-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/cartservice/src/Program.cs",
+      "type": "file",
+      "name": "Program.cs",
+      "filePath": "src/cartservice/src/Program.cs",
+      "summary": "Application entry point for the cart service that creates and runs the ASP.NET Core host using the Startup class for configuration.",
+      "tags": [
+        "entry-point",
+        "asp-net-core",
+        "cart-service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "schema:src/cartservice/src/protos/Cart.proto",
+      "type": "schema",
+      "name": "Cart.proto",
+      "filePath": "src/cartservice/src/protos/Cart.proto",
+      "summary": "Protocol Buffer schema defining the CartService gRPC API with AddItem, GetCart, and EmptyCart RPCs, along with message types for cart items, requests, and responses.",
+      "tags": [
+        "schema-definition",
+        "grpc",
+        "protobuf",
+        "cart-service",
+        "api-schema"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/cartservice/src/services/CartService.cs",
+      "type": "file",
+      "name": "CartService.cs",
+      "filePath": "src/cartservice/src/services/CartService.cs",
+      "summary": "gRPC service implementation for CartService that delegates AddItem, GetCart, and EmptyCart requests to the injected ICartStore backend.",
+      "tags": [
+        "api-handler",
+        "grpc",
+        "service",
+        "cart-service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/cartservice/src/services/CartService.cs:CartService",
+      "type": "class",
+      "name": "CartService",
+      "filePath": "src/cartservice/src/services/CartService.cs",
+      "lineRange": [
+        24,
+        50
+      ],
+      "summary": "gRPC service handler that implements the CartService proto contract by delegating to ICartStore for all cart operations.",
+      "tags": [
+        "api-handler",
+        "grpc",
+        "service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/cartservice/src/services/HealthCheckService.cs",
+      "type": "file",
+      "name": "HealthCheckService.cs",
+      "filePath": "src/cartservice/src/services/HealthCheckService.cs",
+      "summary": "gRPC health check service implementation that pings the underlying cart store to determine service health status.",
+      "tags": [
+        "api-handler",
+        "grpc",
+        "health-check",
+        "cart-service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/cartservice/src/services/HealthCheckService.cs:HealthCheckService",
+      "type": "class",
+      "name": "HealthCheckService",
+      "filePath": "src/cartservice/src/services/HealthCheckService.cs",
+      "lineRange": [
+        24,
+        40
+      ],
+      "summary": "Implements gRPC Health protocol by checking the backing cart store's connectivity via Ping.",
+      "tags": [
+        "health-check",
+        "grpc",
+        "service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/cartservice/src/Startup.cs",
+      "type": "file",
+      "name": "Startup.cs",
+      "filePath": "src/cartservice/src/Startup.cs",
+      "summary": "ASP.NET Core startup configuration that registers the appropriate cart store implementation (Redis, Spanner, or AlloyDB) based on environment variables and configures gRPC services with OpenTelemetry tracing.",
+      "tags": [
+        "configuration",
+        "entry-point",
+        "dependency-injection",
+        "cart-service"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses environment variable ALLOYDB_PRIMARY_IP_ADDR and SPANNER_CONNECTION_STRING to select the cart store backend at startup via dependency injection."
+    },
+    {
+      "id": "class:src/cartservice/src/Startup.cs:Startup",
+      "type": "class",
+      "name": "Startup",
+      "filePath": "src/cartservice/src/Startup.cs",
+      "lineRange": [
+        16,
+        83
+      ],
+      "summary": "Configures dependency injection for the cart service, selecting between AlloyDB, Spanner, or Redis cart stores and registering gRPC services.",
+      "tags": [
+        "configuration",
+        "dependency-injection",
+        "startup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/cartservice/tests/cartservice.tests.csproj",
+      "type": "file",
+      "name": "cartservice.tests.csproj",
+      "filePath": "src/cartservice/tests/cartservice.tests.csproj",
+      "summary": ".NET test project file referencing xUnit, Moq, and the main cartservice project for unit testing.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "test",
+        "dotnet"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/cartservice/tests/CartServiceTests.cs",
+      "type": "file",
+      "name": "CartServiceTests.cs",
+      "filePath": "src/cartservice/tests/CartServiceTests.cs",
+      "summary": "xUnit integration tests for the cart service gRPC API verifying empty cart retrieval, item update, and new item insertion against a real Redis instance.",
+      "tags": [
+        "test",
+        "grpc",
+        "integration-test",
+        "cart-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/cartservice/tests/CartServiceTests.cs:CartServiceTests",
+      "type": "class",
+      "name": "CartServiceTests",
+      "filePath": "src/cartservice/tests/CartServiceTests.cs",
+      "lineRange": [
+        27,
+        159
+      ],
+      "summary": "Test class with three integration tests covering cart retrieval, item update, and item insertion using a real gRPC client connection.",
+      "tags": [
+        "test",
+        "integration-test",
+        "xunit"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/checkoutservice/.dockerignore",
+      "type": "file",
+      "name": ".dockerignore",
+      "filePath": "src/checkoutservice/.dockerignore",
+      "summary": "Docker ignore file for the checkout service to exclude unnecessary files from the Docker build context.",
+      "tags": [
+        "configuration",
+        "containerization",
+        "checkout-service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "service:src/checkoutservice/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/checkoutservice/Dockerfile",
+      "summary": "Multi-stage Docker build for the checkout service that compiles the Go binary and produces a minimal distroless image exposing port 5050.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "golang",
+        "checkout-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/checkoutservice/genproto.sh",
+      "type": "file",
+      "name": "genproto.sh",
+      "filePath": "src/checkoutservice/genproto.sh",
+      "summary": "Shell script to regenerate Go gRPC/Protobuf stubs from the proto definition files in the project's protos directory.",
+      "tags": [
+        "script",
+        "code-generation",
+        "grpc",
+        "protobuf"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/checkoutservice/genproto/demo_grpc.pb.go",
+      "type": "file",
+      "name": "demo_grpc.pb.go",
+      "filePath": "src/checkoutservice/genproto/demo_grpc.pb.go",
+      "summary": "Auto-generated Go gRPC client and server stubs for all microservice APIs including CartService, RecommendationService, ProductCatalogService, ShippingService, CurrencyService, PaymentService, EmailService, CheckoutService, and AdService.",
+      "tags": [
+        "code-generation",
+        "grpc",
+        "api-handler",
+        "type-definition"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Auto-generated by protoc-gen-go-grpc; defines client/server interfaces and registration functions for 9 gRPC services."
+    },
+    {
+      "id": "file:src/checkoutservice/genproto/demo.pb.go",
+      "type": "file",
+      "name": "demo.pb.go",
+      "filePath": "src/checkoutservice/genproto/demo.pb.go",
+      "summary": "Auto-generated Go Protocol Buffer message types for all microservice APIs, defining request/response structures for cart, product catalog, shipping, currency, payment, email, checkout, and ad services.",
+      "tags": [
+        "code-generation",
+        "protobuf",
+        "type-definition",
+        "data-model"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Auto-generated by protoc-gen-go with 33+ message types and extensive field accessor methods."
+    },
+    {
+      "id": "file:src/checkoutservice/go.mod",
+      "type": "file",
+      "name": "go.mod",
+      "filePath": "src/checkoutservice/go.mod",
+      "summary": "Go module definition for the checkout service specifying dependencies including gRPC, OpenTelemetry, Cloud Profiler, and UUID generation.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "golang",
+        "checkout-service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/checkoutservice/go.sum",
+      "type": "file",
+      "name": "go.sum",
+      "filePath": "src/checkoutservice/go.sum",
+      "summary": "Go module checksum file ensuring reproducible builds by recording cryptographic hashes of all checkout service dependencies.",
+      "tags": [
+        "configuration",
+        "build-system",
+        "golang",
+        "lockfile"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/checkoutservice/main.go",
+      "type": "file",
+      "name": "main.go",
+      "filePath": "src/checkoutservice/main.go",
+      "summary": "Entry point and core business logic for the checkout service, implementing the PlaceOrder gRPC RPC by orchestrating calls to cart, product catalog, currency, shipping, payment, and email microservices.",
+      "tags": [
+        "entry-point",
+        "api-handler",
+        "grpc",
+        "checkout-service",
+        "service"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Implements the checkout workflow as a saga pattern across 6 downstream microservices with OpenTelemetry tracing and Cloud Profiler integration."
+    },
+    {
+      "id": "function:src/checkoutservice/main.go:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [
+        88,
+        148
+      ],
+      "summary": "Initializes tracing, profiling, and stats, establishes gRPC connections to all downstream services, and starts the checkout gRPC server on port 5050.",
+      "tags": [
+        "entry-point",
+        "initialization",
+        "grpc"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/checkoutservice/main.go:PlaceOrder",
+      "type": "function",
+      "name": "PlaceOrder",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [
+        230,
+        280
+      ],
+      "summary": "Handles the PlaceOrder gRPC request by coordinating cart retrieval, shipping quote, currency conversion, payment charging, order confirmation email, and cart emptying.",
+      "tags": [
+        "api-handler",
+        "checkout",
+        "orchestration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/checkoutservice/main.go:prepareOrderItemsAndShippingQuoteFromCart",
+      "type": "function",
+      "name": "prepareOrderItemsAndShippingQuoteFromCart",
+      "filePath": "src/checkoutservice/main.go",
+      "lineRange": [
+        288,
+        311
+      ],
+      "summary": "Retrieves the user's cart, prepares order items with current prices from the product catalog, and obtains a shipping cost quote.",
+      "tags": [
+        "checkout",
+        "orchestration",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/checkoutservice/money/money_test.go",
+      "type": "file",
+      "name": "money_test.go",
+      "filePath": "src/checkoutservice/money/money_test.go",
+      "summary": "Comprehensive table-driven unit tests for the money package covering validation, comparison, negation, summation, and currency arithmetic operations.",
+      "tags": [
+        "test",
+        "unit-test",
+        "money",
+        "checkout-service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/checkoutservice/money/money.go",
+      "type": "file",
+      "name": "money.go",
+      "filePath": "src/checkoutservice/money/money.go",
+      "summary": "Utility package providing safe arithmetic operations on Protocol Buffer Money types including validation, comparison, negation, summation, and multiplication with proper nanos overflow handling.",
+      "tags": [
+        "utility",
+        "money",
+        "arithmetic",
+        "checkout-service"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Operates on pb.Money protobuf types with careful nanos-to-units carry logic to prevent overflow."
+    },
+    {
+      "id": "function:src/checkoutservice/money/money.go:Sum",
+      "type": "function",
+      "name": "Sum",
+      "filePath": "src/checkoutservice/money/money.go",
+      "lineRange": [
+        93,
+        121
+      ],
+      "summary": "Adds two Money values of the same currency with proper nanos overflow handling and sign normalization.",
+      "tags": [
+        "utility",
+        "arithmetic",
+        "money"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/checkoutservice/money/money.go:MultiplySlow",
+      "type": "function",
+      "name": "MultiplySlow",
+      "filePath": "src/checkoutservice/money/money.go",
+      "lineRange": [
+        125,
+        132
+      ],
+      "summary": "Multiplies a Money value by a positive integer using repeated addition for correctness over performance.",
+      "tags": [
+        "utility",
+        "arithmetic",
+        "money"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:src/checkoutservice/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "src/checkoutservice/README.md",
+      "summary": "Minimal README for the checkout service, containing only the service name heading and a brief build command reference.",
+      "tags": [
+        "documentation",
+        "checkout-service",
+        "readme"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/currencyservice/.dockerignore",
+      "type": "file",
+      "name": ".dockerignore",
+      "filePath": "src/currencyservice/.dockerignore",
+      "summary": "Docker ignore file that excludes node_modules and npm-debug.log from the currency service Docker build context.",
+      "tags": [
+        "configuration",
+        "docker",
+        "currency-service"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/currencyservice/client.js",
+      "type": "file",
+      "name": "client.js",
+      "filePath": "src/currencyservice/client.js",
+      "summary": "Test client for the currency gRPC service that exercises GetSupportedCurrencies and Convert RPCs against localhost, useful for manual testing and debugging.",
+      "tags": [
+        "grpc-client",
+        "testing",
+        "currency-service",
+        "javascript"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:src/currencyservice/data/currency_conversion.json",
+      "type": "config",
+      "name": "currency_conversion.json",
+      "filePath": "src/currencyservice/data/currency_conversion.json",
+      "summary": "Static currency conversion rate data mapping 33 ISO 4217 currency codes to their EUR-based exchange rates, sourced from European Central Bank public data.",
+      "tags": [
+        "configuration",
+        "currency-data",
+        "exchange-rates",
+        "static-data"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "service:src/currencyservice/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/currencyservice/Dockerfile",
+      "summary": "Multi-stage Docker build for the Node.js currency service: installs npm dependencies with native build tools in a builder stage, then copies to a minimal Alpine image exposing port 7000.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "currency-service",
+        "node-js"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses multi-stage build to separate native compilation dependencies (python3, make, g++) from the lean runtime image."
+    },
+    {
+      "id": "file:src/currencyservice/genproto.sh",
+      "type": "file",
+      "name": "genproto.sh",
+      "filePath": "src/currencyservice/genproto.sh",
+      "summary": "Shell script to generate JavaScript protobuf stubs from the demo.proto definition using grpc_tools_node_protoc for the currency service.",
+      "tags": [
+        "code-generation",
+        "protobuf",
+        "currency-service",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:src/currencyservice/package.json",
+      "type": "config",
+      "name": "package.json",
+      "filePath": "src/currencyservice/package.json",
+      "summary": "Node.js package manifest for the currency service, declaring gRPC, OpenTelemetry tracing, and Google Cloud Profiler as runtime dependencies.",
+      "tags": [
+        "configuration",
+        "npm",
+        "currency-service",
+        "dependencies"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "schema:src/currencyservice/proto/demo.proto",
+      "type": "schema",
+      "name": "demo.proto",
+      "filePath": "src/currencyservice/proto/demo.proto",
+      "summary": "Core protobuf schema defining all 9 gRPC service interfaces (Cart, Recommendation, ProductCatalog, Shipping, Currency, Payment, Email, Checkout, Ad) and 32 message types for the Online Boutique microservices demo.",
+      "tags": [
+        "schema-definition",
+        "protobuf",
+        "grpc",
+        "api-schema",
+        "microservices"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Proto3 syntax with the hipstershop package; Money message uses units/nanos pattern for precise decimal representation."
+    },
+    {
+      "id": "schema:src/currencyservice/proto/grpc/health/v1/health.proto",
+      "type": "schema",
+      "name": "health.proto",
+      "filePath": "src/currencyservice/proto/grpc/health/v1/health.proto",
+      "summary": "Standard gRPC health checking protocol definition providing a Check RPC for service liveness and readiness probes.",
+      "tags": [
+        "schema-definition",
+        "protobuf",
+        "health-check",
+        "grpc"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/currencyservice/server.js",
+      "type": "file",
+      "name": "server.js",
+      "filePath": "src/currencyservice/server.js",
+      "summary": "Main gRPC server for the currency service implementing GetSupportedCurrencies and Convert RPCs, with OpenTelemetry tracing integration and Google Cloud Profiler support.",
+      "tags": [
+        "entry-point",
+        "grpc-server",
+        "currency-service",
+        "service",
+        "javascript"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Converts currencies through EUR as an intermediary using exchange rate data from a static JSON file."
+    },
+    {
+      "id": "function:src/currencyservice/server.js:convert",
+      "type": "function",
+      "name": "convert",
+      "filePath": "src/currencyservice/server.js",
+      "lineRange": [
+        138,
+        169
+      ],
+      "summary": "gRPC handler that converts a monetary amount between currencies by first normalizing to EUR and then to the target currency using stored exchange rates.",
+      "tags": [
+        "grpc-handler",
+        "currency-conversion",
+        "business-logic"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/currencyservice/server.js:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "src/currencyservice/server.js",
+      "lineRange": [
+        182,
+        196
+      ],
+      "summary": "Bootstraps the gRPC server, registering the CurrencyService and Health service handlers and binding to the configured port.",
+      "tags": [
+        "entry-point",
+        "server-bootstrap",
+        "grpc"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/currencyservice/server.js:_loadProto",
+      "type": "function",
+      "name": "_loadProto",
+      "filePath": "src/currencyservice/server.js",
+      "lineRange": [
+        91,
+        103
+      ],
+      "summary": "Loads and parses a protobuf file into a gRPC package definition with standard options for case and type handling.",
+      "tags": [
+        "utility",
+        "protobuf",
+        "grpc"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/emailservice/demo_pb2_grpc.py",
+      "type": "file",
+      "name": "demo_pb2_grpc.py",
+      "filePath": "src/emailservice/demo_pb2_grpc.py",
+      "summary": "Auto-generated Python gRPC stubs providing client stubs, server servicer base classes, and registration functions for all 9 hipstershop services (Cart, Recommendation, ProductCatalog, Shipping, Currency, Payment, Email, Checkout, Ad).",
+      "tags": [
+        "grpc",
+        "auto-generated",
+        "type-definition",
+        "service"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Generated by the gRPC Python protocol compiler plugin; contains Stub, Servicer, and experimental client classes for each service."
+    },
+    {
+      "id": "file:src/emailservice/demo_pb2.py",
+      "type": "file",
+      "name": "demo_pb2.py",
+      "filePath": "src/emailservice/demo_pb2.py",
+      "summary": "Auto-generated Python protobuf message definitions corresponding to the demo.proto schema, providing serialization and deserialization for all hipstershop message types.",
+      "tags": [
+        "protobuf",
+        "auto-generated",
+        "type-definition",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "service:src/emailservice/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/emailservice/Dockerfile",
+      "summary": "Multi-stage Docker build for the Python email service: compiles native dependencies in a builder stage, then copies Python packages to a slim Alpine image exposing port 8080.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "email-service",
+        "python"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Separates pip install with native compilation from runtime to reduce final image size; enables profiler by default via ENV."
+    },
+    {
+      "id": "file:src/emailservice/email_client.py",
+      "type": "file",
+      "name": "email_client.py",
+      "filePath": "src/emailservice/email_client.py",
+      "summary": "Test client for the email gRPC service that sends order confirmation requests to the local email server on port 8080 for debugging and manual testing.",
+      "tags": [
+        "grpc-client",
+        "testing",
+        "email-service",
+        "python"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/emailservice/email_server.py",
+      "type": "file",
+      "name": "email_server.py",
+      "filePath": "src/emailservice/email_server.py",
+      "summary": "Main gRPC server for the email service implementing SendOrderConfirmation via Jinja2 HTML templating, with a DummyEmailService for development that logs instead of sending real emails.",
+      "tags": [
+        "entry-point",
+        "grpc-server",
+        "email-service",
+        "service",
+        "python"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Runs in dummy mode by default since real cloud mail client integration is not yet implemented; supports OpenTelemetry tracing and Stackdriver Profiler."
+    },
+    {
+      "id": "class:src/emailservice/email_server.py:BaseEmailService",
+      "type": "class",
+      "name": "BaseEmailService",
+      "filePath": "src/emailservice/email_server.py",
+      "lineRange": [
+        52,
+        59
+      ],
+      "summary": "Base gRPC servicer class implementing health check endpoints (Check/Watch) for the email service.",
+      "tags": [
+        "grpc",
+        "health-check",
+        "base-class"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/emailservice/email_server.py:EmailService",
+      "type": "class",
+      "name": "EmailService",
+      "filePath": "src/emailservice/email_server.py",
+      "lineRange": [
+        61,
+        106
+      ],
+      "summary": "Cloud-based email service implementation that renders order confirmations using Jinja2 templates and sends via a cloud mail client (currently unimplemented).",
+      "tags": [
+        "grpc-handler",
+        "email",
+        "service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/emailservice/email_server.py:DummyEmailService",
+      "type": "class",
+      "name": "DummyEmailService",
+      "filePath": "src/emailservice/email_server.py",
+      "lineRange": [
+        108,
+        111
+      ],
+      "summary": "Development-mode email service that logs order confirmation requests instead of actually sending emails.",
+      "tags": [
+        "grpc-handler",
+        "mock",
+        "development"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/emailservice/email_server.py:start",
+      "type": "function",
+      "name": "start",
+      "filePath": "src/emailservice/email_server.py",
+      "lineRange": [
+        118,
+        137
+      ],
+      "summary": "Creates and starts the gRPC server with email and health servicers, binding to the configured port and blocking until interrupted.",
+      "tags": [
+        "entry-point",
+        "server-bootstrap",
+        "grpc"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/emailservice/genproto.sh",
+      "type": "file",
+      "name": "genproto.sh",
+      "filePath": "src/emailservice/genproto.sh",
+      "summary": "Shell script to generate Python protobuf and gRPC stubs from the demo.proto definition using grpc_tools.protoc for the email service.",
+      "tags": [
+        "code-generation",
+        "protobuf",
+        "email-service",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/emailservice/logger.py",
+      "type": "file",
+      "name": "logger.py",
+      "filePath": "src/emailservice/logger.py",
+      "summary": "Provides a JSON-formatted logger factory using python-json-logger with structured fields for timestamp, severity, and message, suitable for cloud log aggregation.",
+      "tags": [
+        "utility",
+        "logging",
+        "email-service",
+        "observability"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/emailservice/logger.py:CustomJsonFormatter",
+      "type": "class",
+      "name": "CustomJsonFormatter",
+      "filePath": "src/emailservice/logger.py",
+      "lineRange": [
+        23,
+        31
+      ],
+      "summary": "Custom JSON log formatter that normalizes timestamps and uppercases severity levels for consistent structured logging output.",
+      "tags": [
+        "logging",
+        "formatter",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/emailservice/logger.py:getJSONLogger",
+      "type": "function",
+      "name": "getJSONLogger",
+      "filePath": "src/emailservice/logger.py",
+      "lineRange": [
+        33,
+        41
+      ],
+      "summary": "Factory function that creates a named JSON logger with stdout output and INFO-level threshold, used by all email service modules.",
+      "tags": [
+        "utility",
+        "logging",
+        "factory"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/emailservice/requirements.in",
+      "type": "file",
+      "name": "requirements.in",
+      "filePath": "src/emailservice/requirements.in",
+      "summary": "Top-level Python dependency specification for the email service listing direct dependencies: grpcio, Jinja2, OpenTelemetry, and Google Cloud Profiler packages.",
+      "tags": [
+        "configuration",
+        "dependencies",
+        "email-service",
+        "python"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:src/emailservice/requirements.txt",
+      "type": "document",
+      "name": "requirements.txt",
+      "filePath": "src/emailservice/requirements.txt",
+      "summary": "Pinned Python dependency lockfile for the email service with 120 lines of versioned packages including gRPC, OpenTelemetry, Jinja2, and their transitive dependencies.",
+      "tags": [
+        "dependencies",
+        "python",
+        "email-service",
+        "lockfile"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/emailservice/templates/confirmation.html",
+      "type": "file",
+      "name": "confirmation.html",
+      "filePath": "src/emailservice/templates/confirmation.html",
+      "summary": "Jinja2 HTML email template for order confirmation, rendering order ID, shipping details, cost breakdown, and a list of purchased items with quantities.",
+      "tags": [
+        "template",
+        "email",
+        "html",
+        "jinja2"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/.dockerignore",
+      "type": "file",
+      "name": ".dockerignore",
+      "filePath": "src/frontend/.dockerignore",
+      "summary": "Docker ignore file for the frontend service build context.",
+      "tags": [
+        "configuration",
+        "docker",
+        "frontend"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/.gitkeep",
+      "type": "file",
+      "name": ".gitkeep",
+      "filePath": "src/frontend/.gitkeep",
+      "summary": "Empty placeholder file to preserve the frontend directory in version control.",
+      "tags": [
+        "placeholder",
+        "git",
+        "frontend"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/deployment_details.go",
+      "type": "file",
+      "name": "deployment_details.go",
+      "filePath": "src/frontend/deployment_details.go",
+      "summary": "Initializes deployment metadata (hostname, cluster name, zone) by querying the GCP metadata server asynchronously on startup, making it available for frontend UI display.",
+      "tags": [
+        "utility",
+        "gcp",
+        "frontend",
+        "metadata"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses a goroutine for GCP metadata API calls to avoid blocking non-GCP deployments on startup."
+    },
+    {
+      "id": "function:src/frontend/deployment_details.go:init",
+      "type": "function",
+      "name": "init",
+      "filePath": "src/frontend/deployment_details.go",
+      "lineRange": [
+        15,
+        20
+      ],
+      "summary": "Go init function that initializes the logger and spawns a background goroutine to load GCP deployment metadata.",
+      "tags": [
+        "initialization",
+        "go",
+        "entry-point"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/frontend/deployment_details.go:loadDeploymentDetails",
+      "type": "function",
+      "name": "loadDeploymentDetails",
+      "filePath": "src/frontend/deployment_details.go",
+      "lineRange": [
+        36,
+        64
+      ],
+      "summary": "Fetches pod hostname, cluster name, and zone from the GCP metadata server and stores them in a package-level map for deployment info display.",
+      "tags": [
+        "gcp",
+        "metadata",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "service:src/frontend/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/frontend/Dockerfile",
+      "summary": "Multi-stage Docker build for the Go frontend service: compiles the Go binary with Skaffold-compatible debug flags in a builder stage, then copies to a distroless static image with templates and static assets.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "frontend",
+        "golang"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses gcr.io/distroless/static for minimal attack surface; supports cross-compilation via TARGETOS/TARGETARCH build args."
+    },
+    {
+      "id": "file:src/frontend/genproto.sh",
+      "type": "file",
+      "name": "genproto.sh",
+      "filePath": "src/frontend/genproto.sh",
+      "summary": "Shell script to generate Go protobuf and gRPC stubs from the demo.proto definition using protoc with Go plugins for the frontend service.",
+      "tags": [
+        "code-generation",
+        "protobuf",
+        "frontend",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/genproto/demo_grpc.pb.go",
+      "type": "file",
+      "name": "demo_grpc.pb.go",
+      "filePath": "src/frontend/genproto/demo_grpc.pb.go",
+      "summary": "Auto-generated gRPC client and server stubs for all Online Boutique microservices (Cart, Recommendation, ProductCatalog, Shipping, Currency, Payment, Email, Checkout, Ad), providing typed RPC interfaces used by the frontend to communicate with backend services.",
+      "tags": [
+        "auto-generated",
+        "grpc",
+        "service",
+        "type-definition",
+        "api-handler"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Protobuf-generated Go code defining gRPC client/server interfaces with Unimplemented* and Unsafe* server types for forward compatibility."
+    },
+    {
+      "id": "file:src/frontend/genproto/demo.pb.go",
+      "type": "file",
+      "name": "demo.pb.go",
+      "filePath": "src/frontend/genproto/demo.pb.go",
+      "summary": "Auto-generated protobuf message types for the Online Boutique including CartItem, Product, Money, Address, Order, Ad, and all request/response types used in gRPC communication between microservices.",
+      "tags": [
+        "auto-generated",
+        "protobuf",
+        "data-model",
+        "type-definition",
+        "serialization"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Protobuf-generated Go code with ProtoReflect methods for runtime reflection and file_demo_proto_init for lazy initialization of the proto registry."
+    },
+    {
+      "id": "file:src/frontend/go.mod",
+      "type": "file",
+      "name": "go.mod",
+      "filePath": "src/frontend/go.mod",
+      "summary": "Go module definition for the frontend service declaring dependencies on gRPC, OpenTelemetry tracing, Gorilla mux router, and Google Cloud profiler.",
+      "tags": [
+        "configuration",
+        "dependency-management",
+        "go-module"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/go.sum",
+      "type": "file",
+      "name": "go.sum",
+      "filePath": "src/frontend/go.sum",
+      "summary": "Go module checksum file ensuring reproducible builds by pinning exact dependency versions and their cryptographic hashes.",
+      "tags": [
+        "configuration",
+        "dependency-management",
+        "go-module"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/handlers.go",
+      "type": "file",
+      "name": "handlers.go",
+      "filePath": "src/frontend/handlers.go",
+      "summary": "HTTP request handlers for the frontend web application, implementing routes for the home page, product details, cart management, checkout/order placement, currency switching, chatbot assistant, and error rendering with Go HTML templates.",
+      "tags": [
+        "api-handler",
+        "middleware",
+        "component",
+        "entry-point",
+        "utility"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/frontend/handlers.go:homeHandler",
+      "type": "function",
+      "name": "homeHandler",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [
+        59,
+        120
+      ],
+      "summary": "Renders the home page by fetching products, currencies, cart items, and ads, then converting product prices to the user's selected currency.",
+      "tags": [
+        "api-handler",
+        "rendering",
+        "aggregation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/frontend/handlers.go:productHandler",
+      "type": "function",
+      "name": "productHandler",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [
+        144,
+        209
+      ],
+      "summary": "Renders product detail page by fetching the product, converting its price, retrieving recommendations and ads, and optionally querying packaging info.",
+      "tags": [
+        "api-handler",
+        "rendering",
+        "aggregation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/frontend/handlers.go:viewCartHandler",
+      "type": "function",
+      "name": "viewCartHandler",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [
+        251,
+        318
+      ],
+      "summary": "Renders the shopping cart view by loading cart items, resolving product details, converting prices, calculating shipping quote, and fetching recommendations.",
+      "tags": [
+        "api-handler",
+        "rendering",
+        "cart"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/frontend/handlers.go:placeOrderHandler",
+      "type": "function",
+      "name": "placeOrderHandler",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [
+        320,
+        401
+      ],
+      "summary": "Processes checkout by validating credit card input, placing the order via the checkout service, and rendering the order confirmation page with converted prices.",
+      "tags": [
+        "api-handler",
+        "checkout",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/frontend/handlers.go:chatBotHandler",
+      "type": "function",
+      "name": "chatBotHandler",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [
+        451,
+        497
+      ],
+      "summary": "Handles chatbot requests by forwarding user messages to the shopping assistant gRPC service and streaming the response back as JSON.",
+      "tags": [
+        "api-handler",
+        "assistant",
+        "streaming"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/frontend/handlers.go:setCurrencyHandler",
+      "type": "function",
+      "name": "setCurrencyHandler",
+      "filePath": "src/frontend/handlers.go",
+      "lineRange": [
+        499,
+        523
+      ],
+      "summary": "Sets the user's preferred currency via a cookie and redirects back to the referring page.",
+      "tags": [
+        "api-handler",
+        "currency",
+        "session"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/main.go",
+      "type": "file",
+      "name": "main.go",
+      "filePath": "src/frontend/main.go",
+      "summary": "Application entry point that initializes the frontendServer, establishes gRPC connections to all backend microservices, configures OpenTelemetry tracing and Cloud Profiler, registers HTTP routes via Gorilla mux, and starts the HTTP server on port 8080.",
+      "tags": [
+        "entry-point",
+        "service",
+        "configuration",
+        "middleware"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/frontend/main.go:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "src/frontend/main.go",
+      "lineRange": [
+        91,
+        172
+      ],
+      "summary": "Bootstraps the frontend service by reading service addresses from environment variables, dialing gRPC backends, registering HTTP route handlers with middleware, and starting the web server.",
+      "tags": [
+        "entry-point",
+        "initialization",
+        "service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/frontend/main.go:frontendServer",
+      "type": "class",
+      "name": "frontendServer",
+      "filePath": "src/frontend/main.go",
+      "lineRange": [
+        63,
+        89
+      ],
+      "summary": "Central server struct holding gRPC client connections to all backend microservices (product catalog, currency, cart, recommendation, checkout, shipping, ad, and shopping assistant).",
+      "tags": [
+        "service",
+        "data-model",
+        "grpc"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/middleware.go",
+      "type": "file",
+      "name": "middleware.go",
+      "filePath": "src/frontend/middleware.go",
+      "summary": "HTTP middleware providing structured request/response logging with unique request IDs and session ID management via cookies, ensuring every request has a tracked session.",
+      "tags": [
+        "middleware",
+        "logging",
+        "session"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/frontend/middleware.go:ensureSessionID",
+      "type": "function",
+      "name": "ensureSessionID",
+      "filePath": "src/frontend/middleware.go",
+      "lineRange": [
+        85,
+        111
+      ],
+      "summary": "Middleware that ensures each request has a session ID cookie, generating a new UUID or using a shared session ID for demo mode.",
+      "tags": [
+        "middleware",
+        "session",
+        "authentication"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/money/money_test.go",
+      "type": "file",
+      "name": "money_test.go",
+      "filePath": "src/frontend/money/money_test.go",
+      "summary": "Comprehensive table-driven unit tests for the money package covering validation, comparison, arithmetic (sum, negate), and edge cases like mismatched currencies and overflow handling.",
+      "tags": [
+        "test",
+        "unit-test",
+        "money"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/money/money.go",
+      "type": "file",
+      "name": "money.go",
+      "filePath": "src/frontend/money/money.go",
+      "summary": "Utility package for protobuf Money type arithmetic and validation, providing functions for sum, negate, comparison, and sign checking with proper nanos overflow handling.",
+      "tags": [
+        "utility",
+        "money",
+        "validation",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/frontend/money/money.go:Sum",
+      "type": "function",
+      "name": "Sum",
+      "filePath": "src/frontend/money/money.go",
+      "lineRange": [
+        93,
+        121
+      ],
+      "summary": "Adds two Money values with matching currencies, handling nanos overflow and sign normalization between units and nanos fields.",
+      "tags": [
+        "utility",
+        "money",
+        "arithmetic"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/packaging_info.go",
+      "type": "file",
+      "name": "packaging_info.go",
+      "filePath": "src/frontend/packaging_info.go",
+      "summary": "Optional integration with a packaging microservice, fetching product packaging dimensions (weight, width, height, depth) via HTTP GET for display on product detail pages.",
+      "tags": [
+        "utility",
+        "service",
+        "http-client",
+        "integration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/frontend/packaging_info.go:httpGetPackagingInfo",
+      "type": "function",
+      "name": "httpGetPackagingInfo",
+      "filePath": "src/frontend/packaging_info.go",
+      "lineRange": [
+        50,
+        79
+      ],
+      "summary": "Makes an HTTP GET request to the packaging microservice and deserializes the JSON response into a PackagingInfo struct.",
+      "tags": [
+        "http-client",
+        "integration",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:src/frontend/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "src/frontend/README.md",
+      "summary": "Brief README for the frontend microservice directing readers to the top-level project documentation.",
+      "tags": [
+        "documentation",
+        "entry-point",
+        "overview"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/rpc.go",
+      "type": "file",
+      "name": "rpc.go",
+      "filePath": "src/frontend/rpc.go",
+      "summary": "gRPC client wrapper methods on frontendServer for calling backend microservices including product catalog, cart, currency conversion, shipping, recommendation, and ad services.",
+      "tags": [
+        "grpc",
+        "service",
+        "api-handler",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/frontend/rpc.go:getRecommendations",
+      "type": "function",
+      "name": "getRecommendations",
+      "filePath": "src/frontend/rpc.go",
+      "lineRange": [
+        99,
+        117
+      ],
+      "summary": "Fetches product recommendations for a user, resolves each recommended product ID to full product details, and limits results to 4 items for UI display.",
+      "tags": [
+        "grpc",
+        "recommendation",
+        "aggregation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:src/frontend/static/images/credits.txt",
+      "type": "document",
+      "name": "credits.txt",
+      "filePath": "src/frontend/static/images/credits.txt",
+      "summary": "Image attribution credits for product photos used in the Online Boutique storefront.",
+      "tags": [
+        "documentation",
+        "attribution",
+        "assets"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/static/styles/bot.css",
+      "type": "file",
+      "name": "bot.css",
+      "filePath": "src/frontend/static/styles/bot.css",
+      "summary": "Stylesheet for the shopping assistant chatbot UI, styling the chat overlay, message bubbles, input form, and loading animation.",
+      "tags": [
+        "stylesheet",
+        "assistant",
+        "component"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/static/styles/cart.css",
+      "type": "file",
+      "name": "cart.css",
+      "filePath": "src/frontend/static/styles/cart.css",
+      "summary": "Stylesheet for the shopping cart page, styling cart item rows, quantity display, pricing layout, and responsive adjustments.",
+      "tags": [
+        "stylesheet",
+        "cart",
+        "component"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/static/styles/order.css",
+      "type": "file",
+      "name": "order.css",
+      "filePath": "src/frontend/static/styles/order.css",
+      "summary": "Stylesheet for the order confirmation page, styling the order summary, item list, and shipping details.",
+      "tags": [
+        "stylesheet",
+        "order",
+        "component"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/static/styles/styles.css",
+      "type": "file",
+      "name": "styles.css",
+      "filePath": "src/frontend/static/styles/styles.css",
+      "summary": "Main global stylesheet for the Online Boutique storefront defining base typography, layout grid, header/footer styling, product cards, navigation, forms, and responsive breakpoints.",
+      "tags": [
+        "stylesheet",
+        "global",
+        "layout",
+        "component"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/frontend/templates/ad.html",
+      "type": "file",
+      "name": "ad.html",
+      "filePath": "src/frontend/templates/ad.html",
+      "summary": "Go HTML template partial rendering advertisement banners with redirect links and ad text, conditionally displayed when ads are available.",
+      "tags": [
+        "template",
+        "component",
+        "advertising"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/templates/assistant.html",
+      "type": "file",
+      "name": "assistant.html",
+      "filePath": "src/frontend/templates/assistant.html",
+      "summary": "Full-page Go HTML template for the shopping assistant chatbot interface, including JavaScript for message streaming, markdown rendering, and dynamic chat interaction.",
+      "tags": [
+        "template",
+        "assistant",
+        "component",
+        "entry-point"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/templates/cart.html",
+      "type": "file",
+      "name": "cart.html",
+      "filePath": "src/frontend/templates/cart.html",
+      "summary": "Go HTML template rendering the shopping cart page with item listing, quantity display, shipping cost, checkout form with credit card fields, and recommendation section.",
+      "tags": [
+        "template",
+        "cart",
+        "component",
+        "checkout"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/templates/error.html",
+      "type": "file",
+      "name": "error.html",
+      "filePath": "src/frontend/templates/error.html",
+      "summary": "Go HTML template for displaying HTTP error pages with status code and error message details.",
+      "tags": [
+        "template",
+        "error-handling",
+        "component"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/templates/footer.html",
+      "type": "file",
+      "name": "footer.html",
+      "filePath": "src/frontend/templates/footer.html",
+      "summary": "Go HTML template partial for the site footer showing platform details, session ID, request ID, and an OpenTelemetry tracing script for web instrumentation.",
+      "tags": [
+        "template",
+        "component",
+        "layout"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/templates/header.html",
+      "type": "file",
+      "name": "header.html",
+      "filePath": "src/frontend/templates/header.html",
+      "summary": "Go HTML template partial for the site header with brand logo, currency selector dropdown, cart icon with item count, and navigation bar.",
+      "tags": [
+        "template",
+        "component",
+        "layout",
+        "navigation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/templates/home.html",
+      "type": "file",
+      "name": "home.html",
+      "filePath": "src/frontend/templates/home.html",
+      "summary": "Go HTML template for the home page rendering a hero banner and a grid of product cards with images, names, and prices.",
+      "tags": [
+        "template",
+        "component",
+        "product-listing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/templates/order.html",
+      "type": "file",
+      "name": "order.html",
+      "filePath": "src/frontend/templates/order.html",
+      "summary": "Go HTML template for the order confirmation page displaying order ID, tracking ID, shipping cost, total price, and line items.",
+      "tags": [
+        "template",
+        "order",
+        "component"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/templates/product.html",
+      "type": "file",
+      "name": "product.html",
+      "filePath": "src/frontend/templates/product.html",
+      "summary": "Go HTML template rendering the product detail page, including product image, description, pricing, packaging info, an add-to-cart form, recommendations, and ad placement.",
+      "tags": [
+        "markup",
+        "component",
+        "frontend",
+        "template"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/templates/recommendations.html",
+      "type": "file",
+      "name": "recommendations.html",
+      "filePath": "src/frontend/templates/recommendations.html",
+      "summary": "Go HTML template partial that renders a horizontal list of recommended products with thumbnails and prices, included by the product and home page templates.",
+      "tags": [
+        "markup",
+        "component",
+        "frontend",
+        "template"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/frontend/validator/validator_test.go",
+      "type": "file",
+      "name": "validator_test.go",
+      "filePath": "src/frontend/validator/validator_test.go",
+      "summary": "Unit tests for the frontend request validator covering PlaceOrder, AddToCart, and SetCurrency payloads with both valid and invalid input scenarios.",
+      "tags": [
+        "test",
+        "validation",
+        "frontend",
+        "go"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/frontend/validator/validator.go",
+      "type": "file",
+      "name": "validator.go",
+      "filePath": "src/frontend/validator/validator.go",
+      "summary": "Defines request payload structs (AddToCart, PlaceOrder, SetCurrency) with struct-tag-based validation rules and a reusable error formatting function for the frontend service.",
+      "tags": [
+        "validation",
+        "utility",
+        "frontend",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/frontend/validator/validator.go:ValidationErrorResponse",
+      "type": "function",
+      "name": "ValidationErrorResponse",
+      "filePath": "src/frontend/validator/validator.go",
+      "lineRange": [
+        73,
+        83
+      ],
+      "summary": "Converts validation errors into a human-readable error message listing each invalid field and its violated constraint.",
+      "tags": [
+        "validation",
+        "error-handling",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/frontend/validator/validator.go:AddToCartPayload",
+      "type": "class",
+      "name": "AddToCartPayload",
+      "filePath": "src/frontend/validator/validator.go",
+      "lineRange": [
+        37,
+        40
+      ],
+      "summary": "Struct representing an add-to-cart request with quantity (1-10) and product ID validation constraints.",
+      "tags": [
+        "data-model",
+        "validation",
+        "frontend"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/frontend/validator/validator.go:PlaceOrderPayload",
+      "type": "class",
+      "name": "PlaceOrderPayload",
+      "filePath": "src/frontend/validator/validator.go",
+      "lineRange": [
+        42,
+        53
+      ],
+      "summary": "Struct representing a checkout/place-order request with validation for email, address, and credit card fields.",
+      "tags": [
+        "data-model",
+        "validation",
+        "frontend"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:src/frontend/validator/validator.go:SetCurrencyPayload",
+      "type": "class",
+      "name": "SetCurrencyPayload",
+      "filePath": "src/frontend/validator/validator.go",
+      "lineRange": [
+        55,
+        57
+      ],
+      "summary": "Struct representing a currency selection request with ISO 4217 currency code validation.",
+      "tags": [
+        "data-model",
+        "validation",
+        "frontend"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "service:src/loadgenerator/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/loadgenerator/Dockerfile",
+      "summary": "Multi-stage Dockerfile for the Locust-based load generator that installs Python dependencies and runs headless load tests against the frontend service.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "load-testing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/loadgenerator/locustfile.py",
+      "type": "file",
+      "name": "locustfile.py",
+      "filePath": "src/loadgenerator/locustfile.py",
+      "summary": "Locust load test script simulating realistic user behavior including browsing products, adding to cart, setting currency, and completing checkout with weighted task distribution.",
+      "tags": [
+        "load-testing",
+        "test",
+        "simulation",
+        "entry-point"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/loadgenerator/locustfile.py:UserBehavior",
+      "type": "class",
+      "name": "UserBehavior",
+      "filePath": "src/loadgenerator/locustfile.py",
+      "lineRange": [
+        78,
+        89
+      ],
+      "summary": "TaskSet defining weighted user actions (browse=10, viewCart=3, setCurrency=2, addToCart=2, checkout=1) to simulate realistic shopping traffic patterns.",
+      "tags": [
+        "load-testing",
+        "simulation",
+        "test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/loadgenerator/locustfile.py:checkout",
+      "type": "function",
+      "name": "checkout",
+      "filePath": "src/loadgenerator/locustfile.py",
+      "lineRange": [
+        58,
+        73
+      ],
+      "summary": "Simulates a full checkout flow by adding a random product to cart and posting fake credit card and address data generated by Faker.",
+      "tags": [
+        "load-testing",
+        "simulation",
+        "checkout"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/loadgenerator/requirements.in",
+      "type": "file",
+      "name": "requirements.in",
+      "filePath": "src/loadgenerator/requirements.in",
+      "summary": "Top-level Python dependency specification listing locust and faker as direct dependencies for the load generator.",
+      "tags": [
+        "configuration",
+        "dependency",
+        "python"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:src/loadgenerator/requirements.txt",
+      "type": "document",
+      "name": "requirements.txt",
+      "filePath": "src/loadgenerator/requirements.txt",
+      "summary": "Auto-generated pinned Python dependency file produced by uv pip compile, listing all transitive dependencies for the load generator.",
+      "tags": [
+        "dependency",
+        "python",
+        "configuration"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/paymentservice/.dockerignore",
+      "type": "file",
+      "name": ".dockerignore",
+      "filePath": "src/paymentservice/.dockerignore",
+      "summary": "Docker ignore file for the payment service excluding node_modules from the build context.",
+      "tags": [
+        "configuration",
+        "containerization",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/paymentservice/charge.js",
+      "type": "file",
+      "name": "charge.js",
+      "filePath": "src/paymentservice/charge.js",
+      "summary": "Core payment processing module that validates credit card numbers (VISA/MasterCard only), checks expiration dates, and returns a UUID transaction ID for simulated charges.",
+      "tags": [
+        "service",
+        "validation",
+        "payment",
+        "api-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "service:src/paymentservice/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/paymentservice/Dockerfile",
+      "summary": "Multi-stage Dockerfile for the Node.js payment service, building from a Node image then copying to a minimal Alpine runtime image exposing gRPC port 50051.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "deployment"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/paymentservice/genproto.sh",
+      "type": "file",
+      "name": "genproto.sh",
+      "filePath": "src/paymentservice/genproto.sh",
+      "summary": "Shell script that generates JavaScript gRPC client stubs from the protobuf definitions for the payment service.",
+      "tags": [
+        "script",
+        "code-generation",
+        "protobuf"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/paymentservice/index.js",
+      "type": "file",
+      "name": "index.js",
+      "filePath": "src/paymentservice/index.js",
+      "summary": "Entry point for the payment service that configures Google Cloud Profiler, optional OpenTelemetry tracing, and starts the gRPC HipsterShopServer.",
+      "tags": [
+        "entry-point",
+        "service",
+        "payment",
+        "observability"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/paymentservice/logger.js",
+      "type": "file",
+      "name": "logger.js",
+      "filePath": "src/paymentservice/logger.js",
+      "summary": "Configures and exports a pino logger instance with structured severity-based formatting for the payment service.",
+      "tags": [
+        "utility",
+        "logging",
+        "payment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:src/paymentservice/package.json",
+      "type": "config",
+      "name": "package.json",
+      "filePath": "src/paymentservice/package.json",
+      "summary": "Node.js package manifest for the payment service defining runtime dependencies including gRPC, OpenTelemetry, pino logger, and credit card validation.",
+      "tags": [
+        "configuration",
+        "dependency",
+        "nodejs"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "schema:src/paymentservice/proto/demo.proto",
+      "type": "schema",
+      "name": "demo.proto",
+      "filePath": "src/paymentservice/proto/demo.proto",
+      "summary": "Master protobuf schema defining all 10 gRPC service interfaces (Cart, Recommendation, ProductCatalog, Shipping, Currency, Payment, Email, Checkout, Ad) and their request/response messages for inter-service communication.",
+      "tags": [
+        "schema-definition",
+        "api-schema",
+        "protobuf",
+        "grpc"
+      ],
+      "complexity": "complex",
+      "languageNotes": "This is the shared service contract used across all microservices; each service imports this proto to generate language-specific stubs."
+    },
+    {
+      "id": "schema:src/paymentservice/proto/grpc/health/v1/health.proto",
+      "type": "schema",
+      "name": "health.proto",
+      "filePath": "src/paymentservice/proto/grpc/health/v1/health.proto",
+      "summary": "Standard gRPC health checking protocol definition with HealthCheckRequest/Response messages and a Health service with a Check RPC.",
+      "tags": [
+        "schema-definition",
+        "health-check",
+        "protobuf",
+        "grpc"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/paymentservice/server.js",
+      "type": "file",
+      "name": "server.js",
+      "filePath": "src/paymentservice/server.js",
+      "summary": "HipsterShopServer class implementing the gRPC PaymentService.Charge handler and health check endpoint, loading proto definitions and binding to the configured port.",
+      "tags": [
+        "service",
+        "api-handler",
+        "payment",
+        "grpc"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/productcatalogservice/.dockerignore",
+      "type": "file",
+      "name": ".dockerignore",
+      "filePath": "src/productcatalogservice/.dockerignore",
+      "summary": "Docker ignore file for the product catalog service.",
+      "tags": [
+        "configuration",
+        "containerization",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/productcatalogservice/catalog_loader.go",
+      "type": "file",
+      "name": "catalog_loader.go",
+      "filePath": "src/productcatalogservice/catalog_loader.go",
+      "summary": "Loads the product catalog either from a local JSON file or from Google Cloud AlloyDB, with Secret Manager integration for database credentials.",
+      "tags": [
+        "data-model",
+        "service",
+        "database",
+        "cloud"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Supports two catalog sources: local products.json for development, and AlloyDB with pgx connection pooling and AlloyDB Connector for production."
+    },
+    {
+      "id": "function:src/productcatalogservice/catalog_loader.go:loadCatalogFromAlloyDB",
+      "type": "function",
+      "name": "loadCatalogFromAlloyDB",
+      "filePath": "src/productcatalogservice/catalog_loader.go",
+      "lineRange": [
+        85,
+        161
+      ],
+      "summary": "Connects to AlloyDB via the AlloyDB Connector, retrieves product rows using pgx connection pooling, and populates the catalog with parsed product data.",
+      "tags": [
+        "database",
+        "cloud",
+        "data-loading"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/productcatalogservice/catalog_loader.go:getSecretPayload",
+      "type": "function",
+      "name": "getSecretPayload",
+      "filePath": "src/productcatalogservice/catalog_loader.go",
+      "lineRange": [
+        62,
+        83
+      ],
+      "summary": "Retrieves a secret value from Google Cloud Secret Manager given a project, secret name, and version.",
+      "tags": [
+        "cloud",
+        "security",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/productcatalogservice/catalog_loader.go:loadCatalogFromLocalFile",
+      "type": "function",
+      "name": "loadCatalogFromLocalFile",
+      "filePath": "src/productcatalogservice/catalog_loader.go",
+      "lineRange": [
+        44,
+        60
+      ],
+      "summary": "Reads and parses the local products.json file into the protobuf ListProductsResponse catalog structure.",
+      "tags": [
+        "data-loading",
+        "utility",
+        "file-io"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "service:src/productcatalogservice/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/productcatalogservice/Dockerfile",
+      "summary": "Multi-stage Dockerfile for the Go product catalog service, compiling the binary with CGO disabled and deploying to a distroless static image on port 3550.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "deployment"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/productcatalogservice/genproto.sh",
+      "type": "file",
+      "name": "genproto.sh",
+      "filePath": "src/productcatalogservice/genproto.sh",
+      "summary": "Shell script that generates Go gRPC client and server stubs from the demo protobuf definition for the product catalog service.",
+      "tags": [
+        "script",
+        "code-generation",
+        "protobuf"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/productcatalogservice/genproto/demo_grpc.pb.go",
+      "type": "file",
+      "name": "demo_grpc.pb.go",
+      "filePath": "src/productcatalogservice/genproto/demo_grpc.pb.go",
+      "summary": "Auto-generated Go gRPC client and server stubs for all 10 microservice interfaces including registration functions, handler wrappers, and unimplemented server base types.",
+      "tags": [
+        "code-generation",
+        "grpc",
+        "protobuf",
+        "api-handler"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Generated by protoc-gen-go-grpc; contains client constructors (NewXxxClient), server registration (RegisterXxxServer), and handler boilerplate for each service."
+    },
+    {
+      "id": "file:src/productcatalogservice/genproto/demo.pb.go",
+      "type": "file",
+      "name": "demo.pb.go",
+      "filePath": "src/productcatalogservice/genproto/demo.pb.go",
+      "summary": "Auto-generated Go protobuf message types and serialization code for all request/response messages used across the microservices demo.",
+      "tags": [
+        "code-generation",
+        "protobuf",
+        "data-model",
+        "type-definition"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Generated by protoc-gen-go; contains all message structs, getter methods, and protobuf wire format descriptors."
+    },
+    {
+      "id": "file:src/productcatalogservice/go.mod",
+      "type": "file",
+      "name": "go.mod",
+      "filePath": "src/productcatalogservice/go.mod",
+      "summary": "Go module definition for the product catalog service declaring dependencies on gRPC, OpenTelemetry, AlloyDB connector, pgx, and Google Cloud client libraries.",
+      "tags": [
+        "configuration",
+        "dependency",
+        "go"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/productcatalogservice/go.sum",
+      "type": "file",
+      "name": "go.sum",
+      "filePath": "src/productcatalogservice/go.sum",
+      "summary": "Go module checksum file for the product catalog service, ensuring reproducible dependency resolution.",
+      "tags": [
+        "configuration",
+        "dependency-management",
+        "go-modules"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/productcatalogservice/product_catalog_test.go",
+      "type": "file",
+      "name": "product_catalog_test.go",
+      "filePath": "src/productcatalogservice/product_catalog_test.go",
+      "summary": "Unit tests for the product catalog gRPC service, validating product retrieval, listing, search, and not-found error handling by spinning up an in-process gRPC server.",
+      "tags": [
+        "test",
+        "grpc",
+        "product-catalog",
+        "unit-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/productcatalogservice/product_catalog_test.go:TestMain",
+      "type": "function",
+      "name": "TestMain",
+      "filePath": "src/productcatalogservice/product_catalog_test.go",
+      "lineRange": [
+        31,
+        56
+      ],
+      "summary": "Test setup function that starts a gRPC server with the product catalog service, creates a client connection, and runs all tests.",
+      "tags": [
+        "test",
+        "setup",
+        "grpc"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/productcatalogservice/product_catalog_test.go:TestGetProductExists",
+      "type": "function",
+      "name": "TestGetProductExists",
+      "filePath": "src/productcatalogservice/product_catalog_test.go",
+      "lineRange": [
+        58,
+        68
+      ],
+      "summary": "Verifies that GetProduct returns a valid product with matching ID and non-empty name.",
+      "tags": [
+        "test",
+        "product-catalog",
+        "grpc"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/productcatalogservice/product_catalog_test.go:TestSearchProducts",
+      "type": "function",
+      "name": "TestSearchProducts",
+      "filePath": "src/productcatalogservice/product_catalog_test.go",
+      "lineRange": [
+        91,
+        101
+      ],
+      "summary": "Verifies that SearchProducts returns matching results for a keyword query.",
+      "tags": [
+        "test",
+        "product-catalog",
+        "search"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/productcatalogservice/product_catalog.go",
+      "type": "file",
+      "name": "product_catalog.go",
+      "filePath": "src/productcatalogservice/product_catalog.go",
+      "summary": "Implements the gRPC ProductCatalogService handlers (ListProducts, GetProduct, SearchProducts) with health check support, reading product data from a JSON catalog.",
+      "tags": [
+        "api-handler",
+        "grpc",
+        "product-catalog",
+        "service"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/productcatalogservice/product_catalog.go:productCatalog",
+      "type": "class",
+      "name": "productCatalog",
+      "filePath": "src/productcatalogservice/product_catalog.go",
+      "lineRange": [
+        28,
+        31
+      ],
+      "summary": "gRPC service implementation struct holding a reference to the product catalog loader, with methods for listing, getting, and searching products.",
+      "tags": [
+        "grpc",
+        "service",
+        "product-catalog"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/productcatalogservice/product_catalog.go:GetProduct",
+      "type": "function",
+      "name": "GetProduct",
+      "filePath": "src/productcatalogservice/product_catalog.go",
+      "lineRange": [
+        47,
+        58
+      ],
+      "summary": "Retrieves a single product by ID from the catalog, returning NOT_FOUND if no match exists.",
+      "tags": [
+        "grpc",
+        "api-handler",
+        "product-catalog"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/productcatalogservice/product_catalog.go:SearchProducts",
+      "type": "function",
+      "name": "SearchProducts",
+      "filePath": "src/productcatalogservice/product_catalog.go",
+      "lineRange": [
+        60,
+        72
+      ],
+      "summary": "Searches the product catalog by matching a query string against product names and descriptions.",
+      "tags": [
+        "grpc",
+        "api-handler",
+        "search"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:src/productcatalogservice/products.json",
+      "type": "config",
+      "name": "products.json",
+      "filePath": "src/productcatalogservice/products.json",
+      "summary": "Static product catalog data containing the list of products with their IDs, names, descriptions, pictures, prices, and categories for the Online Boutique storefront.",
+      "tags": [
+        "data",
+        "product-catalog",
+        "configuration",
+        "seed-data"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "document:src/productcatalogservice/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "src/productcatalogservice/README.md",
+      "summary": "Documentation for the product catalog service covering dynamic catalog reloading, artificial delay injection, bug triggering via environment variables, and latency injection features.",
+      "tags": [
+        "documentation",
+        "product-catalog",
+        "operations"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/productcatalogservice/server.go",
+      "type": "file",
+      "name": "server.go",
+      "filePath": "src/productcatalogservice/server.go",
+      "summary": "Main entry point for the product catalog gRPC microservice, initializing logging, tracing, profiling, and starting the gRPC server with OpenTelemetry instrumentation.",
+      "tags": [
+        "entry-point",
+        "grpc",
+        "service",
+        "observability"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Uses OpenTelemetry Go SDK for distributed tracing and Stackdriver profiling integration."
+    },
+    {
+      "id": "function:src/productcatalogservice/server.go:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "src/productcatalogservice/server.go",
+      "lineRange": [
+        68,
+        121
+      ],
+      "summary": "Application entry point that configures environment-driven tracing/profiling, creates a gRPC server with health checks, and starts listening on the configured port.",
+      "tags": [
+        "entry-point",
+        "grpc",
+        "initialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/productcatalogservice/server.go:run",
+      "type": "function",
+      "name": "run",
+      "filePath": "src/productcatalogservice/server.go",
+      "lineRange": [
+        123,
+        149
+      ],
+      "summary": "Starts the gRPC listener and registers the product catalog and health services on the server.",
+      "tags": [
+        "grpc",
+        "server",
+        "initialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/productcatalogservice/server.go:initTracing",
+      "type": "function",
+      "name": "initTracing",
+      "filePath": "src/productcatalogservice/server.go",
+      "lineRange": [
+        155,
+        177
+      ],
+      "summary": "Initializes OpenTelemetry tracing with OTLP gRPC exporter for distributed trace collection.",
+      "tags": [
+        "observability",
+        "tracing",
+        "opentelemetry"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/productcatalogservice/server.go:initProfiling",
+      "type": "function",
+      "name": "initProfiling",
+      "filePath": "src/productcatalogservice/server.go",
+      "lineRange": [
+        179,
+        197
+      ],
+      "summary": "Initializes Stackdriver profiling with retry logic for the product catalog service.",
+      "tags": [
+        "observability",
+        "profiling",
+        "gcp"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/recommendationservice/client.py",
+      "type": "file",
+      "name": "client.py",
+      "filePath": "src/recommendationservice/client.py",
+      "summary": "CLI test client for the recommendation gRPC service, making a ListRecommendations call with sample product IDs and printing the response.",
+      "tags": [
+        "utility",
+        "grpc",
+        "test-client",
+        "recommendation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/recommendationservice/demo_pb2_grpc.py",
+      "type": "file",
+      "name": "demo_pb2_grpc.py",
+      "filePath": "src/recommendationservice/demo_pb2_grpc.py",
+      "summary": "Auto-generated gRPC Python stubs and servicer base classes for all Online Boutique microservices (Cart, Recommendation, ProductCatalog, Shipping, Currency, Payment, Email, Checkout, Ad).",
+      "tags": [
+        "grpc",
+        "generated-code",
+        "protobuf",
+        "type-definition"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Generated by protoc-gen-grpc; contains stub classes for client-side and servicer base classes for server-side gRPC implementation."
+    },
+    {
+      "id": "file:src/recommendationservice/demo_pb2.py",
+      "type": "file",
+      "name": "demo_pb2.py",
+      "filePath": "src/recommendationservice/demo_pb2.py",
+      "summary": "Auto-generated Protocol Buffer Python message definitions for all Online Boutique service request/response types.",
+      "tags": [
+        "grpc",
+        "generated-code",
+        "protobuf",
+        "type-definition"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "service:src/recommendationservice/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/recommendationservice/Dockerfile",
+      "summary": "Multi-stage Docker build for the Python recommendation service, using Alpine base with compiled dependencies copied from a builder stage, exposing port 8080.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "deployment",
+        "python"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/recommendationservice/genproto.sh",
+      "type": "file",
+      "name": "genproto.sh",
+      "filePath": "src/recommendationservice/genproto.sh",
+      "summary": "Shell script that generates Python gRPC stubs from the demo.proto protobuf definition file using grpc_tools.protoc.",
+      "tags": [
+        "script",
+        "code-generation",
+        "protobuf",
+        "grpc"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/recommendationservice/logger.py",
+      "type": "file",
+      "name": "logger.py",
+      "filePath": "src/recommendationservice/logger.py",
+      "summary": "Provides a JSON-formatted logger factory for the recommendation service using Python's logging module with structured output suitable for cloud log aggregation.",
+      "tags": [
+        "utility",
+        "logging",
+        "observability"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/recommendationservice/recommendation_server.py",
+      "type": "file",
+      "name": "recommendation_server.py",
+      "filePath": "src/recommendationservice/recommendation_server.py",
+      "summary": "Main entry point for the recommendation gRPC microservice that suggests products by filtering out already-viewed items from the product catalog and returning a random sample of up to 5 alternatives.",
+      "tags": [
+        "entry-point",
+        "grpc",
+        "service",
+        "recommendation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/recommendationservice/recommendation_server.py:RecommendationService",
+      "type": "class",
+      "name": "RecommendationService",
+      "filePath": "src/recommendationservice/recommendation_server.py",
+      "lineRange": [
+        69,
+        94
+      ],
+      "summary": "gRPC servicer implementation that provides product recommendations by randomly sampling from the catalog after excluding already-viewed products, plus health check endpoints.",
+      "tags": [
+        "grpc",
+        "service",
+        "recommendation",
+        "api-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/recommendationservice/recommendation_server.py:ListRecommendations",
+      "type": "function",
+      "name": "ListRecommendations",
+      "filePath": "src/recommendationservice/recommendation_server.py",
+      "lineRange": [
+        70,
+        86
+      ],
+      "summary": "Fetches the full product catalog, filters out products the user has already seen, and returns a random sample of up to 5 product IDs as recommendations.",
+      "tags": [
+        "grpc",
+        "api-handler",
+        "recommendation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/recommendationservice/requirements.in",
+      "type": "file",
+      "name": "requirements.in",
+      "filePath": "src/recommendationservice/requirements.in",
+      "summary": "Top-level Python dependency specification for the recommendation service, listing direct dependencies like grpcio, protobuf, and OpenTelemetry packages.",
+      "tags": [
+        "configuration",
+        "dependency-management",
+        "python"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:src/recommendationservice/requirements.txt",
+      "type": "document",
+      "name": "requirements.txt",
+      "filePath": "src/recommendationservice/requirements.txt",
+      "summary": "Pinned Python dependency lock file for the recommendation service, generated by pip-compile with exact version constraints for reproducible builds.",
+      "tags": [
+        "configuration",
+        "dependency-management",
+        "python"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/shippingservice/.dockerignore",
+      "type": "file",
+      "name": ".dockerignore",
+      "filePath": "src/shippingservice/.dockerignore",
+      "summary": "Docker ignore file for the shipping service to exclude unnecessary files from the build context.",
+      "tags": [
+        "configuration",
+        "containerization",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "service:src/shippingservice/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/shippingservice/Dockerfile",
+      "summary": "Multi-stage Docker build for the Go shipping service, compiling a static binary with the golang Alpine builder and deploying to a distroless base image on port 50051.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "deployment",
+        "go"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Uses CGO_ENABLED=0 for a fully static Go binary compatible with distroless/static base image."
+    },
+    {
+      "id": "file:src/shippingservice/genproto.sh",
+      "type": "file",
+      "name": "genproto.sh",
+      "filePath": "src/shippingservice/genproto.sh",
+      "summary": "Shell script that generates Go gRPC stubs from the demo.proto protobuf definition file using protoc with the Go gRPC plugin.",
+      "tags": [
+        "script",
+        "code-generation",
+        "protobuf",
+        "grpc"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/shippingservice/genproto/demo_grpc.pb.go",
+      "type": "file",
+      "name": "demo_grpc.pb.go",
+      "filePath": "src/shippingservice/genproto/demo_grpc.pb.go",
+      "summary": "Auto-generated Go gRPC client stubs and server interfaces for all Online Boutique microservices, providing type-safe RPC method definitions and registration helpers.",
+      "tags": [
+        "grpc",
+        "generated-code",
+        "protobuf",
+        "type-definition"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/shippingservice/genproto/demo.pb.go",
+      "type": "file",
+      "name": "demo.pb.go",
+      "filePath": "src/shippingservice/genproto/demo.pb.go",
+      "summary": "Auto-generated Go Protocol Buffer message types for all Online Boutique service request/response structures including Cart, Product, Order, Money, and Address types.",
+      "tags": [
+        "grpc",
+        "generated-code",
+        "protobuf",
+        "type-definition"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:src/shippingservice/go.mod",
+      "type": "file",
+      "name": "go.mod",
+      "filePath": "src/shippingservice/go.mod",
+      "summary": "Go module definition for the shipping service, declaring the module path and dependencies including gRPC, logrus, and Google Cloud profiler.",
+      "tags": [
+        "configuration",
+        "dependency-management",
+        "go-modules"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/shippingservice/go.sum",
+      "type": "file",
+      "name": "go.sum",
+      "filePath": "src/shippingservice/go.sum",
+      "summary": "Go module checksum file for the shipping service, ensuring reproducible dependency resolution.",
+      "tags": [
+        "configuration",
+        "dependency-management",
+        "go-modules"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/shippingservice/main.go",
+      "type": "file",
+      "name": "main.go",
+      "filePath": "src/shippingservice/main.go",
+      "summary": "Main entry point for the shipping gRPC microservice that provides shipping quote calculation and mock order shipment with tracking ID generation, listening on port 50051.",
+      "tags": [
+        "entry-point",
+        "grpc",
+        "service",
+        "shipping"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:src/shippingservice/main.go:server",
+      "type": "class",
+      "name": "server",
+      "filePath": "src/shippingservice/main.go",
+      "lineRange": [
+        105,
+        107
+      ],
+      "summary": "gRPC server struct implementing the ShippingService interface with methods for health checks, shipping quotes, and order shipment.",
+      "tags": [
+        "grpc",
+        "service",
+        "shipping"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/shippingservice/main.go:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "src/shippingservice/main.go",
+      "lineRange": [
+        56,
+        102
+      ],
+      "summary": "Application entry point that initializes tracing, profiling, creates a gRPC server, registers the shipping service and health check, and starts listening.",
+      "tags": [
+        "entry-point",
+        "grpc",
+        "initialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/shippingservice/main.go:GetQuote",
+      "type": "function",
+      "name": "GetQuote",
+      "filePath": "src/shippingservice/main.go",
+      "lineRange": [
+        119,
+        138
+      ],
+      "summary": "gRPC handler that calculates a shipping quote in USD based on the total number of items in the request.",
+      "tags": [
+        "grpc",
+        "api-handler",
+        "shipping"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:src/shippingservice/main.go:ShipOrder",
+      "type": "function",
+      "name": "ShipOrder",
+      "filePath": "src/shippingservice/main.go",
+      "lineRange": [
+        142,
+        153
+      ],
+      "summary": "gRPC handler that mocks order shipment by generating a tracking ID from the shipping address.",
+      "tags": [
+        "grpc",
+        "api-handler",
+        "shipping"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/shippingservice/main.go:initProfiling",
+      "type": "function",
+      "name": "initProfiling",
+      "filePath": "src/shippingservice/main.go",
+      "lineRange": [
+        163,
+        183
+      ],
+      "summary": "Initializes Stackdriver profiling with up to 3 retries and exponential backoff.",
+      "tags": [
+        "observability",
+        "profiling",
+        "gcp"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/shippingservice/quote.go",
+      "type": "file",
+      "name": "quote.go",
+      "filePath": "src/shippingservice/quote.go",
+      "summary": "Provides shipping quote calculation utilities with a Quote struct representing dollar/cents values and factory functions for creating quotes from item counts or float prices.",
+      "tags": [
+        "utility",
+        "shipping",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/shippingservice/quote.go:CreateQuoteFromCount",
+      "type": "function",
+      "name": "CreateQuoteFromCount",
+      "filePath": "src/shippingservice/quote.go",
+      "lineRange": [
+        34,
+        39
+      ],
+      "summary": "Returns a flat $8.99 shipping quote for any non-zero item count, or $0 for empty orders.",
+      "tags": [
+        "utility",
+        "shipping",
+        "pricing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:src/shippingservice/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "src/shippingservice/README.md",
+      "summary": "Documentation for the shipping service covering its role in providing shipping quotes and tracking IDs within the Online Boutique demo.",
+      "tags": [
+        "documentation",
+        "shipping",
+        "overview"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:src/shippingservice/shippingservice_test.go",
+      "type": "file",
+      "name": "shippingservice_test.go",
+      "filePath": "src/shippingservice/shippingservice_test.go",
+      "summary": "Comprehensive test suite for the shipping service covering GetQuote, ShipOrder RPCs, tracking ID generation, quote creation from floats and counts, and helper function correctness.",
+      "tags": [
+        "test",
+        "grpc",
+        "shipping",
+        "service-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/shippingservice/tracker.go",
+      "type": "file",
+      "name": "tracker.go",
+      "filePath": "src/shippingservice/tracker.go",
+      "summary": "Generates pseudo-random shipment tracking IDs in a two-letter prefix plus numeric suffix format for the shipping service.",
+      "tags": [
+        "utility",
+        "shipping",
+        "tracking",
+        "random-generation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "service:src/shoppingassistantservice/Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "src/shoppingassistantservice/Dockerfile",
+      "summary": "Multi-stage Docker build for the shopping assistant service, using Python 3.14-slim with a separate builder stage for native dependencies and a minimal production image exposing port 8080.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "python",
+        "deployment"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Multi-stage build separates g++ compilation dependencies from the runtime image to reduce size."
+    },
+    {
+      "id": "file:src/shoppingassistantservice/requirements.in",
+      "type": "file",
+      "name": "requirements.in",
+      "filePath": "src/shoppingassistantservice/requirements.in",
+      "summary": "Top-level Python dependency specifications for the shopping assistant service, listing Flask, LangChain with Google Generative AI, AlloyDB, Pillow, and Secret Manager.",
+      "tags": [
+        "configuration",
+        "dependencies",
+        "python"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:src/shoppingassistantservice/requirements.txt",
+      "type": "document",
+      "name": "requirements.txt",
+      "filePath": "src/shoppingassistantservice/requirements.txt",
+      "summary": "Auto-generated pinned Python dependency lockfile produced by uv, containing the full transitive dependency tree for the shopping assistant service.",
+      "tags": [
+        "dependencies",
+        "python",
+        "lockfile"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:src/shoppingassistantservice/shoppingassistantservice.py",
+      "type": "file",
+      "name": "shoppingassistantservice.py",
+      "filePath": "src/shoppingassistantservice/shoppingassistantservice.py",
+      "summary": "Flask-based shopping assistant service implementing a RAG pipeline that uses Gemini vision to analyze room images, performs similarity search against an AlloyDB vector store, and returns interior design product recommendations.",
+      "tags": [
+        "api-handler",
+        "service",
+        "rag",
+        "generative-ai",
+        "flask"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Implements a three-step RAG pattern: image description via Gemini vision, vector similarity search on AlloyDB, and augmented generation for final recommendations."
+    },
+    {
+      "id": "resource:terraform/main.tf",
+      "type": "resource",
+      "name": "main.tf",
+      "filePath": "terraform/main.tf",
+      "summary": "Core Terraform configuration that enables Google Cloud APIs, provisions a GKE Autopilot cluster, retrieves cluster credentials, and deploys the Online Boutique application via kubectl apply.",
+      "tags": [
+        "infrastructure",
+        "deployment",
+        "gke",
+        "terraform",
+        "orchestration"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "resource:terraform/memorystore.tf",
+      "type": "resource",
+      "name": "memorystore.tf",
+      "filePath": "terraform/memorystore.tf",
+      "summary": "Optional Terraform configuration that provisions a Google Cloud Memorystore Redis instance and updates Kustomize manifests to replace in-cluster Redis with the managed instance.",
+      "tags": [
+        "infrastructure",
+        "redis",
+        "memorystore",
+        "terraform"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "resource:terraform/output.tf",
+      "type": "resource",
+      "name": "output.tf",
+      "filePath": "terraform/output.tf",
+      "summary": "Terraform outputs exposing the GKE cluster name and location for use by downstream automation or user reference.",
+      "tags": [
+        "infrastructure",
+        "terraform",
+        "outputs"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "resource:terraform/providers.tf",
+      "type": "resource",
+      "name": "providers.tf",
+      "filePath": "terraform/providers.tf",
+      "summary": "Terraform provider configuration pinning the Google provider to version 7.16.0 and setting the default project and region from variables.",
+      "tags": [
+        "infrastructure",
+        "terraform",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:terraform/README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "terraform/README.md",
+      "summary": "Step-by-step guide for deploying Online Boutique on GKE using Terraform, covering prerequisites, deployment commands, accessing the frontend, and cleanup procedures.",
+      "tags": [
+        "documentation",
+        "terraform",
+        "deployment",
+        "guide"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "resource:terraform/variables.tf",
+      "type": "resource",
+      "name": "variables.tf",
+      "filePath": "terraform/variables.tf",
+      "summary": "Terraform variable definitions for the Online Boutique deployment including GCP project ID, cluster name, region, namespace, manifest path, and Memorystore toggle.",
+      "tags": [
+        "infrastructure",
+        "terraform",
+        "configuration",
+        "variables"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/shippingservice/tracker.go:CreateTrackingId",
+      "type": "function",
+      "name": "CreateTrackingId",
+      "filePath": "src/shippingservice/tracker.go",
+      "lineRange": [
+        23,
+        32
+      ],
+      "summary": "Generates a formatted tracking ID string with random letter prefix, salt-derived digits, and random numeric suffixes.",
+      "tags": [
+        "utility",
+        "tracking",
+        "random-generation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:src/shoppingassistantservice/shoppingassistantservice.py:create_app",
+      "type": "function",
+      "name": "create_app",
+      "filePath": "src/shoppingassistantservice/shoppingassistantservice.py",
+      "lineRange": [
+        62,
+        116
+      ],
+      "summary": "Flask application factory that registers the main POST route implementing the three-step RAG pipeline for interior design recommendations.",
+      "tags": [
+        "api-handler",
+        "factory",
+        "flask",
+        "rag"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:src/shoppingassistantservice/shoppingassistantservice.py:talkToGemini",
+      "type": "function",
+      "name": "talkToGemini",
+      "filePath": "src/shoppingassistantservice/shoppingassistantservice.py",
+      "lineRange": [
+        66,
+        114
+      ],
+      "summary": "Route handler that performs room image analysis via Gemini vision, vector similarity search on product embeddings, and augmented generation to produce product recommendations.",
+      "tags": [
+        "api-handler",
+        "rag",
+        "generative-ai",
+        "vector-search"
+      ],
+      "complexity": "complex"
+    }
+  ],
+  "edges": [
+    {
+      "source": "file:.deploystack/test",
+      "target": "function:.deploystack/test:evalTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:.deploystack/test",
+      "target": "function:.deploystack/test:generateProject",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "config:.deploystack/test.yaml",
+      "target": "file:.deploystack/test",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:.github/release-cluster/README.md",
+      "target": "config:.github/release-cluster/frontend-ingress.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:.github/release-cluster/README.md",
+      "target": "config:.github/release-cluster/backend-config.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:.github/release-cluster/README.md",
+      "target": "config:.github/release-cluster/frontend-config.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:.github/release-cluster/README.md",
+      "target": "config:.github/release-cluster/managed-cert.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:.github/release-cluster/README.md",
+      "target": "config:.github/release-cluster/frontend-service.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:.github/release-cluster/frontend-ingress.yaml",
+      "target": "config:.github/release-cluster/frontend-service.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:.github/release-cluster/frontend-ingress.yaml",
+      "target": "config:.github/release-cluster/managed-cert.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:.github/release-cluster/frontend-ingress.yaml",
+      "target": "config:.github/release-cluster/frontend-config.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:.github/release-cluster/frontend-service.yaml",
+      "target": "config:.github/release-cluster/backend-config.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:.deploystack/deploystack.yaml",
+      "target": "document:.deploystack/messages/description.txt",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:.deploystack/deploystack.yaml",
+      "target": "document:.deploystack/messages/success.txt",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:.deploystack/deploystack.yaml",
+      "target": "file:.deploystack/scripts/preinit.sh",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "resource:.github/terraform/main.tf",
+      "target": "resource:.github/terraform/variables.tf",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "resource:.github/terraform/main.tf",
+      "target": "resource:.github/terraform/versions.tf",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:.github/terraform/README.md",
+      "target": "resource:.github/terraform/main.tf",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "pipeline:.github/workflows/ci-pr.yaml",
+      "target": "resource:.github/terraform/main.tf",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/ci-pr.yaml",
+      "target": "file:.github/workflows/install-dependencies.sh",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/ci-main.yaml",
+      "target": "file:.github/workflows/install-dependencies.sh",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/cleanup.yaml",
+      "target": "resource:.github/terraform/main.tf",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/helm-chart-ci.yaml",
+      "target": "file:.github/workflows/install-dependencies.sh",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/kubevious-manifests-ci.yaml",
+      "target": "file:.github/workflows/install-dependencies.sh",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/kustomize-build-ci.yaml",
+      "target": "file:.github/workflows/install-dependencies.sh",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/terraform-validate-ci.yaml",
+      "target": "resource:.github/terraform/main.tf",
+      "type": "triggers",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:.github/workflows/README.md",
+      "target": "pipeline:.github/workflows/ci-pr.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:.github/workflows/README.md",
+      "target": "pipeline:.github/workflows/cleanup.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:.github/workflows/README.md",
+      "target": "pipeline:.github/workflows/ci-main.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:docs/releasing/make-release.sh",
+      "target": "file:docs/releasing/make-docker-images.sh",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:docs/releasing/make-release.sh",
+      "target": "file:docs/releasing/make-release-artifacts.sh",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:docs/releasing/make-release.sh",
+      "target": "file:docs/releasing/make-helm-chart.sh",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:docs/releasing/make-release-artifacts.sh",
+      "target": "document:docs/releasing/license_header.txt",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:docs/releasing/make-release-artifacts.sh",
+      "target": "function:docs/releasing/make-release-artifacts.sh:mk_kubernetes_manifests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:docs/releasing/make-release-artifacts.sh",
+      "target": "function:docs/releasing/make-release-artifacts.sh:mk_kustomize_base",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:docs/releasing/make-release-artifacts.sh",
+      "target": "function:docs/releasing/make-release-artifacts.sh:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:docs/releasing/make-release-artifacts.sh",
+      "target": "function:docs/releasing/make-release-artifacts.sh:mk_kubernetes_manifests",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:docs/releasing/make-release-artifacts.sh",
+      "target": "function:docs/releasing/make-release-artifacts.sh:mk_kustomize_base",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:docs/releasing/make-release-artifacts.sh",
+      "target": "function:docs/releasing/make-release-artifacts.sh:main",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "document:docs/development-guide.md",
+      "target": "document:docs/adding-new-microservice.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:docs/purpose.md",
+      "target": "document:docs/product-requirements.md",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:helm-chart/README.md",
+      "target": "config:helm-chart/Chart.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:helm-chart/README.md",
+      "target": "config:helm-chart/values.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/adservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/cartservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/checkoutservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/currencyservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/emailservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/frontend.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/loadgenerator.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/opentelemetry-collector.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/paymentservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/productcatalogservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/recommendationservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/shippingservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/values.yaml",
+      "target": "config:helm-chart/templates/common.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:helm-chart/templates/common.yaml",
+      "target": "config:helm-chart/templates/adservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:helm-chart/templates/frontend.yaml",
+      "target": "config:istio-manifests/frontend-gateway.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:istio-manifests/frontend-gateway.yaml",
+      "target": "config:istio-manifests/frontend.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kubernetes-manifests/adservice.yaml",
+      "target": "config:helm-chart/templates/adservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kubernetes-manifests/cartservice.yaml",
+      "target": "config:helm-chart/templates/cartservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kubernetes-manifests/checkoutservice.yaml",
+      "target": "config:helm-chart/templates/checkoutservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kubernetes-manifests/currencyservice.yaml",
+      "target": "config:helm-chart/templates/currencyservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kubernetes-manifests/kustomization.yaml",
+      "target": "config:kubernetes-manifests/emailservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kubernetes-manifests/kustomization.yaml",
+      "target": "config:kubernetes-manifests/frontend.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kubernetes-manifests/kustomization.yaml",
+      "target": "config:kubernetes-manifests/paymentservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kubernetes-manifests/kustomization.yaml",
+      "target": "config:kubernetes-manifests/productcatalogservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kubernetes-manifests/kustomization.yaml",
+      "target": "config:kubernetes-manifests/recommendationservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kubernetes-manifests/kustomization.yaml",
+      "target": "config:kubernetes-manifests/shippingservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kubernetes-manifests/kustomization.yaml",
+      "target": "config:kubernetes-manifests/loadgenerator.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/adservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/cartservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/checkoutservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/currencyservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/emailservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/frontend.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/loadgenerator.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/paymentservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/productcatalogservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/recommendationservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/base/kustomization.yaml",
+      "target": "config:kustomize/base/shippingservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/alloydb/kustomization.yaml",
+      "target": "config:kustomize/base/cartservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:kustomize/components/alloydb/README.md",
+      "target": "config:kustomize/components/alloydb/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/container-images-registry/README.md",
+      "target": "config:kustomize/components/container-images-registry/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kubernetes-manifests/README.md",
+      "target": "config:kubernetes-manifests/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/checkoutservice.yaml",
+      "target": "config:kustomize/base/productcatalogservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/checkoutservice.yaml",
+      "target": "config:kustomize/base/shippingservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/checkoutservice.yaml",
+      "target": "config:kustomize/base/paymentservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/checkoutservice.yaml",
+      "target": "config:kustomize/base/emailservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/checkoutservice.yaml",
+      "target": "config:kustomize/base/currencyservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/checkoutservice.yaml",
+      "target": "config:kustomize/base/cartservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/frontend.yaml",
+      "target": "config:kustomize/base/checkoutservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/frontend.yaml",
+      "target": "config:kustomize/base/adservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/frontend.yaml",
+      "target": "config:kustomize/base/recommendationservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/recommendationservice.yaml",
+      "target": "config:kustomize/base/productcatalogservice.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/base/loadgenerator.yaml",
+      "target": "config:kustomize/base/frontend.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/components/container-images-registry/kustomization.yaml",
+      "target": "config:kustomize/base/kustomization.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:kustomize/components/container-images-tag-suffix/README.md",
+      "target": "config:kustomize/components/container-images-tag-suffix/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/container-images-tag/README.md",
+      "target": "config:kustomize/components/container-images-tag/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/custom-base-url/README.md",
+      "target": "config:kustomize/components/custom-base-url/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/cymbal-branding/README.md",
+      "target": "config:kustomize/components/cymbal-branding/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/google-cloud-operations/README.md",
+      "target": "config:kustomize/components/google-cloud-operations/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/google-cloud-operations/README.md",
+      "target": "config:kustomize/components/google-cloud-operations/otel-collector.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/components/google-cloud-operations/kustomization.yaml",
+      "target": "config:kustomize/components/google-cloud-operations/otel-collector.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:kustomize/components/memorystore/README.md",
+      "target": "config:kustomize/components/memorystore/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-deny-all.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-adservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-cartservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-checkoutservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-currencyservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-emailservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-frontend.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-loadgenerator.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-paymentservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-productcatalogservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/network-policies/kustomization.yaml",
+      "target": "config:kustomize/components/network-policies/network-policy-recommendationservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:kustomize/components/network-policies/README.md",
+      "target": "config:kustomize/components/network-policies/network-policy-redis.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/network-policies/README.md",
+      "target": "config:kustomize/components/network-policies/network-policy-shippingservice.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/non-public-frontend/README.md",
+      "target": "config:kustomize/components/non-public-frontend/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/components/service-mesh-istio/kustomization.yaml",
+      "target": "config:kustomize/components/service-mesh-istio/allow-egress-googleapis.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/service-mesh-istio/kustomization.yaml",
+      "target": "config:kustomize/components/service-mesh-istio/frontend-gateway.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:kustomize/components/service-mesh-istio/kustomization.yaml",
+      "target": "config:kustomize/components/service-mesh-istio/frontend.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:kustomize/components/service-mesh-istio/README.md",
+      "target": "config:kustomize/components/service-mesh-istio/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/components/shopping-assistant/kustomization.yaml",
+      "target": "config:kustomize/components/shopping-assistant/shoppingassistantservice.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:kustomize/components/shopping-assistant/README.md",
+      "target": "config:kustomize/components/shopping-assistant/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/shopping-assistant/README.md",
+      "target": "file:kustomize/components/shopping-assistant/scripts/1_deploy_alloydb_infra.sh",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/shopping-assistant/README.md",
+      "target": "file:kustomize/components/shopping-assistant/scripts/2_create_populate_alloydb_tables.sh",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:kustomize/components/shopping-assistant/scripts/2_create_populate_alloydb_tables.sh",
+      "target": "file:kustomize/components/shopping-assistant/scripts/generate_sql_from_products.py",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:kustomize/components/shopping-assistant/scripts/1_deploy_alloydb_infra.sh",
+      "target": "config:kustomize/components/shopping-assistant/shoppingassistantservice.yaml",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:kustomize/components/single-shared-session/README.md",
+      "target": "config:kustomize/components/single-shared-session/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/components/spanner/README.md",
+      "target": "config:kustomize/components/spanner/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/components/without-loadgenerator/kustomization.yaml",
+      "target": "config:kustomize/components/without-loadgenerator/delete-loadgenerator.patch.yaml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:kustomize/components/without-loadgenerator/README.md",
+      "target": "config:kustomize/components/without-loadgenerator/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:kustomize/README.md",
+      "target": "config:kustomize/kustomization.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/components/service-mesh-istio/frontend-gateway.yaml",
+      "target": "config:kustomize/components/service-mesh-istio/frontend.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:kustomize/components/non-public-frontend/kustomization.yaml",
+      "target": "config:kustomize/components/service-mesh-istio/kustomization.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "target": "class:src/adservice/src/main/java/hipstershop/AdService.java:AdService",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "target": "function:src/adservice/src/main/java/hipstershop/AdService.java:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "target": "function:src/adservice/src/main/java/hipstershop/AdService.java:getAds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "target": "function:src/adservice/src/main/java/hipstershop/AdService.java:createAdsMap",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "target": "function:src/adservice/src/main/java/hipstershop/AdService.java:start",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "target": "function:src/adservice/src/main/java/hipstershop/AdService.java:initStats",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "target": "function:src/adservice/src/main/java/hipstershop/AdService.java:initTracing",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "target": "schema:src/adservice/src/main/proto/demo.proto",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+      "target": "class:src/adservice/src/main/java/hipstershop/AdServiceClient.java:AdServiceClient",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+      "target": "function:src/adservice/src/main/java/hipstershop/AdServiceClient.java:getAds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+      "target": "function:src/adservice/src/main/java/hipstershop/AdServiceClient.java:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+      "target": "schema:src/adservice/src/main/proto/demo.proto",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "schema:src/adservice/src/main/proto/demo.proto",
+      "target": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "type": "defines_schema",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "schema:protos/demo.proto",
+      "target": "schema:src/adservice/src/main/proto/demo.proto",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "service:src/adservice/Dockerfile",
+      "target": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "config:src/adservice/src/main/resources/log4j2.xml",
+      "target": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:src/adservice/README.md",
+      "target": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/adservice/build.gradle",
+      "target": "schema:src/adservice/src/main/proto/demo.proto",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:src/adservice/genproto.sh",
+      "target": "schema:src/adservice/src/main/proto/demo.proto",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+      "target": "file:src/adservice/src/main/java/hipstershop/AdService.java",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:release/kubernetes-manifests.yaml",
+      "target": "service:src/adservice/Dockerfile",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "config:release/istio-manifests.yaml",
+      "target": "config:release/kubernetes-manifests.yaml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "schema:protos/demo.proto",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "config:release/kubernetes-manifests.yaml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:skaffold.yaml",
+      "target": "service:src/adservice/Dockerfile",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:src/cartservice/src/cartstore/AlloyDBCartStore.cs",
+      "target": "file:src/cartservice/src/cartstore/ICartStore.cs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/cartservice/src/cartstore/AlloyDBCartStore.cs",
+      "target": "class:src/cartservice/src/cartstore/AlloyDBCartStore.cs:AlloyDBCartStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "class:src/cartservice/src/cartstore/AlloyDBCartStore.cs:AlloyDBCartStore",
+      "target": "class:src/cartservice/src/cartstore/ICartStore.cs:ICartStore",
+      "type": "implements",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "file:src/cartservice/src/cartstore/ICartStore.cs",
+      "target": "class:src/cartservice/src/cartstore/ICartStore.cs:ICartStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/cartservice/src/cartstore/RedisCartStore.cs",
+      "target": "file:src/cartservice/src/cartstore/ICartStore.cs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/cartservice/src/cartstore/RedisCartStore.cs",
+      "target": "class:src/cartservice/src/cartstore/RedisCartStore.cs:RedisCartStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "class:src/cartservice/src/cartstore/RedisCartStore.cs:RedisCartStore",
+      "target": "class:src/cartservice/src/cartstore/ICartStore.cs:ICartStore",
+      "type": "implements",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "file:src/cartservice/src/cartstore/SpannerCartStore.cs",
+      "target": "file:src/cartservice/src/cartstore/ICartStore.cs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/cartservice/src/cartstore/SpannerCartStore.cs",
+      "target": "class:src/cartservice/src/cartstore/SpannerCartStore.cs:SpannerCartStore",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "class:src/cartservice/src/cartstore/SpannerCartStore.cs:SpannerCartStore",
+      "target": "class:src/cartservice/src/cartstore/ICartStore.cs:ICartStore",
+      "type": "implements",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "service:src/cartservice/src/Dockerfile",
+      "target": "file:src/cartservice/src/Program.cs",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "service:src/cartservice/src/Dockerfile.debug",
+      "target": "file:src/cartservice/src/Program.cs",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "config:src/cartservice/src/appsettings.json",
+      "target": "file:src/cartservice/src/Program.cs",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "schema:src/cartservice/src/protos/Cart.proto",
+      "target": "file:src/cartservice/src/services/CartService.cs",
+      "type": "defines_schema",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "schema:src/cartservice/src/protos/Cart.proto",
+      "target": "file:src/cartservice/src/services/HealthCheckService.cs",
+      "type": "defines_schema",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/cartservice/src/services/CartService.cs",
+      "target": "file:src/cartservice/src/cartstore/ICartStore.cs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/cartservice/src/services/CartService.cs",
+      "target": "class:src/cartservice/src/services/CartService.cs:CartService",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/cartservice/src/services/HealthCheckService.cs",
+      "target": "class:src/cartservice/src/services/HealthCheckService.cs:HealthCheckService",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/cartservice/src/Startup.cs",
+      "target": "file:src/cartservice/src/cartstore/ICartStore.cs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/cartservice/src/Startup.cs",
+      "target": "file:src/cartservice/src/cartstore/RedisCartStore.cs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/cartservice/src/Startup.cs",
+      "target": "file:src/cartservice/src/cartstore/AlloyDBCartStore.cs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/cartservice/src/Startup.cs",
+      "target": "file:src/cartservice/src/cartstore/SpannerCartStore.cs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/cartservice/src/Startup.cs",
+      "target": "file:src/cartservice/src/services/CartService.cs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/cartservice/src/Startup.cs",
+      "target": "file:src/cartservice/src/services/HealthCheckService.cs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/cartservice/src/Startup.cs",
+      "target": "class:src/cartservice/src/Startup.cs:Startup",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/cartservice/tests/CartServiceTests.cs",
+      "target": "class:src/cartservice/tests/CartServiceTests.cs:CartServiceTests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/cartservice/src/services/CartService.cs",
+      "target": "file:src/cartservice/tests/CartServiceTests.cs",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "service:src/checkoutservice/Dockerfile",
+      "target": "file:src/checkoutservice/main.go",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/checkoutservice/genproto/demo_grpc.pb.go",
+      "target": "file:src/checkoutservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/checkoutservice/main.go",
+      "target": "file:src/checkoutservice/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/checkoutservice/main.go",
+      "target": "file:src/checkoutservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/checkoutservice/main.go",
+      "target": "file:src/checkoutservice/money/money.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/checkoutservice/main.go",
+      "target": "function:src/checkoutservice/main.go:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/checkoutservice/main.go",
+      "target": "function:src/checkoutservice/main.go:PlaceOrder",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/checkoutservice/main.go",
+      "target": "function:src/checkoutservice/main.go:prepareOrderItemsAndShippingQuoteFromCart",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/checkoutservice/money/money_test.go",
+      "target": "file:src/checkoutservice/money/money.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/checkoutservice/money/money.go",
+      "target": "function:src/checkoutservice/money/money.go:Sum",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/checkoutservice/money/money.go",
+      "target": "function:src/checkoutservice/money/money.go:MultiplySlow",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/checkoutservice/money/money.go",
+      "target": "function:src/checkoutservice/money/money.go:Sum",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/checkoutservice/money/money.go",
+      "target": "function:src/checkoutservice/money/money.go:MultiplySlow",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/checkoutservice/money/money.go",
+      "target": "file:src/checkoutservice/money/money_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/currencyservice/server.js",
+      "target": "function:src/currencyservice/server.js:convert",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/currencyservice/server.js",
+      "target": "function:src/currencyservice/server.js:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/currencyservice/server.js",
+      "target": "function:src/currencyservice/server.js:_loadProto",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/emailservice/email_server.py",
+      "target": "class:src/emailservice/email_server.py:BaseEmailService",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/emailservice/email_server.py",
+      "target": "class:src/emailservice/email_server.py:EmailService",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/emailservice/email_server.py",
+      "target": "class:src/emailservice/email_server.py:DummyEmailService",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/emailservice/email_server.py",
+      "target": "function:src/emailservice/email_server.py:start",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/emailservice/logger.py",
+      "target": "class:src/emailservice/logger.py:CustomJsonFormatter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/emailservice/logger.py",
+      "target": "function:src/emailservice/logger.py:getJSONLogger",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/deployment_details.go",
+      "target": "function:src/frontend/deployment_details.go:init",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/deployment_details.go",
+      "target": "function:src/frontend/deployment_details.go:loadDeploymentDetails",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/currencyservice/client.js",
+      "target": "schema:src/currencyservice/proto/demo.proto",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/currencyservice/server.js",
+      "target": "schema:src/currencyservice/proto/demo.proto",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/currencyservice/server.js",
+      "target": "schema:src/currencyservice/proto/grpc/health/v1/health.proto",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/emailservice/demo_pb2_grpc.py",
+      "target": "file:src/emailservice/demo_pb2.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/emailservice/email_client.py",
+      "target": "file:src/emailservice/demo_pb2.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/emailservice/email_client.py",
+      "target": "file:src/emailservice/demo_pb2_grpc.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/emailservice/email_server.py",
+      "target": "file:src/emailservice/demo_pb2.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/emailservice/email_server.py",
+      "target": "file:src/emailservice/demo_pb2_grpc.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/emailservice/email_server.py",
+      "target": "file:src/emailservice/logger.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/emailservice/email_server.py",
+      "target": "file:src/emailservice/templates/confirmation.html",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "class:src/emailservice/email_server.py:EmailService",
+      "target": "class:src/emailservice/email_server.py:BaseEmailService",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:src/emailservice/email_server.py:DummyEmailService",
+      "target": "class:src/emailservice/email_server.py:BaseEmailService",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "schema:src/currencyservice/proto/demo.proto",
+      "target": "file:src/currencyservice/server.js",
+      "type": "defines_schema",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "schema:src/currencyservice/proto/demo.proto",
+      "target": "file:src/emailservice/email_server.py",
+      "type": "defines_schema",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "config:src/currencyservice/data/currency_conversion.json",
+      "target": "file:src/currencyservice/server.js",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:src/currencyservice/package.json",
+      "target": "file:src/currencyservice/server.js",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "service:src/currencyservice/Dockerfile",
+      "target": "file:src/currencyservice/server.js",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "service:src/emailservice/Dockerfile",
+      "target": "file:src/emailservice/email_server.py",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "service:src/frontend/Dockerfile",
+      "target": "file:src/frontend/deployment_details.go",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/emailservice/email_server.py",
+      "target": "function:src/emailservice/logger.py:getJSONLogger",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/emailservice/email_client.py",
+      "target": "function:src/emailservice/logger.py:getJSONLogger",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/frontend/genproto/demo_grpc.pb.go",
+      "target": "file:src/frontend/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/money/money.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/templates/home.html",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/templates/cart.html",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/templates/order.html",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/templates/error.html",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/templates/ad.html",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/templates/header.html",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/templates/footer.html",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/templates/assistant.html",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/main.go",
+      "target": "file:src/frontend/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/main.go",
+      "target": "file:src/frontend/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/main.go",
+      "target": "file:src/frontend/handlers.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/main.go",
+      "target": "file:src/frontend/rpc.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/main.go",
+      "target": "file:src/frontend/middleware.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/main.go",
+      "target": "file:src/frontend/packaging_info.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/money/money_test.go",
+      "target": "file:src/frontend/money/money.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/rpc.go",
+      "target": "file:src/frontend/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/rpc.go",
+      "target": "file:src/frontend/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/rpc.go",
+      "target": "file:src/frontend/money/money.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "function:src/frontend/handlers.go:homeHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "function:src/frontend/handlers.go:productHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "function:src/frontend/handlers.go:viewCartHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "function:src/frontend/handlers.go:placeOrderHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "function:src/frontend/handlers.go:chatBotHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "function:src/frontend/handlers.go:setCurrencyHandler",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/main.go",
+      "target": "function:src/frontend/main.go:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/main.go",
+      "target": "class:src/frontend/main.go:frontendServer",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/middleware.go",
+      "target": "function:src/frontend/middleware.go:ensureSessionID",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/money/money.go",
+      "target": "function:src/frontend/money/money.go:Sum",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/money/money.go",
+      "target": "function:src/frontend/money/money.go:Sum",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/frontend/packaging_info.go",
+      "target": "function:src/frontend/packaging_info.go:httpGetPackagingInfo",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/rpc.go",
+      "target": "function:src/frontend/rpc.go:getRecommendations",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/rpc.go",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/frontend/money/money.go",
+      "target": "file:src/frontend/money/money_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:src/frontend/README.md",
+      "target": "file:src/frontend/main.go",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/frontend/static/styles/styles.css",
+      "target": "file:src/frontend/templates/home.html",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/frontend/static/styles/cart.css",
+      "target": "file:src/frontend/templates/cart.html",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/frontend/static/styles/order.css",
+      "target": "file:src/frontend/templates/order.html",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/frontend/static/styles/bot.css",
+      "target": "file:src/frontend/templates/assistant.html",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/frontend/validator/validator.go",
+      "target": "function:src/frontend/validator/validator.go:ValidationErrorResponse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/validator/validator.go",
+      "target": "class:src/frontend/validator/validator.go:AddToCartPayload",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/validator/validator.go",
+      "target": "class:src/frontend/validator/validator.go:PlaceOrderPayload",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/validator/validator.go",
+      "target": "class:src/frontend/validator/validator.go:SetCurrencyPayload",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/frontend/validator/validator_test.go",
+      "target": "file:src/frontend/validator/validator.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/validator/validator.go",
+      "target": "file:src/frontend/validator/validator_test.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/loadgenerator/locustfile.py",
+      "target": "class:src/loadgenerator/locustfile.py:UserBehavior",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/loadgenerator/locustfile.py",
+      "target": "function:src/loadgenerator/locustfile.py:checkout",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "service:src/loadgenerator/Dockerfile",
+      "target": "file:src/loadgenerator/locustfile.py",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "service:src/loadgenerator/Dockerfile",
+      "target": "document:src/loadgenerator/requirements.txt",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:src/paymentservice/index.js",
+      "target": "file:src/paymentservice/charge.js",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/paymentservice/index.js",
+      "target": "file:src/paymentservice/logger.js",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/paymentservice/index.js",
+      "target": "file:src/paymentservice/server.js",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/paymentservice/index.js",
+      "target": "schema:src/paymentservice/proto/demo.proto",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/paymentservice/index.js",
+      "target": "schema:src/paymentservice/proto/grpc/health/v1/health.proto",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/paymentservice/server.js",
+      "target": "file:src/paymentservice/charge.js",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/paymentservice/server.js",
+      "target": "file:src/paymentservice/logger.js",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/paymentservice/server.js",
+      "target": "schema:src/paymentservice/proto/demo.proto",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/paymentservice/server.js",
+      "target": "schema:src/paymentservice/proto/grpc/health/v1/health.proto",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/paymentservice/server.js",
+      "target": "file:src/paymentservice/charge.js",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "service:src/paymentservice/Dockerfile",
+      "target": "file:src/paymentservice/index.js",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "config:src/paymentservice/package.json",
+      "target": "file:src/paymentservice/index.js",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "schema:src/paymentservice/proto/demo.proto",
+      "target": "file:src/paymentservice/server.js",
+      "type": "defines_schema",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "schema:src/paymentservice/proto/grpc/health/v1/health.proto",
+      "target": "file:src/paymentservice/server.js",
+      "type": "defines_schema",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/productcatalogservice/catalog_loader.go",
+      "target": "file:src/productcatalogservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/genproto/demo_grpc.pb.go",
+      "target": "file:src/productcatalogservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/catalog_loader.go",
+      "target": "function:src/productcatalogservice/catalog_loader.go:loadCatalogFromAlloyDB",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/catalog_loader.go",
+      "target": "function:src/productcatalogservice/catalog_loader.go:getSecretPayload",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/catalog_loader.go",
+      "target": "function:src/productcatalogservice/catalog_loader.go:loadCatalogFromLocalFile",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "service:src/productcatalogservice/Dockerfile",
+      "target": "file:src/productcatalogservice/catalog_loader.go",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog_test.go",
+      "target": "file:src/productcatalogservice/product_catalog.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog_test.go",
+      "target": "file:src/productcatalogservice/catalog_loader.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog_test.go",
+      "target": "file:src/productcatalogservice/server.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog_test.go",
+      "target": "file:src/productcatalogservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog.go",
+      "target": "file:src/productcatalogservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog.go",
+      "target": "file:src/productcatalogservice/catalog_loader.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/server.go",
+      "target": "file:src/productcatalogservice/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/server.go",
+      "target": "file:src/productcatalogservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/server.go",
+      "target": "file:src/productcatalogservice/catalog_loader.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/server.go",
+      "target": "file:src/productcatalogservice/product_catalog.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog_test.go",
+      "target": "file:src/productcatalogservice/product_catalog.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog.go",
+      "target": "class:src/productcatalogservice/product_catalog.go:productCatalog",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog.go",
+      "target": "function:src/productcatalogservice/product_catalog.go:GetProduct",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog.go",
+      "target": "function:src/productcatalogservice/product_catalog.go:SearchProducts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog.go",
+      "target": "function:src/productcatalogservice/product_catalog.go:GetProduct",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog.go",
+      "target": "function:src/productcatalogservice/product_catalog.go:SearchProducts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog.go",
+      "target": "class:src/productcatalogservice/product_catalog.go:productCatalog",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog_test.go",
+      "target": "function:src/productcatalogservice/product_catalog_test.go:TestMain",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog_test.go",
+      "target": "function:src/productcatalogservice/product_catalog_test.go:TestGetProductExists",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog_test.go",
+      "target": "function:src/productcatalogservice/product_catalog_test.go:TestSearchProducts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/server.go",
+      "target": "function:src/productcatalogservice/server.go:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/server.go",
+      "target": "function:src/productcatalogservice/server.go:run",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/server.go",
+      "target": "function:src/productcatalogservice/server.go:initTracing",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/productcatalogservice/server.go",
+      "target": "function:src/productcatalogservice/server.go:initProfiling",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "document:src/productcatalogservice/README.md",
+      "target": "file:src/productcatalogservice/server.go",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:src/productcatalogservice/products.json",
+      "target": "file:src/productcatalogservice/product_catalog.go",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:src/recommendationservice/client.py",
+      "target": "file:src/recommendationservice/demo_pb2.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/recommendationservice/client.py",
+      "target": "file:src/recommendationservice/demo_pb2_grpc.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/recommendationservice/demo_pb2_grpc.py",
+      "target": "file:src/recommendationservice/demo_pb2.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/recommendationservice/recommendation_server.py",
+      "target": "file:src/recommendationservice/demo_pb2.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/recommendationservice/recommendation_server.py",
+      "target": "file:src/recommendationservice/demo_pb2_grpc.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/recommendationservice/recommendation_server.py",
+      "target": "file:src/recommendationservice/logger.py",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/recommendationservice/recommendation_server.py",
+      "target": "class:src/recommendationservice/recommendation_server.py:RecommendationService",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/recommendationservice/recommendation_server.py",
+      "target": "function:src/recommendationservice/recommendation_server.py:ListRecommendations",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "class:src/recommendationservice/recommendation_server.py:RecommendationService",
+      "target": "function:src/recommendationservice/recommendation_server.py:ListRecommendations",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "service:src/recommendationservice/Dockerfile",
+      "target": "file:src/recommendationservice/recommendation_server.py",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/shippingservice/genproto/demo_grpc.pb.go",
+      "target": "file:src/shippingservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "file:src/shippingservice/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "file:src/shippingservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "file:src/shippingservice/quote.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "file:src/shippingservice/tracker.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "class:src/shippingservice/main.go:server",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "function:src/shippingservice/main.go:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "function:src/shippingservice/main.go:GetQuote",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "function:src/shippingservice/main.go:ShipOrder",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "function:src/shippingservice/main.go:initProfiling",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "function:src/shippingservice/main.go:GetQuote",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/shippingservice/main.go",
+      "target": "function:src/shippingservice/main.go:ShipOrder",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:src/shippingservice/main.go:GetQuote",
+      "target": "function:src/shippingservice/quote.go:CreateQuoteFromCount",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:src/shippingservice/quote.go",
+      "target": "function:src/shippingservice/quote.go:CreateQuoteFromCount",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/shippingservice/quote.go",
+      "target": "function:src/shippingservice/quote.go:CreateQuoteFromCount",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "service:src/shippingservice/Dockerfile",
+      "target": "file:src/shippingservice/main.go",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "document:src/shippingservice/README.md",
+      "target": "file:src/shippingservice/main.go",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/shippingservice/shippingservice_test.go",
+      "target": "file:src/shippingservice/main.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/shippingservice/shippingservice_test.go",
+      "target": "file:src/shippingservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/shippingservice/shippingservice_test.go",
+      "target": "file:src/shippingservice/main.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/shippingservice/shippingservice_test.go",
+      "target": "file:src/shippingservice/tracker.go",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/shippingservice/tracker.go",
+      "target": "function:src/shippingservice/tracker.go:CreateTrackingId",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/shippingservice/tracker.go",
+      "target": "function:src/shippingservice/tracker.go:CreateTrackingId",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "service:src/shoppingassistantservice/Dockerfile",
+      "target": "file:src/shoppingassistantservice/shoppingassistantservice.py",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/shoppingassistantservice/shoppingassistantservice.py",
+      "target": "function:src/shoppingassistantservice/shoppingassistantservice.py:create_app",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:src/shoppingassistantservice/shoppingassistantservice.py",
+      "target": "function:src/shoppingassistantservice/shoppingassistantservice.py:talkToGemini",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:src/shoppingassistantservice/shoppingassistantservice.py:create_app",
+      "target": "function:src/shoppingassistantservice/shoppingassistantservice.py:talkToGemini",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "resource:terraform/main.tf",
+      "target": "resource:terraform/variables.tf",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "resource:terraform/memorystore.tf",
+      "target": "resource:terraform/variables.tf",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "resource:terraform/providers.tf",
+      "target": "resource:terraform/variables.tf",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "resource:terraform/output.tf",
+      "target": "resource:terraform/main.tf",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:terraform/README.md",
+      "target": "resource:terraform/main.tf",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:terraform/README.md",
+      "target": "resource:terraform/variables.tf",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:src/shoppingassistantservice/requirements.txt",
+      "target": "file:src/shoppingassistantservice/requirements.in",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:src/shoppingassistantservice/requirements.in",
+      "target": "file:src/shoppingassistantservice/shoppingassistantservice.py",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:src/checkoutservice/main.go",
+      "target": "file:src/checkoutservice/money/money_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/checkoutservice/money/money.go",
+      "target": "file:src/checkoutservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/checkoutservice/money/money.go",
+      "target": "file:src/checkoutservice/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/checkoutservice/money/money_test.go",
+      "target": "file:src/checkoutservice/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/checkoutservice/money/money_test.go",
+      "target": "file:src/checkoutservice/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/currencyservice/server.js",
+      "target": "config:src/currencyservice/data/currency_conversion.json",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/money/money_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/validator/validator.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/handlers.go",
+      "target": "file:src/frontend/validator/validator_test.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/money/money.go",
+      "target": "file:src/frontend/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/money/money.go",
+      "target": "file:src/frontend/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/money/money_test.go",
+      "target": "file:src/frontend/genproto/demo.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/frontend/money/money_test.go",
+      "target": "file:src/frontend/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/catalog_loader.go",
+      "target": "file:src/productcatalogservice/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog.go",
+      "target": "file:src/productcatalogservice/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/productcatalogservice/product_catalog_test.go",
+      "target": "file:src/productcatalogservice/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:src/shippingservice/shippingservice_test.go",
+      "target": "file:src/shippingservice/genproto/demo_grpc.pb.go",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    }
+  ],
+  "layers": [
+    {
+      "id": "layer:frontend-service",
+      "name": "Frontend Service",
+      "description": "Go-based web frontend that serves the Online Boutique UI, handles HTTP requests, renders HTML templates, and orchestrates calls to all backend microservices via gRPC",
+      "nodeIds": [
+        "file:src/frontend/.dockerignore",
+        "file:src/frontend/.gitkeep",
+        "file:src/frontend/deployment_details.go",
+        "service:src/frontend/Dockerfile",
+        "file:src/frontend/genproto.sh",
+        "file:src/frontend/genproto/demo_grpc.pb.go",
+        "file:src/frontend/genproto/demo.pb.go",
+        "file:src/frontend/go.mod",
+        "file:src/frontend/go.sum",
+        "file:src/frontend/handlers.go",
+        "file:src/frontend/main.go",
+        "file:src/frontend/middleware.go",
+        "file:src/frontend/money/money_test.go",
+        "file:src/frontend/money/money.go",
+        "file:src/frontend/packaging_info.go",
+        "document:src/frontend/README.md",
+        "file:src/frontend/rpc.go",
+        "document:src/frontend/static/images/credits.txt",
+        "file:src/frontend/static/styles/bot.css",
+        "file:src/frontend/static/styles/cart.css",
+        "file:src/frontend/static/styles/order.css",
+        "file:src/frontend/static/styles/styles.css",
+        "file:src/frontend/templates/ad.html",
+        "file:src/frontend/templates/assistant.html",
+        "file:src/frontend/templates/cart.html",
+        "file:src/frontend/templates/error.html",
+        "file:src/frontend/templates/footer.html",
+        "file:src/frontend/templates/header.html",
+        "file:src/frontend/templates/home.html",
+        "file:src/frontend/templates/order.html",
+        "file:src/frontend/templates/product.html",
+        "file:src/frontend/templates/recommendations.html",
+        "file:src/frontend/validator/validator_test.go",
+        "file:src/frontend/validator/validator.go"
+      ]
+    },
+    {
+      "id": "layer:backend-services",
+      "name": "Backend Microservices",
+      "description": "Ten backend gRPC microservices implementing core e-commerce domain logic including cart, checkout, product catalog, payments, shipping, currency conversion, email notifications, recommendations, and ad serving across Go, C#, Java, Node.js, and Python",
+      "nodeIds": [
+        "file:src/adservice/build.gradle",
+        "service:src/adservice/Dockerfile",
+        "file:src/adservice/genproto.sh",
+        "file:src/adservice/gradle/wrapper/gradle-wrapper.jar",
+        "file:src/adservice/gradle/wrapper/gradle-wrapper.properties",
+        "file:src/adservice/gradlew",
+        "file:src/adservice/gradlew.bat",
+        "document:src/adservice/README.md",
+        "file:src/adservice/settings.gradle",
+        "file:src/adservice/src/main/java/hipstershop/AdService.java",
+        "file:src/adservice/src/main/java/hipstershop/AdServiceClient.java",
+        "schema:src/adservice/src/main/proto/demo.proto",
+        "config:src/adservice/src/main/resources/log4j2.xml",
+        "file:src/cartservice/cartservice.sln",
+        "file:src/cartservice/src/.dockerignore",
+        "config:src/cartservice/src/appsettings.json",
+        "file:src/cartservice/src/cartservice.csproj",
+        "file:src/cartservice/src/cartstore/AlloyDBCartStore.cs",
+        "file:src/cartservice/src/cartstore/ICartStore.cs",
+        "file:src/cartservice/src/cartstore/RedisCartStore.cs",
+        "file:src/cartservice/src/cartstore/SpannerCartStore.cs",
+        "service:src/cartservice/src/Dockerfile",
+        "service:src/cartservice/src/Dockerfile.debug",
+        "file:src/cartservice/src/Program.cs",
+        "schema:src/cartservice/src/protos/Cart.proto",
+        "file:src/cartservice/src/services/CartService.cs",
+        "file:src/cartservice/src/services/HealthCheckService.cs",
+        "file:src/cartservice/src/Startup.cs",
+        "file:src/cartservice/tests/cartservice.tests.csproj",
+        "file:src/cartservice/tests/CartServiceTests.cs",
+        "file:src/checkoutservice/.dockerignore",
+        "service:src/checkoutservice/Dockerfile",
+        "file:src/checkoutservice/genproto.sh",
+        "file:src/checkoutservice/genproto/demo_grpc.pb.go",
+        "file:src/checkoutservice/genproto/demo.pb.go",
+        "file:src/checkoutservice/go.mod",
+        "file:src/checkoutservice/go.sum",
+        "file:src/checkoutservice/main.go",
+        "file:src/checkoutservice/money/money_test.go",
+        "file:src/checkoutservice/money/money.go",
+        "document:src/checkoutservice/README.md",
+        "file:src/currencyservice/.dockerignore",
+        "file:src/currencyservice/client.js",
+        "config:src/currencyservice/data/currency_conversion.json",
+        "service:src/currencyservice/Dockerfile",
+        "file:src/currencyservice/genproto.sh",
+        "config:src/currencyservice/package.json",
+        "schema:src/currencyservice/proto/demo.proto",
+        "schema:src/currencyservice/proto/grpc/health/v1/health.proto",
+        "file:src/currencyservice/server.js",
+        "file:src/emailservice/demo_pb2_grpc.py",
+        "file:src/emailservice/demo_pb2.py",
+        "service:src/emailservice/Dockerfile",
+        "file:src/emailservice/email_client.py",
+        "file:src/emailservice/email_server.py",
+        "file:src/emailservice/genproto.sh",
+        "file:src/emailservice/logger.py",
+        "file:src/emailservice/requirements.in",
+        "document:src/emailservice/requirements.txt",
+        "file:src/emailservice/templates/confirmation.html",
+        "file:src/paymentservice/.dockerignore",
+        "file:src/paymentservice/charge.js",
+        "service:src/paymentservice/Dockerfile",
+        "file:src/paymentservice/genproto.sh",
+        "file:src/paymentservice/index.js",
+        "file:src/paymentservice/logger.js",
+        "config:src/paymentservice/package.json",
+        "schema:src/paymentservice/proto/demo.proto",
+        "schema:src/paymentservice/proto/grpc/health/v1/health.proto",
+        "file:src/paymentservice/server.js",
+        "file:src/productcatalogservice/.dockerignore",
+        "file:src/productcatalogservice/catalog_loader.go",
+        "service:src/productcatalogservice/Dockerfile",
+        "file:src/productcatalogservice/genproto.sh",
+        "file:src/productcatalogservice/genproto/demo_grpc.pb.go",
+        "file:src/productcatalogservice/genproto/demo.pb.go",
+        "file:src/productcatalogservice/go.mod",
+        "file:src/productcatalogservice/go.sum",
+        "file:src/productcatalogservice/product_catalog_test.go",
+        "file:src/productcatalogservice/product_catalog.go",
+        "config:src/productcatalogservice/products.json",
+        "document:src/productcatalogservice/README.md",
+        "file:src/productcatalogservice/server.go",
+        "file:src/recommendationservice/client.py",
+        "file:src/recommendationservice/demo_pb2_grpc.py",
+        "file:src/recommendationservice/demo_pb2.py",
+        "service:src/recommendationservice/Dockerfile",
+        "file:src/recommendationservice/genproto.sh",
+        "file:src/recommendationservice/logger.py",
+        "file:src/recommendationservice/recommendation_server.py",
+        "file:src/recommendationservice/requirements.in",
+        "document:src/recommendationservice/requirements.txt",
+        "file:src/shippingservice/.dockerignore",
+        "service:src/shippingservice/Dockerfile",
+        "file:src/shippingservice/genproto.sh",
+        "file:src/shippingservice/genproto/demo_grpc.pb.go",
+        "file:src/shippingservice/genproto/demo.pb.go",
+        "file:src/shippingservice/go.mod",
+        "file:src/shippingservice/go.sum",
+        "file:src/shippingservice/main.go",
+        "file:src/shippingservice/quote.go",
+        "document:src/shippingservice/README.md",
+        "file:src/shippingservice/shippingservice_test.go",
+        "file:src/shippingservice/tracker.go",
+        "service:src/shoppingassistantservice/Dockerfile",
+        "file:src/shoppingassistantservice/requirements.in",
+        "document:src/shoppingassistantservice/requirements.txt",
+        "file:src/shoppingassistantservice/shoppingassistantservice.py"
+      ]
+    },
+    {
+      "id": "layer:load-testing",
+      "name": "Load Testing",
+      "description": "Python-based load generator using Locust to simulate user traffic against the Online Boutique frontend for performance and reliability testing",
+      "nodeIds": [
+        "service:src/loadgenerator/Dockerfile",
+        "file:src/loadgenerator/locustfile.py",
+        "file:src/loadgenerator/requirements.in",
+        "document:src/loadgenerator/requirements.txt"
+      ]
+    },
+    {
+      "id": "layer:api-contracts",
+      "name": "API Contracts",
+      "description": "Shared Protocol Buffer definitions that define the gRPC service interfaces and message types used for inter-service communication across all microservices",
+      "nodeIds": [
+        "schema:protos/demo.proto",
+        "schema:protos/grpc/health/v1/health.proto"
+      ]
+    },
+    {
+      "id": "layer:kubernetes-deployment",
+      "name": "Kubernetes Deployment",
+      "description": "Kubernetes manifests, Kustomize overlays with reusable components (network policies, service mesh, storage backends), Helm chart templates, Istio service mesh configuration, and release artifacts for deploying all microservices to GKE",
+      "nodeIds": [
+        "config:kubernetes-manifests/adservice.yaml",
+        "config:kubernetes-manifests/cartservice.yaml",
+        "config:kubernetes-manifests/checkoutservice.yaml",
+        "config:kubernetes-manifests/currencyservice.yaml",
+        "config:kubernetes-manifests/emailservice.yaml",
+        "config:kubernetes-manifests/frontend.yaml",
+        "config:kubernetes-manifests/kustomization.yaml",
+        "config:kubernetes-manifests/loadgenerator.yaml",
+        "config:kubernetes-manifests/paymentservice.yaml",
+        "config:kubernetes-manifests/productcatalogservice.yaml",
+        "document:kubernetes-manifests/README.md",
+        "config:kubernetes-manifests/recommendationservice.yaml",
+        "config:kubernetes-manifests/shippingservice.yaml",
+        "config:kustomize/base/adservice.yaml",
+        "config:kustomize/base/cartservice.yaml",
+        "config:kustomize/base/checkoutservice.yaml",
+        "config:kustomize/base/currencyservice.yaml",
+        "config:kustomize/base/emailservice.yaml",
+        "config:kustomize/base/frontend.yaml",
+        "config:kustomize/base/kustomization.yaml",
+        "config:kustomize/base/loadgenerator.yaml",
+        "config:kustomize/base/paymentservice.yaml",
+        "config:kustomize/base/productcatalogservice.yaml",
+        "config:kustomize/base/recommendationservice.yaml",
+        "config:kustomize/base/shippingservice.yaml",
+        "config:kustomize/components/alloydb/kustomization.yaml",
+        "document:kustomize/components/alloydb/README.md",
+        "config:kustomize/components/container-images-registry/kustomization.yaml",
+        "document:kustomize/components/container-images-registry/README.md",
+        "config:kustomize/components/container-images-tag-suffix/kustomization.yaml",
+        "document:kustomize/components/container-images-tag-suffix/README.md",
+        "config:kustomize/components/container-images-tag/kustomization.yaml",
+        "document:kustomize/components/container-images-tag/README.md",
+        "config:kustomize/components/custom-base-url/kustomization.yaml",
+        "document:kustomize/components/custom-base-url/README.md",
+        "config:kustomize/components/cymbal-branding/kustomization.yaml",
+        "document:kustomize/components/cymbal-branding/README.md",
+        "config:kustomize/components/google-cloud-operations/kustomization.yaml",
+        "config:kustomize/components/google-cloud-operations/otel-collector.yaml",
+        "document:kustomize/components/google-cloud-operations/README.md",
+        "config:kustomize/components/memorystore/kustomization.yaml",
+        "document:kustomize/components/memorystore/README.md",
+        "config:kustomize/components/network-policies/kustomization.yaml",
+        "config:kustomize/components/network-policies/network-policy-adservice.yaml",
+        "config:kustomize/components/network-policies/network-policy-cartservice.yaml",
+        "config:kustomize/components/network-policies/network-policy-checkoutservice.yaml",
+        "config:kustomize/components/network-policies/network-policy-currencyservice.yaml",
+        "config:kustomize/components/network-policies/network-policy-deny-all.yaml",
+        "config:kustomize/components/network-policies/network-policy-emailservice.yaml",
+        "config:kustomize/components/network-policies/network-policy-frontend.yaml",
+        "config:kustomize/components/network-policies/network-policy-loadgenerator.yaml",
+        "config:kustomize/components/network-policies/network-policy-paymentservice.yaml",
+        "config:kustomize/components/network-policies/network-policy-productcatalogservice.yaml",
+        "config:kustomize/components/network-policies/network-policy-recommendationservice.yaml",
+        "config:kustomize/components/network-policies/network-policy-redis.yaml",
+        "config:kustomize/components/network-policies/network-policy-shippingservice.yaml",
+        "document:kustomize/components/network-policies/README.md",
+        "config:kustomize/components/non-public-frontend/kustomization.yaml",
+        "document:kustomize/components/non-public-frontend/README.md",
+        "config:kustomize/components/service-mesh-istio/allow-egress-googleapis.yaml",
+        "config:kustomize/components/service-mesh-istio/frontend-gateway.yaml",
+        "config:kustomize/components/service-mesh-istio/frontend.yaml",
+        "config:kustomize/components/service-mesh-istio/kustomization.yaml",
+        "document:kustomize/components/service-mesh-istio/README.md",
+        "config:kustomize/components/shopping-assistant/kustomization.yaml",
+        "document:kustomize/components/shopping-assistant/README.md",
+        "file:kustomize/components/shopping-assistant/scripts/1_deploy_alloydb_infra.sh",
+        "file:kustomize/components/shopping-assistant/scripts/2_create_populate_alloydb_tables.sh",
+        "file:kustomize/components/shopping-assistant/scripts/generate_sql_from_products.py",
+        "config:kustomize/components/shopping-assistant/shoppingassistantservice.yaml",
+        "config:kustomize/components/single-shared-session/kustomization.yaml",
+        "document:kustomize/components/single-shared-session/README.md",
+        "config:kustomize/components/spanner/kustomization.yaml",
+        "document:kustomize/components/spanner/README.md",
+        "config:kustomize/components/without-loadgenerator/delete-loadgenerator.patch.yaml",
+        "config:kustomize/components/without-loadgenerator/kustomization.yaml",
+        "document:kustomize/components/without-loadgenerator/README.md",
+        "config:kustomize/kustomization.yaml",
+        "document:kustomize/README.md",
+        "config:kustomize/tests/memorystore-with-all-components/kustomization.yaml",
+        "document:kustomize/tests/README.md",
+        "config:kustomize/tests/service-mesh-istio-with-all-components/kustomization.yaml",
+        "config:kustomize/tests/spanner-with-all-components/kustomization.yaml",
+        "config:helm-chart/Chart.yaml",
+        "document:helm-chart/README.md",
+        "config:helm-chart/templates/adservice.yaml",
+        "config:helm-chart/templates/cartservice.yaml",
+        "config:helm-chart/templates/checkoutservice.yaml",
+        "config:helm-chart/templates/common.yaml",
+        "config:helm-chart/templates/currencyservice.yaml",
+        "config:helm-chart/templates/emailservice.yaml",
+        "config:helm-chart/templates/frontend.yaml",
+        "config:helm-chart/templates/loadgenerator.yaml",
+        "document:helm-chart/templates/NOTES.txt",
+        "config:helm-chart/templates/opentelemetry-collector.yaml",
+        "config:helm-chart/templates/paymentservice.yaml",
+        "config:helm-chart/templates/productcatalogservice.yaml",
+        "config:helm-chart/templates/recommendationservice.yaml",
+        "config:helm-chart/templates/shippingservice.yaml",
+        "config:helm-chart/values.yaml",
+        "config:istio-manifests/allow-egress-googleapis.yaml",
+        "config:istio-manifests/frontend-gateway.yaml",
+        "config:istio-manifests/frontend.yaml",
+        "config:release/istio-manifests.yaml",
+        "config:release/kubernetes-manifests.yaml"
+      ]
+    },
+    {
+      "id": "layer:ci-cd",
+      "name": "CI/CD & Cloud Build",
+      "description": "GitHub Actions workflows for continuous integration (PR validation, Helm chart linting, Kustomize builds, Terraform validation), Cloud Build configuration, and supporting Terraform modules for CI infrastructure",
+      "nodeIds": [
+        "config:.github/auto-approve.yml",
+        "document:.github/CODE_OF_CONDUCT.md",
+        "file:.github/CODEOWNERS",
+        "document:.github/CONTRIBUTING.md",
+        "config:.github/header-checker-lint.yml",
+        "document:.github/ISSUE_TEMPLATE/bug-report.md",
+        "document:.github/ISSUE_TEMPLATE/feature-request.md",
+        "document:.github/ISSUE_TEMPLATE/other.md",
+        "document:.github/pull_request_template.md",
+        "config:.github/release-cluster/backend-config.yaml",
+        "config:.github/release-cluster/frontend-config.yaml",
+        "config:.github/release-cluster/frontend-ingress.yaml",
+        "config:.github/release-cluster/frontend-service.yaml",
+        "config:.github/release-cluster/managed-cert.yaml",
+        "document:.github/release-cluster/README.md",
+        "file:.github/renovate.json5",
+        "document:.github/SECURITY.md",
+        "config:.github/snippet-bot.yml",
+        "resource:.github/terraform/main.tf",
+        "document:.github/terraform/README.md",
+        "resource:.github/terraform/variables.tf",
+        "resource:.github/terraform/versions.tf",
+        "pipeline:.github/workflows/ci-main.yaml",
+        "pipeline:.github/workflows/ci-pr.yaml",
+        "pipeline:.github/workflows/cleanup.yaml",
+        "pipeline:.github/workflows/helm-chart-ci.yaml",
+        "file:.github/workflows/install-dependencies.sh",
+        "pipeline:.github/workflows/kubevious-manifests-ci.yaml",
+        "pipeline:.github/workflows/kustomize-build-ci.yaml",
+        "document:.github/workflows/README.md",
+        "pipeline:.github/workflows/terraform-validate-ci.yaml",
+        "config:cloudbuild.yaml",
+        "config:skaffold.yaml"
+      ]
+    },
+    {
+      "id": "layer:terraform-infrastructure",
+      "name": "Terraform Infrastructure",
+      "description": "Terraform modules for provisioning GCP infrastructure including GKE clusters, Memorystore Redis instances, and associated networking for the Online Boutique deployment",
+      "nodeIds": [
+        "resource:terraform/main.tf",
+        "resource:terraform/memorystore.tf",
+        "resource:terraform/output.tf",
+        "resource:terraform/providers.tf",
+        "document:terraform/README.md",
+        "resource:terraform/variables.tf"
+      ]
+    },
+    {
+      "id": "layer:documentation",
+      "name": "Documentation & Project Config",
+      "description": "Project-level documentation covering development guides, deployment tutorials, release procedures, and product requirements, plus DeployStack and root-level configuration files",
+      "nodeIds": [
+        "document:docs/adding-new-microservice.md",
+        "document:docs/cloudshell-tutorial.md",
+        "document:docs/deploystack.md",
+        "document:docs/development-guide.md",
+        "document:docs/product-requirements.md",
+        "document:docs/purpose.md",
+        "document:docs/releasing/license_header.txt",
+        "file:docs/releasing/make-docker-images.sh",
+        "file:docs/releasing/make-helm-chart.sh",
+        "file:docs/releasing/make-release-artifacts.sh",
+        "file:docs/releasing/make-release.sh",
+        "document:docs/releasing/README.md",
+        "config:.deploystack/deploystack.yaml",
+        "document:.deploystack/messages/description.txt",
+        "document:.deploystack/messages/success.txt",
+        "file:.deploystack/scripts/preinit.sh",
+        "file:.deploystack/test",
+        "config:.deploystack/test.yaml",
+        "file:.gitattributes",
+        "document:README.md"
+      ]
+    }
+  ],
+  "tour": [
+    {
+      "order": 1,
+      "title": "Project Overview",
+      "description": "Start with the README to understand Online Boutique's purpose: a cloud-first microservices demo by Google, showcasing 11 services written in Go, C#, Java, Python, and Node.js that communicate over gRPC. The README maps out the architecture, lists every microservice with its language and role, and provides GKE quickstart instructions. This document is your roadmap for everything that follows.",
+      "nodeIds": [
+        "document:README.md"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "gRPC Service Contracts",
+      "description": "The master protobuf schema is the single source of truth for how all 11 microservices communicate. It defines 9 gRPC service interfaces (Cart, Recommendation, ProductCatalog, Shipping, Currency, Payment, Email, Checkout, Ad) and 32 message types. Every service in the project generates language-specific stubs from this file, making it the most fundamental artifact in the codebase.",
+      "nodeIds": [
+        "schema:protos/demo.proto",
+        "schema:protos/grpc/health/v1/health.proto"
+      ],
+      "languageLesson": "Protobuf field numbers are permanent identifiers for wire compatibility -- never reuse a deleted field number. Each service definition here generates both client stubs and server interfaces in the target language, enforcing a strict API contract across all microservices."
+    },
+    {
+      "order": 3,
+      "title": "Frontend Entry Point",
+      "description": "The frontend is the user-facing gateway that ties all backend services together. Its main.go bootstraps the HTTP server on port 8080, establishes gRPC connections to every backend microservice, configures OpenTelemetry tracing and Cloud Profiler, and registers HTTP routes via Gorilla mux. This is where a user request enters the system and gets routed to the appropriate handler.",
+      "nodeIds": [
+        "file:src/frontend/main.go"
+      ],
+      "languageLesson": "Go's main package is the executable entry point. Here, gRPC client connections are established using grpc.Dial with interceptors for tracing, and the HTTP server uses gorilla/mux for routing -- a common pattern in Go web services that need both HTTP and gRPC."
+    },
+    {
+      "order": 4,
+      "title": "Frontend HTTP Handlers",
+      "description": "Building on the routes registered in Step 3, handlers.go implements every user-facing page: home, product details, cart management, checkout, and order confirmation. With 21 outbound dependencies (the highest fan-out in the project), this file orchestrates calls to nearly every backend service -- product catalog for listings, cart service for shopping cart state, currency service for price conversion, and checkout service for order placement.",
+      "nodeIds": [
+        "file:src/frontend/handlers.go",
+        "file:src/frontend/genproto/demo.pb.go"
+      ],
+      "languageLesson": "The auto-generated demo.pb.go file contains Go structs for all protobuf message types (CartItem, Product, Money, Address, Order). The handlers use these typed structs to make gRPC calls, giving compile-time safety for inter-service communication."
+    },
+    {
+      "order": 5,
+      "title": "Product Catalog Service",
+      "description": "The product catalog is one of the most depended-upon services in the system, referenced by the frontend, checkout, and recommendation services. It implements ListProducts, GetProduct, and SearchProducts RPCs, reading product data from a JSON file. The server.go file sets up the gRPC server with OpenTelemetry tracing, while product_catalog.go contains the business logic and an in-memory catalog that supports hot-reloading.",
+      "nodeIds": [
+        "file:src/productcatalogservice/server.go",
+        "file:src/productcatalogservice/product_catalog.go",
+        "file:src/productcatalogservice/catalog_loader.go"
+      ],
+      "languageLesson": "Go's struct embedding and interface satisfaction are on display here: the productCatalog struct implements the generated gRPC server interface without explicit declaration. The catalog uses sync.Mutex for thread-safe access to the shared product list."
+    },
+    {
+      "order": 6,
+      "title": "Cart Service",
+      "description": "The cart service, written in C#, demonstrates a different language's approach to the same gRPC patterns. Its Startup.cs configures dependency injection to select between Redis, Spanner, or AlloyDB as the backing store based on environment variables, while ICartStore.cs defines the storage abstraction. This strategy pattern lets the service swap databases without changing business logic -- a key architectural decision for cloud flexibility.",
+      "nodeIds": [
+        "file:src/cartservice/src/Program.cs",
+        "file:src/cartservice/src/Startup.cs",
+        "file:src/cartservice/src/cartstore/ICartStore.cs"
+      ],
+      "languageLesson": "C#'s dependency injection container (IServiceCollection) and interface-based abstractions are central here. The ICartStore interface decouples cart operations from the storage backend, and ASP.NET Core's middleware pipeline handles gRPC hosting, health checks, and OpenTelemetry integration."
+    },
+    {
+      "order": 7,
+      "title": "Checkout Orchestrator",
+      "description": "The checkout service is the most complex business logic in the system, orchestrating the entire purchase flow. Its PlaceOrder RPC calls six other microservices in sequence: it retrieves cart items, looks up product details, converts currency, calculates shipping, charges payment, and sends a confirmation email. This single file demonstrates the fan-out pattern characteristic of microservice orchestration.",
+      "nodeIds": [
+        "file:src/checkoutservice/main.go",
+        "file:src/checkoutservice/money/money.go"
+      ],
+      "languageLesson": "Go error handling is prominent here -- each outbound gRPC call returns an error that must be checked before proceeding. The money.go utility handles currency arithmetic with integer-based precision to avoid floating-point rounding issues in financial calculations."
+    },
+    {
+      "order": 8,
+      "title": "Supporting Microservices",
+      "description": "Four smaller services round out the backend: the currency service (Node.js) converts money between currencies using exchange rate data; the payment service (Node.js) provides a mock credit card charge; the email service (Python) renders order confirmations using Jinja2 templates; and the shipping service (Go) calculates quotes and generates tracking IDs. Each demonstrates gRPC server patterns in its respective language, and all integrate OpenTelemetry for distributed tracing.",
+      "nodeIds": [
+        "file:src/currencyservice/server.js",
+        "file:src/paymentservice/server.js",
+        "file:src/emailservice/email_server.py",
+        "file:src/shippingservice/main.go"
+      ]
+    },
+    {
+      "order": 9,
+      "title": "Recommendation and Ad Services",
+      "description": "The recommendation service (Python) queries the product catalog and filters out items the user has already viewed, returning random suggestions. The ad service (Java) serves contextual advertisements based on product category keys. Both are read-only services that enhance the shopping experience without participating in the transactional checkout flow, showing how auxiliary features integrate into a microservice architecture.",
+      "nodeIds": [
+        "file:src/recommendationservice/recommendation_server.py",
+        "file:src/adservice/src/main/java/hipstershop/AdService.java"
+      ],
+      "languageLesson": "The ad service uses Java's gRPC server builder pattern with OpenCensus stats for monitoring, while the recommendation service uses Python's grpc.server with concurrent.futures for threading -- illustrating how the same gRPC contract manifests differently across language ecosystems."
+    },
+    {
+      "order": 10,
+      "title": "Load Generator",
+      "description": "The load generator uses Locust, a Python load testing framework, to simulate realistic user behavior against the frontend: browsing products, managing cart items, switching currencies, and completing checkout. This service validates that all 11 microservices work together under concurrent load and serves as living documentation of the expected user workflows.",
+      "nodeIds": [
+        "file:src/loadgenerator/locustfile.py",
+        "service:src/loadgenerator/Dockerfile"
+      ]
+    },
+    {
+      "order": 11,
+      "title": "Kubernetes Deployment",
+      "description": "The Kubernetes manifests define how every microservice runs in production. Each service gets a Deployment (with resource limits, health probes, and environment variables), a ClusterIP Service for internal gRPC routing, and a ServiceAccount for identity. The frontend additionally gets an external LoadBalancer Service. The kustomization.yaml aggregates all manifests and enables composable overlays for different deployment scenarios.",
+      "nodeIds": [
+        "config:kubernetes-manifests/frontend.yaml",
+        "config:kubernetes-manifests/checkoutservice.yaml",
+        "config:kustomize/base/kustomization.yaml",
+        "config:release/kubernetes-manifests.yaml"
+      ],
+      "languageLesson": "Kubernetes Deployments manage pod replicas with rolling updates and readiness gates. The liveness and readiness probes defined here use gRPC health checks (from the health.proto in Step 2) to let Kubernetes automatically restart unhealthy pods and route traffic only to ready ones."
+    },
+    {
+      "order": 12,
+      "title": "Containerization",
+      "description": "Each microservice has its own Dockerfile using multi-stage builds tailored to its language runtime. The Go services compile to static binaries deployed on distroless images, the C# service uses .NET self-contained publishing on chiseled Ubuntu, the Java service uses a Gradle build stage with a minimal JRE runtime, and the Node.js/Python services use Alpine-based images. Skaffold ties these together with a single build-and-deploy workflow defined in skaffold.yaml.",
+      "nodeIds": [
+        "service:src/frontend/Dockerfile",
+        "service:src/checkoutservice/Dockerfile",
+        "service:src/cartservice/src/Dockerfile",
+        "config:skaffold.yaml"
+      ],
+      "languageLesson": "Multi-stage Docker builds use multiple FROM statements to separate build-time dependencies (compilers, dev tools) from runtime. Layer ordering matters for cache efficiency -- copying dependency manifests (go.mod, package.json) before source code ensures dependency layers are cached when only application code changes."
+    },
+    {
+      "order": 13,
+      "title": "Infrastructure as Code",
+      "description": "The Terraform configuration provisions the entire GCP infrastructure: enabling required APIs, creating a GKE Autopilot cluster, retrieving credentials, and deploying the application via kubectl. The optional memorystore.tf module shows how to swap the in-cluster Redis for a managed Cloud Memorystore instance. Variables.tf parameterizes the deployment for different environments, regions, and configuration choices.",
+      "nodeIds": [
+        "resource:terraform/main.tf",
+        "resource:terraform/variables.tf",
+        "resource:terraform/memorystore.tf"
+      ],
+      "languageLesson": "Terraform declares desired infrastructure state rather than imperative steps. The google_container_cluster resource with enable_autopilot delegates node management to GKE, while the null_resource with local-exec provisioner bridges Terraform and kubectl for application deployment."
+    },
+    {
+      "order": 14,
+      "title": "CI/CD Pipeline",
+      "description": "GitHub Actions workflows automate testing and deployment across the entire project. The ci-pr workflow deploys each pull request to an isolated GKE namespace for staging validation, ci-main runs on merges to main, and specialized workflows validate Helm charts, Kustomize builds, Kubernetes manifests, and Terraform configuration independently. The cleanup workflow tears down PR namespaces after merge, keeping the cluster tidy.",
+      "nodeIds": [
+        "pipeline:.github/workflows/ci-pr.yaml",
+        "pipeline:.github/workflows/ci-main.yaml",
+        "pipeline:.github/workflows/cleanup.yaml",
+        "resource:.github/terraform/main.tf"
+      ],
+      "languageLesson": "GitHub Actions workflows use 'on' triggers for event-driven execution and 'jobs' for parallel task groups. The CI Terraform provisions a dedicated GKE Autopilot cluster for PR staging, demonstrating infrastructure-as-code principles applied to the CI/CD environment itself."
+    },
+    {
+      "order": 15,
+      "title": "Helm Chart and Customization",
+      "description": "The Helm chart provides a templated, configurable deployment alternative to raw manifests. The values.yaml file centralizes configuration for all 11 microservices -- image repositories, resource limits, feature flags, and service names -- while individual templates generate the Kubernetes resources. This enables one-command deployment with environment-specific overrides, completing the picture of how Online Boutique moves from source code to a running cluster.",
+      "nodeIds": [
+        "config:helm-chart/values.yaml",
+        "config:helm-chart/Chart.yaml",
+        "document:helm-chart/README.md"
+      ]
+    }
+  ]
+}

--- a/demo-data/manifest.json
+++ b/demo-data/manifest.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "dataset": {
+    "repository": "Lum1104/microservices-demo",
+    "commit": "f0120e4544c41104f0d9b45d320764f1b1148fe4",
+    "path": ".understand-anything",
+    "analyzedCommit": "c9857ee54fba10486013f15ba6b31411986f530c"
+  },
+  "files": [
+    {
+      "filename": "knowledge-graph.json",
+      "bytes": 328640,
+      "sha256": "f17e433f394b5c1ab0826a7f619d28968d145fbc9f7df552f1853558dce9388d",
+      "contentType": "application/json",
+      "cacheControl": "public,max-age=3600,must-revalidate"
+    },
+    {
+      "filename": "domain-graph.json",
+      "bytes": 44806,
+      "sha256": "061119b1edfd7d97611d1e02c7160e4d2409958f504de784850328b65a51177f",
+      "contentType": "application/json",
+      "cacheControl": "public,max-age=3600,must-revalidate"
+    },
+    {
+      "filename": "meta.json",
+      "bytes": 159,
+      "sha256": "1f03fcca2a58f0929ebbc15ba57c54c5da177bcac1abd422fd7db34f8dbd84ff",
+      "contentType": "application/json",
+      "cacheControl": "public,max-age=3600,must-revalidate"
+    }
+  ]
+}

--- a/demo-data/meta.json
+++ b/demo-data/meta.json
@@ -1,0 +1,6 @@
+{
+  "lastAnalyzedAt": "2026-04-14T03:12:23.361Z",
+  "gitCommitHash": "c9857ee54fba10486013f15ba6b31411986f530c",
+  "version": "1.0.0",
+  "analyzedFiles": 312
+}

--- a/scripts/validate-demo-data.mjs
+++ b/scripts/validate-demo-data.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { lstatSync, readFileSync, readdirSync } from "node:fs";
+import { basename, dirname, isAbsolute, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const EXPECTED_FILENAMES = [
+  "knowledge-graph.json",
+  "domain-graph.json",
+  "meta.json",
+];
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/;
+const DATASET_REPOSITORY = "Lum1104/microservices-demo";
+const DATASET_PATH = ".understand-anything";
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function parseJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${error.message}`);
+  }
+}
+
+function validateManifest(manifest) {
+  invariant(
+    manifest && typeof manifest === "object" && !Array.isArray(manifest),
+    "manifest must be a JSON object",
+  );
+  invariant(manifest.schemaVersion === 1, "manifest schemaVersion must be 1");
+  invariant(
+    manifest.dataset && typeof manifest.dataset === "object",
+    "manifest dataset must be an object",
+  );
+  invariant(
+    manifest.dataset.repository === DATASET_REPOSITORY,
+    `manifest dataset.repository must be ${DATASET_REPOSITORY}`,
+  );
+  invariant(
+    COMMIT_PATTERN.test(manifest.dataset.commit ?? ""),
+    "manifest dataset.commit must be a lowercase 40-character Git SHA",
+  );
+  invariant(
+    manifest.dataset.path === DATASET_PATH,
+    `manifest dataset.path must be ${DATASET_PATH}`,
+  );
+  invariant(
+    COMMIT_PATTERN.test(manifest.dataset.analyzedCommit ?? ""),
+    "manifest dataset.analyzedCommit must be a lowercase 40-character Git SHA",
+  );
+  invariant(Array.isArray(manifest.files), "manifest files must be an array");
+
+  const names = [];
+  for (const [index, file] of manifest.files.entries()) {
+    const label = `manifest files[${index}]`;
+    invariant(file && typeof file === "object", `${label} must be an object`);
+    invariant(
+      typeof file.filename === "string" &&
+        file.filename.length > 0 &&
+        !isAbsolute(file.filename) &&
+        basename(file.filename) === file.filename,
+      `${label}.filename must be a plain filename`,
+    );
+    invariant(
+      Number.isSafeInteger(file.bytes) && file.bytes > 0,
+      `${label}.bytes must be a positive safe integer`,
+    );
+    invariant(
+      SHA256_PATTERN.test(file.sha256 ?? ""),
+      `${label}.sha256 must be a lowercase SHA-256 digest`,
+    );
+    invariant(
+      file.contentType === "application/json",
+      `${label}.contentType must be application/json`,
+    );
+    invariant(
+      file.cacheControl === "public,max-age=3600,must-revalidate",
+      `${label}.cacheControl does not match the public demo cache contract`,
+    );
+    names.push(file.filename);
+  }
+
+  invariant(
+    new Set(names).size === names.length,
+    "manifest contains duplicate filenames",
+  );
+  invariant(
+    JSON.stringify([...names].sort()) ===
+      JSON.stringify([...EXPECTED_FILENAMES].sort()),
+    `manifest must contain exactly: ${EXPECTED_FILENAMES.join(", ")}`,
+  );
+}
+
+function validateDatasetBinding(filename, value, analyzedCommit) {
+  invariant(
+    value && typeof value === "object" && !Array.isArray(value),
+    `${filename} must contain a JSON object`,
+  );
+
+  if (filename === "meta.json") {
+    invariant(
+      value.gitCommitHash === analyzedCommit,
+      `${filename} gitCommitHash does not match manifest analyzed commit`,
+    );
+    return;
+  }
+
+  invariant(Array.isArray(value.nodes), `${filename} nodes must be an array`);
+  invariant(Array.isArray(value.edges), `${filename} edges must be an array`);
+  invariant(
+    value.project && value.project.gitCommitHash === analyzedCommit,
+    `${filename} project.gitCommitHash does not match manifest analyzed commit`,
+  );
+}
+
+export function validateDemoData(dataDirectory) {
+  const directory = resolve(dataDirectory);
+  const manifestPath = resolve(directory, "manifest.json");
+  invariant(
+    lstatSync(manifestPath).isFile(),
+    "manifest.json must be a regular file, not a symlink",
+  );
+  const manifest = parseJson(manifestPath, "manifest.json");
+  validateManifest(manifest);
+
+  const expectedEntries = ["manifest.json", ...EXPECTED_FILENAMES].sort();
+  const actualEntries = readdirSync(directory).sort();
+  invariant(
+    JSON.stringify(actualEntries) === JSON.stringify(expectedEntries),
+    `demo-data directory must contain exactly: ${expectedEntries.join(", ")}`,
+  );
+
+  let totalBytes = 0;
+  for (const file of manifest.files) {
+    const path = resolve(directory, file.filename);
+    invariant(
+      dirname(path) === directory,
+      `${file.filename} resolves outside the demo-data directory`,
+    );
+
+    const stat = lstatSync(path);
+    invariant(
+      stat.isFile(),
+      `${file.filename} must be a regular file, not a symlink`,
+    );
+    const bytes = readFileSync(path);
+    const digest = createHash("sha256").update(bytes).digest("hex");
+
+    invariant(
+      bytes.byteLength === file.bytes,
+      `${file.filename} byte size mismatch: expected ${file.bytes}, got ${bytes.byteLength}`,
+    );
+    invariant(
+      digest === file.sha256,
+      `${file.filename} SHA-256 mismatch: expected ${file.sha256}, got ${digest}`,
+    );
+
+    const value = parseJson(path, file.filename);
+    validateDatasetBinding(
+      file.filename,
+      value,
+      manifest.dataset.analyzedCommit,
+    );
+    totalBytes += bytes.byteLength;
+  }
+
+  return {
+    datasetRepository: manifest.dataset.repository,
+    datasetCommit: manifest.dataset.commit,
+    datasetPath: manifest.dataset.path,
+    analyzedCommit: manifest.dataset.analyzedCommit,
+    fileCount: manifest.files.length,
+    totalBytes,
+    files: manifest.files.map(({ filename, bytes, sha256 }) => ({
+      filename,
+      bytes,
+      sha256,
+    })),
+  };
+}
+
+const scriptPath = fileURLToPath(import.meta.url);
+const defaultDirectory = resolve(dirname(scriptPath), "../demo-data");
+const invokedPath = process.argv[1]
+  ? pathToFileURL(resolve(process.argv[1])).href
+  : "";
+
+if (invokedPath === import.meta.url) {
+  try {
+    const summary = validateDemoData(process.argv[2] ?? defaultDirectory);
+    process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`demo-data validation failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/validate-demo-data.mjs
+++ b/scripts/validate-demo-data.mjs
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { createHash } from "node:crypto";
 import { lstatSync, readFileSync, readdirSync } from "node:fs";
 import { basename, dirname, isAbsolute, resolve } from "node:path";

--- a/tests/demo-data/publish-demo-data-workflow.test.mjs
+++ b/tests/demo-data/publish-demo-data-workflow.test.mjs
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../..");
+const workflow = readFileSync(
+  resolve(repoRoot, ".github/workflows/publish-demo-data.yml"),
+  "utf8",
+);
+
+describe("demo data publication workflow", () => {
+  it("is manual and binds authorization to exact live main", () => {
+    expect(workflow).toMatch(/^on:\n {2}workflow_dispatch:/m);
+    expect(workflow).not.toMatch(/^ {2}(push|pull_request|schedule):/m);
+    expect(workflow).toContain('GITHUB_REF" != "refs/heads/main');
+    expect(workflow).toContain('CANDIDATE_SHA" == "$GITHUB_SHA');
+    expect(workflow).toContain("git rev-parse HEAD");
+    expect(workflow.match(/git ls-remote/g)?.length).toBeGreaterThanOrEqual(3);
+    expect(workflow).toContain(
+      "PUBLISH_UA_DEMO_DATA_PROD:${CANDIDATE_SHA}",
+    );
+  });
+
+  it("validates before assuming the dedicated publisher role", () => {
+    expect(workflow).toContain(
+      "arn:aws:iam::309965488466:role/egonex-prod-understand-anything-demo-publisher",
+    );
+    expect(workflow).toContain("egonex-prod-understand-anything-demo");
+    expect(workflow).toContain("vars.DEMO_CLOUDFRONT_DISTRIBUTION_ID");
+    expect(workflow).toContain("vars.DEMO_CLOUDFRONT_DOMAIN");
+    expect(workflow.indexOf("node scripts/validate-demo-data.mjs")).toBeLessThan(
+      workflow.indexOf("aws-actions/configure-aws-credentials@"),
+    );
+  });
+
+  it("publishes only the manifest allowlist and verifies both storage layers", () => {
+    expect(workflow).not.toContain("aws s3 sync");
+    expect(workflow).toContain("aws s3api put-object");
+    expect(workflow).toContain("aws s3api head-object");
+    expect(workflow).toContain("aws s3 cp");
+    expect(workflow).toContain("cloudfront wait invalidation-completed");
+    expect(workflow).toContain('Origin: $EXPECTED_ORIGIN');
+    expect(workflow).toContain("actual_sha");
+    expect(workflow).toContain("aws s3api delete-object");
+  });
+});

--- a/tests/demo-data/publish-demo-data-workflow.test.mjs
+++ b/tests/demo-data/publish-demo-data-workflow.test.mjs
@@ -12,7 +12,7 @@ const workflow = readFileSync(
 
 describe("demo data publication workflow", () => {
   it("is manual and binds authorization to exact live main", () => {
-    expect(workflow).toMatch(/^on:\n {2}workflow_dispatch:/m);
+    expect(workflow).toMatch(/^on:\r?\n {2}workflow_dispatch:/m);
     expect(workflow).not.toMatch(/^ {2}(push|pull_request|schedule):/m);
     expect(workflow).toContain('GITHUB_REF" != "refs/heads/main');
     expect(workflow).toContain('CANDIDATE_SHA" == "$GITHUB_SHA');

--- a/tests/demo-data/validate-demo-data.test.mjs
+++ b/tests/demo-data/validate-demo-data.test.mjs
@@ -1,0 +1,92 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { cp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { validateDemoData } from "../../scripts/validate-demo-data.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "../..");
+const canonicalData = resolve(repoRoot, "demo-data");
+const temporaryDirectories = [];
+
+async function copyFixture() {
+  const directory = mkdtempSync(resolve(tmpdir(), "ua-demo-data-test-"));
+  temporaryDirectories.push(directory);
+  await cp(canonicalData, directory, { recursive: true });
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("demo data manifest validation", () => {
+  it("accepts the exact recovered dataset", () => {
+    const result = validateDemoData(canonicalData);
+
+    expect(result.datasetRepository).toBe(
+      "Lum1104/microservices-demo",
+    );
+    expect(result.datasetCommit).toBe(
+      "f0120e4544c41104f0d9b45d320764f1b1148fe4",
+    );
+    expect(result.datasetPath).toBe(".understand-anything");
+    expect(result.analyzedCommit).toBe(
+      "c9857ee54fba10486013f15ba6b31411986f530c",
+    );
+    expect(result.fileCount).toBe(3);
+    expect(result.totalBytes).toBe(373605);
+  });
+
+  it("rejects a same-length byte-level change to a source object", async () => {
+    const directory = await copyFixture();
+    const graphPath = resolve(directory, "knowledge-graph.json");
+    const bytes = readFileSync(graphPath);
+    bytes[0] ^= 1;
+    writeFileSync(graphPath, bytes);
+
+    expect(() => validateDemoData(directory)).toThrow(/SHA-256 mismatch/);
+  });
+
+  it("rejects an analyzed commit that does not bind the objects", async () => {
+    const directory = await copyFixture();
+    const manifestPath = resolve(directory, "manifest.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.dataset.analyzedCommit = "0".repeat(40);
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    expect(() => validateDemoData(directory)).toThrow(
+      /gitCommitHash does not match manifest analyzed commit/,
+    );
+  });
+
+  it("rejects symlinked data objects", async () => {
+    const directory = await copyFixture();
+    const graphPath = resolve(directory, "knowledge-graph.json");
+    rmSync(graphPath);
+    symlinkSync(resolve(canonicalData, "knowledge-graph.json"), graphPath);
+
+    expect(() => validateDemoData(directory)).toThrow(/regular file, not a symlink/);
+  });
+
+  it("rejects filenames outside the fixed three-object allowlist", async () => {
+    const directory = await copyFixture();
+    const manifestPath = resolve(directory, "manifest.json");
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.files[0].filename = "../knowledge-graph.json";
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    expect(() => validateDemoData(directory)).toThrow(/plain filename/);
+  });
+});


### PR DESCRIPTION
Adds the exact three JSON files from Lum1104/microservices-demo main, a hash/size/source manifest, tamper validation, and a manual AWS publisher with exact-main authorization, S3 version rollback, CloudFront invalidation, and public CORS/hash verification. Existing demo URL variables are unchanged until publication succeeds.