### PR TITLE
Polish: install reliability guards, first-run preflight, and agent prompt consistency

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,6 +39,13 @@ body:
     validations:
       required: true
 
+  - type: textarea
+    id: doctor
+    attributes:
+      label: /understand --doctor output
+      description: Run `/understand --doctor` and paste the output here.
+      render: shell
+
   - type: dropdown
     id: platform
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,8 @@ Swift repo and verified the dashboard shows non-empty edges" is better. -->
 
 <!-- If this PR ships a user-visible behavior change, bump the version in ALL
 five manifests per CLAUDE.md. If it's docs/tests/internal-only, leave them
-alone and the maintainer will bump on merge. -->
+alone and the maintainer will bump on merge. `pnpm test` now enforces that all
+five manifests match, so a partial bump fails CI. -->
 
 - [ ] Version bumped in all five manifests, OR
 - [ ] N/A — internal/docs-only change

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,14 @@ jobs:
   ci:
     strategy:
       fail-fast: false
+      # packages/core depends on 11 native tree-sitter grammar packages that run
+      # node-gyp-build on install and only work because upstream ships prebuilds;
+      # a new Node ABI or platform without a prebuild would force a from-source
+      # compile on a user's first /understand run, so macOS and Node 24 are
+      # included here as an early warning.
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node: [22, 24]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ Point `/understand-knowledge` at a [Karpathy-pattern LLM wiki](https://gist.gith
 
 ## 🚀 Quick Start
 
+### Prerequisites
+
+- Node.js >= 22
+- pnpm >= 10
+- git
+
+The first `/understand` run installs the plugin's dependencies and builds it, which needs network access. Run `/understand --doctor` any time to check your setup.
+
 ### 1. Install the plugin
 
 ```bash
@@ -183,6 +191,12 @@ An interactive web dashboard opens with your codebase visualized as a graph — 
 # Scope to a subdirectory (for huge monorepos)
 /understand src/frontend
 ```
+
+### Troubleshooting
+
+- **"Cannot find the understand-anything plugin root"** — the plugin isn't installed where `/understand` expects. The error message lists every path it checked; make sure one of them actually contains the plugin.
+- **Node.js or pnpm missing / too old** — install the versions listed under [Prerequisites](#prerequisites), then re-run `/understand`.
+- **First run is slow** — that's expected; it's installing dependencies and building the plugin once. Subsequent runs skip this.
 
 ---
 

--- a/tests/install/agent-frontmatter.test.mjs
+++ b/tests/install/agent-frontmatter.test.mjs
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { basename, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
+const agentsDir = resolve(repoRoot, 'understand-anything-plugin/agents');
+
+function readRepoText(path) {
+  return readFileSync(resolve(repoRoot, path), 'utf-8').replace(/\r\n?/g, '\n');
+}
+
+/**
+ * Parse the leading YAML frontmatter block (between the first two `---`
+ * lines) with a simple line-based scan — no YAML dependency needed since
+ * frontmatter here is always flat `key: value` pairs (with `description`
+ * using a `|` block scalar).
+ */
+function parseFrontmatterKeys(source) {
+  const lines = source.split('\n');
+  if (lines[0] !== '---') return null;
+  const end = lines.indexOf('---', 1);
+  if (end === -1) return null;
+  const keys = new Set();
+  for (const line of lines.slice(1, end)) {
+    const m = line.match(/^([a-zA-Z_]+):/);
+    if (m) keys.add(m[1]);
+  }
+  return keys;
+}
+
+const agentFiles = readdirSync(agentsDir).filter((f) => f.endsWith('.md'));
+
+describe('agent frontmatter', () => {
+  it('finds a plausible number of agent files', () => {
+    expect(agentFiles.length).toBeGreaterThanOrEqual(5);
+  });
+
+  for (const file of agentFiles) {
+    describe(file, () => {
+      const source = readRepoText(`understand-anything-plugin/agents/${file}`);
+      const keys = parseFrontmatterKeys(source);
+
+      it('has a parseable frontmatter block', () => {
+        expect(keys, `${file} frontmatter block`).not.toBeNull();
+      });
+
+      it('has name and description keys', () => {
+        expect(keys.has('name'), `${file} missing "name"`).toBe(true);
+        expect(keys.has('description'), `${file} missing "description"`).toBe(true);
+      });
+
+      // #167: opencode (and similar platforms) treat `model` as a literal
+      // model id rather than the Claude Code-only `inherit` keyword and
+      // reject it with ProviderModelNotFoundError, so agent frontmatter must
+      // omit `model` entirely and fall back to the platform's default.
+      it('has no model key', () => {
+        expect(keys.has('model'), `${file} must not set "model" (see #167)`).toBe(false);
+      });
+
+      it('has no tools key', () => {
+        expect(keys.has('tools'), `${file} must not set "tools"`).toBe(false);
+      });
+
+      it('name matches the file basename', () => {
+        const nameLine = source
+          .split('\n')
+          .find((line) => /^name:/.test(line));
+        const name = nameLine.replace(/^name:\s*/, '').trim();
+        expect(name).toBe(basename(file, '.md'));
+      });
+    });
+  }
+});

--- a/tests/install/version-sync.test.mjs
+++ b/tests/install/version-sync.test.mjs
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
+
+function readRepoJson(path) {
+  return JSON.parse(readFileSync(resolve(repoRoot, path), 'utf-8'));
+}
+
+const manifestPaths = [
+  'understand-anything-plugin/package.json',
+  'understand-anything-plugin/.claude-plugin/plugin.json',
+  '.claude-plugin/plugin.json',
+  '.cursor-plugin/plugin.json',
+  '.copilot-plugin/plugin.json',
+];
+
+const manifests = manifestPaths.map((path) => ({ path, json: readRepoJson(path) }));
+const marketplace = readRepoJson('.claude-plugin/marketplace.json');
+
+describe('version sync across manifests', () => {
+  it('every manifest has a non-empty string version', () => {
+    for (const { path, json } of manifests) {
+      expect(typeof json.version, `${path} version type`).toBe('string');
+      expect(json.version.length, `${path} version non-empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('all five manifests have the same version', () => {
+    const versions = manifests.map((m) => m.json.version);
+    expect(new Set(versions).size, `distinct versions: ${versions.join(', ')}`).toBe(1);
+  });
+
+  it('marketplace.json has no top-level version key', () => {
+    expect(Object.prototype.hasOwnProperty.call(marketplace, 'version')).toBe(false);
+  });
+
+  it('marketplace.json plugins[] entries have no version key', () => {
+    expect(Array.isArray(marketplace.plugins)).toBe(true);
+    expect(marketplace.plugins.length).toBeGreaterThan(0);
+    for (const plugin of marketplace.plugins) {
+      expect(
+        Object.prototype.hasOwnProperty.call(plugin, 'version'),
+        `plugin "${plugin.name}" should not have a version key`,
+      ).toBe(false);
+    }
+  });
+});

--- a/understand-anything-infographic-blueprint.html
+++ b/understand-anything-infographic-blueprint.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Understand Anything · Project Infographic (Blueprint)</title>
+<style>
+  :root{
+    --bg:#0a2747; --bg2:#072039; --grid:rgba(255,255,255,.07); --gridM:rgba(160,200,255,.16);
+    --line:rgba(160,200,255,.5); --line2:rgba(160,200,255,.24);
+    --ink:#e6f0ff; --head:#ffffff; --muted:#a9c2e8; --faint:#6f8fc0;
+    --accent:#7fb0ff; --cyan:#9fe0ff; --amber:#ffd27a; --orange:#ff9d5c; --lime:#a8e6b0; --red:#ff9aa6;
+    --mono:"JetBrains Mono","SF Mono",Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Inter","Segoe UI",sans-serif;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html,body{background:#041427}
+  .canvas{
+    width:1600px;height:1010px;position:relative;overflow:hidden;color:var(--ink);font-family:var(--sans);
+    background:linear-gradient(180deg,var(--bg),var(--bg2));
+    padding:38px 44px;
+  }
+  /* blueprint grid: minor + major */
+  .canvas::before{content:"";position:absolute;inset:0;pointer-events:none;
+    background-image:
+      linear-gradient(var(--grid) 1px,transparent 1px),linear-gradient(90deg,var(--grid) 1px,transparent 1px),
+      linear-gradient(var(--gridM) 1px,transparent 1px),linear-gradient(90deg,var(--gridM) 1px,transparent 1px);
+    background-size:40px 40px,40px 40px,200px 200px,200px 200px}
+  .canvas::after{content:"";position:absolute;inset:0;pointer-events:none;
+    box-shadow:inset 0 0 160px rgba(0,0,0,.45)}
+  /* corner registration marks */
+  .reg{position:absolute;width:18px;height:18px;border:0;z-index:3;opacity:.8}
+  .reg::before,.reg::after{content:"";position:absolute;background:var(--line)}
+  .reg::before{left:8px;top:0;width:1px;height:18px}.reg::after{top:8px;left:0;height:1px;width:18px}
+  .reg.tl{left:14px;top:14px}.reg.tr{right:14px;top:14px}.reg.bl{left:14px;bottom:14px}.reg.br{right:14px;bottom:14px}
+  .mono{font-family:var(--mono)}
+  .glow-c,.glow-m{text-shadow:none}
+  header{display:flex;align-items:flex-end;justify-content:space-between;padding-bottom:16px;margin-bottom:20px;
+    border-bottom:1px solid var(--line);position:relative;z-index:2}
+  .brand{display:flex;align-items:center;gap:16px}
+  .logo{width:54px;height:54px;border-radius:8px;display:grid;place-items:center;font-family:Georgia,serif;font-weight:700;font-size:30px;color:var(--head);
+    background:rgba(255,255,255,.04);border:1.5px solid var(--line)}
+  h1{font-size:34px;letter-spacing:3px;font-weight:800;color:var(--head)}
+  .tag{color:var(--accent);font-size:14.5px;margin-top:4px;letter-spacing:.6px;font-family:var(--mono)}
+  .stamp{text-align:right;font-family:var(--mono);font-size:12px;color:var(--faint);line-height:1.7;position:relative;z-index:2}
+  .stamp b{color:var(--accent)}
+  .grid{display:grid;grid-template-columns:repeat(12,1fr);grid-auto-rows:minmax(0,1fr);gap:16px;height:836px;position:relative;z-index:2}
+  .card{background:rgba(255,255,255,.025);border:1px solid var(--line2);border-radius:6px;padding:18px 20px;position:relative;overflow:hidden}
+  /* drawing corner ticks */
+  .card::before{content:attr(data-id);position:absolute;top:9px;right:12px;font-family:var(--mono);font-size:10px;color:var(--accent);opacity:.85;letter-spacing:1px}
+  .card::after{content:"";position:absolute;left:10px;top:10px;width:10px;height:10px;border-left:1px solid var(--line);border-top:1px solid var(--line);opacity:.6}
+  .ct{font-family:var(--mono);font-size:11px;letter-spacing:3px;text-transform:uppercase;color:var(--accent);margin-bottom:10px;padding-left:16px}
+  .lead{font-size:15px;color:var(--ink);line-height:1.5}
+  .muted{color:var(--muted)}
+  .big{font-size:22px;font-weight:800;letter-spacing:-.2px;color:var(--head)}
+  .s-what{grid-column:span 7;grid-row:span 2}.s-stack{grid-column:span 5;grid-row:span 2}
+  .s-pipe{grid-column:span 12;grid-row:span 2}.s-bot{grid-column:span 4;grid-row:span 3}
+  .s-safe{grid-column:span 4;grid-row:span 3}.s-sec{grid-column:span 4;grid-row:span 2}
+  .s-cost{grid-column:span 4;grid-row:span 1}
+  .flow{display:flex;align-items:stretch;margin-top:6px}
+  .step{flex:1;background:rgba(127,176,255,.06);border:1px solid var(--line2);border-radius:4px;padding:12px;text-align:center}
+  .step .n{font-family:var(--mono);font-size:10px;color:var(--accent)}
+  .step .l{font-size:14px;font-weight:700;margin-top:4px;color:var(--head)}
+  .step .s{font-family:var(--mono);font-size:11px;color:var(--cyan);margin-top:3px}
+  .arrow{display:grid;place-items:center;color:var(--accent);font-size:18px;width:30px;flex:0 0 30px}
+  .chain{display:flex;flex-direction:column;gap:9px;margin-top:4px}
+  .node{border:1px solid var(--line2);border-radius:4px;padding:10px 12px;background:rgba(127,176,255,.05);position:relative}
+  .node .h{font-weight:700;font-size:14.5px;color:var(--head)}.node .d{font-size:12px;color:var(--muted);margin-top:2px}
+  .node .pill{position:absolute;top:10px;right:10px;font-family:var(--mono);font-size:10px;padding:2px 7px;border-radius:3px;border:1px solid}
+  .pill.get{color:var(--lime);border-color:rgba(168,230,176,.6)}.pill.post{color:var(--orange);border-color:rgba(255,157,92,.6)}
+  .grp{font-family:var(--mono);font-size:10.5px;letter-spacing:1.5px;text-transform:uppercase;color:var(--cyan);margin:12px 0 6px}
+  .grp:first-of-type{margin-top:2px}
+  .modes{display:flex;flex-wrap:wrap;gap:6px}
+  .chip{font-family:var(--mono);font-size:11px;padding:3px 9px;border:1px solid var(--line);border-radius:3px;color:var(--ink);background:rgba(127,176,255,.05)}
+  .chip.amb{border-color:rgba(255,210,122,.6);color:var(--amber)}
+  .chip.org{border-color:rgba(255,157,92,.6);color:var(--orange)}
+  .layer{display:flex;gap:10px;align-items:flex-start;margin-top:9px}
+  .dot{width:8px;height:8px;border-radius:1px;margin-top:5px;flex:0 0 8px}
+  .layer .t{font-size:13px;color:var(--ink);line-height:1.45}
+  .stackgrid{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:8px}
+  .scol .sh{font-family:var(--mono);font-size:11px;color:var(--cyan);text-transform:uppercase;letter-spacing:1px;margin-bottom:6px}
+  .tagrow{display:flex;flex-wrap:wrap;gap:5px}
+  .t2{font-size:11.5px;padding:3px 8px;border-radius:3px;background:rgba(127,176,255,.06);border:1px solid var(--line2);color:#cfe0ff}
+  .sec li{list-style:none;font-size:13px;color:var(--ink);padding:6px 0;border-bottom:1px dashed var(--line2);display:flex;gap:8px}
+  .sec li:last-child{border-bottom:0}.sec .k{color:var(--accent);font-family:var(--mono);font-size:12px;flex:0 0 14px}
+  .sec .src{color:var(--cyan);font-family:var(--mono);font-size:11px;margin-left:auto;white-space:nowrap}
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-top:6px}
+  .stat{text-align:center}
+  .stat .v{font-family:var(--mono);font-size:30px;font-weight:800;color:var(--cyan)}
+  .stat .v.ok{color:var(--lime)}
+  .stat .v.org{color:var(--orange)}
+  .stat .k{font-size:11px;color:var(--muted);margin-top:2px}
+  .cost{display:flex;align-items:center;gap:12px;flex-wrap:wrap}.cost .v{font-family:var(--mono);font-size:15px;color:var(--lime);font-weight:800}
+  footer{position:absolute;bottom:14px;left:44px;right:44px;display:flex;justify-content:space-between;font-family:var(--mono);font-size:11px;color:var(--faint);border-top:1px solid var(--line);padding-top:10px;z-index:2}
+</style>
+</head>
+<body>
+<div class="canvas">
+  <span class="reg tl"></span><span class="reg tr"></span><span class="reg bl"></span><span class="reg br"></span>
+  <header style="padding-bottom:12px;margin-bottom:16px">
+    <div class="brand">
+      <div class="logo">U</div>
+      <div>
+        <h1>UNDERSTAND&nbsp;ANYTHING</h1>
+        <div class="tag">Turn any codebase into an interactive knowledge graph</div>
+      </div>
+    </div>
+    <div class="stamp">
+      TECHNICAL&nbsp;SCHEMATIC<br/>
+      layout <b>bento-grid</b> &middot; style <b>blueprint</b><br/>
+      SHEET&nbsp;1 OF 1 &middot; 2026-08-09
+    </div>
+  </header>
+
+  <div class="grid">
+    <!-- 01 WHAT IT IS -->
+    <div class="card s-what" data-id="01">
+      <div class="ct">What it is</div>
+      <div class="big">A multi-agent pipeline that turns a repo into a knowledge graph.</div>
+      <div class="lead muted" style="margin-top:10px">
+        Tree-sitter parses source into structural facts (imports, exports, definitions, call sites).
+        LLM agents supply what parsers cannot: plain-English summaries, architectural layers, business
+        domains, guided tours. It all lands in <b style="color:var(--cyan)">.understand-anything/knowledge-graph.json</b>,
+        and a React dashboard makes it clickable. The graph is <b style="color:var(--lime)">just JSON</b>, so a team
+        commits it once and everyone else skips the pipeline.
+      </div>
+    </div>
+
+    <!-- 06 STACK -->
+    <div class="card s-stack" data-id="06">
+      <div class="ct">Stack</div>
+      <div class="stackgrid">
+        <div class="scol"><div class="sh">Dashboard</div>
+          <div class="tagrow"><span class="t2">React 19</span><span class="t2">Vite 6</span><span class="t2">Tailwind 4</span><span class="t2">xyflow</span><span class="t2">zustand</span><span class="t2">graphology</span></div></div>
+        <div class="scol"><div class="sh">Core</div>
+          <div class="tagrow"><span class="t2">TypeScript</span><span class="t2">tree-sitter</span><span class="t2">zod</span><span class="t2">fuse.js</span><span class="t2">pnpm workspace</span><span class="t2">vitest</span></div></div>
+      </div>
+      <div class="lead muted" style="margin-top:10px;font-size:13px">366 TypeScript files and 49 test suites across core, dashboard, and two wasm grammar packages.</div>
+    </div>
+
+    <!-- 02 PIPELINE -->
+    <div class="card s-pipe" data-id="02">
+      <div class="ct">Pipeline &middot; /understand, phase 0 through 7</div>
+      <div class="flow">
+        <div class="step"><div class="n">01</div><div class="l">Scan</div><div class="s">project-scanner</div></div>
+        <div class="arrow">&#9656;</div>
+        <div class="step"><div class="n">02</div><div class="l">Batch</div><div class="s">20 to 30 files</div></div>
+        <div class="arrow">&#9656;</div>
+        <div class="step"><div class="n">03</div><div class="l">Analyze</div><div class="s">5 in parallel</div></div>
+        <div class="arrow">&#9656;</div>
+        <div class="step"><div class="n">04</div><div class="l">Layers</div><div class="s">architecture</div></div>
+        <div class="arrow">&#9656;</div>
+        <div class="step"><div class="n">05</div><div class="l">Tours</div><div class="s">dependency order</div></div>
+        <div class="arrow">&#9656;</div>
+        <div class="step"><div class="n">06</div><div class="l">Save</div><div class="s">graph + meta.json</div></div>
+      </div>
+      <div class="lead muted" style="margin-top:12px;font-size:13px">Phase 3 assemble-review recovers nodes dropped in the batch merge, phase 6 graph-review checks referential integrity, and phase 7 writes a fingerprint baseline before meta.json so the next run can go incremental.</div>
+    </div>
+
+    <!-- 03 COMMANDS -->
+    <div class="card s-bot" data-id="03">
+      <div class="ct">Slash commands &middot; 8</div>
+      <div class="grp">Build and explore</div>
+      <div class="modes"><span class="chip">/understand</span><span class="chip">/understand-dashboard</span></div>
+      <div class="grp">Ask and learn</div>
+      <div class="modes"><span class="chip">/understand-chat</span><span class="chip">/understand-explain</span><span class="chip">/understand-onboard</span></div>
+      <div class="grp">Deeper views</div>
+      <div class="modes"><span class="chip org">/understand-diff</span><span class="chip org">/understand-domain</span><span class="chip amb">/understand-knowledge</span></div>
+      <div class="grp">Install targets &middot; 17</div>
+      <div class="modes"><span class="chip">Claude Code</span><span class="chip">Cursor</span><span class="chip">Copilot</span><span class="chip">Codex</span><span class="chip">Gemini CLI</span><span class="chip">OpenCode</span><span class="chip">Kiro</span></div>
+    </div>
+
+    <!-- 04 AGENTS -->
+    <div class="card s-safe" data-id="04">
+      <div class="ct">Agents &middot; 9</div>
+      <ul class="sec">
+        <li><span class="k">&#9656;</span><div>project-scanner</div><span class="src">scan</span></li>
+        <li><span class="k">&#9656;</span><div>file-analyzer</div><span class="src">nodes + edges</span></li>
+        <li><span class="k">&#9656;</span><div>architecture-analyzer</div><span class="src">layers</span></li>
+        <li><span class="k">&#9656;</span><div>tour-builder</div><span class="src">tours</span></li>
+        <li><span class="k">&#9656;</span><div>graph-reviewer &middot; assemble-reviewer</div><span class="src">validate</span></li>
+        <li><span class="k">&#9656;</span><div>domain-analyzer</div><span class="src">business flows</span></li>
+        <li><span class="k">&#9656;</span><div>article-analyzer &middot; knowledge-graph-guide</div><span class="src">wiki</span></li>
+      </ul>
+    </div>
+
+    <!-- 05 LANGUAGES -->
+    <div class="card s-sec" data-id="05">
+      <div class="ct">Parsers &middot; 41 language configs</div>
+      <div class="modes"><span class="chip">TypeScript</span><span class="chip">JavaScript</span><span class="chip">Python</span><span class="chip">Go</span><span class="chip">Java</span><span class="chip">Rust</span><span class="chip">C</span><span class="chip">C++</span><span class="chip">C#</span><span class="chip">Ruby</span><span class="chip">PHP</span><span class="chip">Swift</span><span class="chip">Kotlin</span><span class="chip">Dart</span><span class="chip amb">Docker</span><span class="chip amb">Kubernetes</span><span class="chip amb">Terraform</span><span class="chip amb">OpenAPI</span></div>
+      <div class="lead muted" style="font-size:12.5px;margin-top:10px">14 are tree-sitter backed (Swift and Dart via wasm). 10 framework detectors cover React, Next, Vue, Django, Rails, Spring, Gin.</div>
+    </div>
+
+    <!-- 07 BY THE NUMBERS -->
+    <div class="card s-sec" data-id="07">
+      <div class="ct">By the numbers</div>
+      <div class="stats">
+        <div class="stat"><div class="v">41</div><div class="k">languages</div></div>
+        <div class="stat"><div class="v">9</div><div class="k">agents</div></div>
+        <div class="stat"><div class="v org">8</div><div class="k">commands</div></div>
+        <div class="stat"><div class="v ok">17</div><div class="k">platforms</div></div>
+      </div>
+      <div class="lead muted" style="font-size:12.5px;margin-top:12px">Later runs are incremental: only files whose tree-sitter fingerprint changed get re-analyzed. Dashboard UI ships in 6 languages across 32 components.</div>
+    </div>
+
+    <!-- 08 SHARE -->
+    <div class="card s-cost" data-id="08">
+      <div class="ct">Share the graph &middot; commit the JSON</div>
+      <div class="cost"><span class="mono" style="color:var(--lime)">--auto-update</span><span class="lead muted" style="font-size:12.5px">post-commit hook <span style="color:var(--accent)">&#9656;</span> incremental patch</span></div>
+    </div>
+  </div>
+
+  <footer>
+    <span>Understand Anything &middot; MIT &middot; Egonex-AI/Understand-Anything &middot; plugin v2.8.2</span>
+    <span>/understand &rarr; .understand-anything/knowledge-graph.json &middot; /understand-dashboard &rarr; vite :5173</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/understand-anything-infographic.html
+++ b/understand-anything-infographic.html
@@ -1,0 +1,214 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Understand Anything · Project Infographic (Cyberpunk)</title>
+<style>
+  :root{
+    --bg:#070310; --panel:rgba(20,8,38,.72); --panel2:rgba(28,10,52,.72); --line:rgba(0,240,255,.22);
+    --ink:#e9f6ff; --muted:#9aa6d6; --faint:#5f6aa0;
+    --cyan:#00f0ff; --mag:#ff2bd6; --purple:#a06bff; --lime:#5cff8f; --amber:#ffcf3a; --red:#ff4d6d; --orange:#ff7a18;
+    --mono:"JetBrains Mono","SF Mono",Menlo,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Inter","Segoe UI",sans-serif;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html,body{background:#000}
+  .canvas{
+    width:1600px;height:1010px;position:relative;overflow:hidden;color:var(--ink);font-family:var(--sans);
+    background:
+      radial-gradient(900px 500px at 12% -8%, rgba(255,43,214,.18), transparent 60%),
+      radial-gradient(1000px 600px at 95% 110%, rgba(0,240,255,.16), transparent 60%),
+      radial-gradient(700px 420px at 60% 50%, rgba(255,122,24,.07), transparent 60%),
+      linear-gradient(180deg,#0a0418,#05020c);
+    padding:38px 44px;
+  }
+  .canvas::before{content:"";position:absolute;inset:0;pointer-events:none;
+    background-image:linear-gradient(rgba(0,240,255,.06) 1px,transparent 1px),linear-gradient(90deg,rgba(255,43,214,.05) 1px,transparent 1px);
+    background-size:44px 44px,44px 44px;mask-image:linear-gradient(180deg,rgba(0,0,0,.9),rgba(0,0,0,.25))}
+  .canvas::after{content:"";position:absolute;inset:0;pointer-events:none;
+    background:repeating-linear-gradient(180deg,rgba(255,255,255,.025) 0 1px,transparent 1px 3px);opacity:.5}
+  .mono{font-family:var(--mono)}
+  .glow-c{text-shadow:0 0 8px rgba(0,240,255,.8),0 0 22px rgba(0,240,255,.45)}
+  .glow-m{text-shadow:0 0 8px rgba(255,43,214,.8),0 0 22px rgba(255,43,214,.45)}
+  header{display:flex;align-items:flex-end;justify-content:space-between;padding-bottom:18px;margin-bottom:20px;
+    border-bottom:1px solid var(--line);box-shadow:0 1px 0 rgba(0,240,255,.25)}
+  .brand{display:flex;align-items:center;gap:16px;position:relative;z-index:2}
+  .logo{width:56px;height:56px;border-radius:14px;display:grid;place-items:center;font-family:Georgia,serif;font-weight:700;font-size:34px;color:#100a04;
+    background:linear-gradient(135deg,var(--orange),var(--cyan));box-shadow:0 0 18px rgba(0,240,255,.6),0 0 36px rgba(255,122,24,.5)}
+  h1{font-size:36px;letter-spacing:2px;font-weight:800;color:#fff}
+  .tag{color:var(--cyan);font-size:15px;margin-top:3px;letter-spacing:.4px}
+  .stamp{text-align:right;font-family:var(--mono);font-size:12px;color:var(--faint);line-height:1.7;position:relative;z-index:2}
+  .stamp b{color:var(--mag)}
+  .grid{display:grid;grid-template-columns:repeat(12,1fr);grid-auto-rows:minmax(0,1fr);gap:16px;height:836px;position:relative;z-index:2}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:18px 20px;position:relative;overflow:hidden;
+    backdrop-filter:blur(3px);box-shadow:inset 0 0 24px rgba(0,240,255,.05),0 0 0 1px rgba(255,43,214,.05)}
+  .card::after{content:"";position:absolute;left:0;top:0;height:2px;width:100%;background:linear-gradient(90deg,var(--cyan),var(--mag),transparent);opacity:.85}
+  .card::before{content:attr(data-id);position:absolute;top:9px;right:12px;font-family:var(--mono);font-size:10px;color:var(--cyan);opacity:.6;letter-spacing:1px}
+  .ct{font-family:var(--mono);font-size:11px;letter-spacing:3px;text-transform:uppercase;color:var(--mag);margin-bottom:10px}
+  .lead{font-size:15px;color:var(--ink);line-height:1.5}
+  .muted{color:var(--muted)}
+  .big{font-size:22px;font-weight:800;letter-spacing:-.2px;color:#fff}
+  .s-what{grid-column:span 7;grid-row:span 2}.s-stack{grid-column:span 5;grid-row:span 2}
+  .s-pipe{grid-column:span 12;grid-row:span 2}.s-bot{grid-column:span 4;grid-row:span 3}
+  .s-safe{grid-column:span 4;grid-row:span 3}.s-sec{grid-column:span 4;grid-row:span 2}
+  .s-cost{grid-column:span 4;grid-row:span 1}
+  .flow{display:flex;align-items:stretch;margin-top:6px}
+  .step{flex:1;background:rgba(0,240,255,.05);border:1px solid var(--line);border-radius:10px;padding:12px;text-align:center;box-shadow:inset 0 0 14px rgba(0,240,255,.06)}
+  .step .n{font-family:var(--mono);font-size:10px;color:var(--mag)}
+  .step .l{font-size:14px;font-weight:700;margin-top:4px;color:#fff}
+  .step .s{font-family:var(--mono);font-size:11px;color:var(--cyan);margin-top:3px}
+  .arrow{display:grid;place-items:center;color:var(--mag);font-size:20px;width:30px;flex:0 0 30px;text-shadow:0 0 10px rgba(255,43,214,.8)}
+  .chain{display:flex;flex-direction:column;gap:9px;margin-top:4px}
+  .node{border:1px solid var(--line);border-radius:10px;padding:10px 12px;background:rgba(0,240,255,.04);position:relative}
+  .node .h{font-weight:700;font-size:14.5px;color:#fff}.node .d{font-size:12px;color:var(--muted);margin-top:2px}
+  .node .pill{position:absolute;top:10px;right:10px;font-family:var(--mono);font-size:10px;padding:2px 7px;border-radius:20px}
+  .pill.get{background:rgba(92,255,143,.16);color:var(--lime)}.pill.post{background:rgba(255,122,24,.18);color:var(--orange)}
+  .grp{font-family:var(--mono);font-size:10.5px;letter-spacing:1.5px;text-transform:uppercase;color:var(--purple);margin:12px 0 6px}
+  .grp:first-of-type{margin-top:2px}
+  .modes{display:flex;flex-wrap:wrap;gap:6px}
+  .chip{font-family:var(--mono);font-size:11px;padding:3px 9px;border:1px solid var(--cyan);border-radius:6px;color:var(--cyan);background:rgba(0,240,255,.06);box-shadow:0 0 8px rgba(0,240,255,.18)}
+  .chip.amb{border-color:var(--amber);color:var(--amber);box-shadow:0 0 8px rgba(255,207,58,.18);background:rgba(255,207,58,.06)}
+  .chip.org{border-color:var(--orange);color:var(--orange);box-shadow:0 0 8px rgba(255,122,24,.18);background:rgba(255,122,24,.06)}
+  .layer{display:flex;gap:10px;align-items:flex-start;margin-top:9px}
+  .dot{width:9px;height:9px;border-radius:50%;margin-top:5px;flex:0 0 9px;box-shadow:0 0 8px currentColor}
+  .layer .t{font-size:13px;color:var(--ink);line-height:1.45}
+  .stackgrid{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:8px}
+  .scol .sh{font-family:var(--mono);font-size:11px;color:var(--purple);text-transform:uppercase;letter-spacing:1px;margin-bottom:6px}
+  .tagrow{display:flex;flex-wrap:wrap;gap:5px}
+  .t2{font-size:11.5px;padding:3px 8px;border-radius:6px;background:rgba(160,107,255,.08);border:1px solid rgba(160,107,255,.35);color:#dcd2ff}
+  .sec li{list-style:none;font-size:13px;color:var(--ink);padding:6px 0;border-bottom:1px dashed var(--line);display:flex;gap:8px}
+  .sec li:last-child{border-bottom:0}.sec .k{color:var(--lime);font-family:var(--mono);font-size:12px;flex:0 0 14px;text-shadow:0 0 8px rgba(92,255,143,.7)}
+  .sec .src{color:var(--cyan);font-family:var(--mono);font-size:11px;margin-left:auto;white-space:nowrap}
+  .stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-top:6px}
+  .stat{text-align:center}
+  .stat .v{font-family:var(--mono);font-size:30px;font-weight:800;color:var(--cyan)}
+  .stat .v.ok{color:var(--lime);text-shadow:0 0 12px rgba(92,255,143,.6)}
+  .stat .v.org{color:var(--orange);text-shadow:0 0 12px rgba(255,122,24,.55)}
+  .stat .k{font-size:11px;color:var(--muted);margin-top:2px}
+  .cost{display:flex;align-items:center;gap:12px;flex-wrap:wrap}.cost .v{font-family:var(--mono);font-size:15px;color:var(--lime);font-weight:800;text-shadow:0 0 10px rgba(92,255,143,.5)}
+  footer{position:absolute;bottom:14px;left:44px;right:44px;display:flex;justify-content:space-between;font-family:var(--mono);font-size:11px;color:var(--faint);border-top:1px solid var(--line);padding-top:10px;z-index:2}
+</style>
+</head>
+<body>
+<div class="canvas">
+  <header style="padding-bottom:12px;margin-bottom:16px">
+    <div class="brand">
+      <div class="logo">U</div>
+      <div>
+        <h1 class="glow-c">UNDERSTAND&nbsp;ANYTHING</h1>
+        <div class="tag">Turn any codebase into an interactive knowledge graph</div>
+      </div>
+    </div>
+    <div class="stamp">
+      PROJECT&nbsp;INFOGRAPHIC<br/>
+      layout <b>bento-grid</b> &middot; style <b>cyberpunk-neon</b><br/>
+      MIT &middot; plugin&nbsp;v2.8.2 &middot; 2026-08-09
+    </div>
+  </header>
+
+  <div class="grid">
+    <!-- 01 WHAT IT IS -->
+    <div class="card s-what" data-id="01">
+      <div class="ct">What it is</div>
+      <div class="big">A multi-agent pipeline that turns a repo into a knowledge graph.</div>
+      <div class="lead muted" style="margin-top:10px">
+        Tree-sitter parses source into structural facts (imports, exports, definitions, call sites).
+        LLM agents supply what parsers cannot: plain-English summaries, architectural layers, business
+        domains, guided tours. It all lands in <b style="color:var(--cyan)">.understand-anything/knowledge-graph.json</b>,
+        and a React dashboard makes it clickable. The graph is <b style="color:var(--lime)">just JSON</b>, so a team
+        commits it once and everyone else skips the pipeline.
+      </div>
+    </div>
+
+    <!-- 06 STACK -->
+    <div class="card s-stack" data-id="06">
+      <div class="ct">Stack</div>
+      <div class="stackgrid">
+        <div class="scol"><div class="sh">Dashboard</div>
+          <div class="tagrow"><span class="t2">React 19</span><span class="t2">Vite 6</span><span class="t2">Tailwind 4</span><span class="t2">xyflow</span><span class="t2">zustand</span><span class="t2">graphology</span></div></div>
+        <div class="scol"><div class="sh">Core</div>
+          <div class="tagrow"><span class="t2">TypeScript</span><span class="t2">tree-sitter</span><span class="t2">zod</span><span class="t2">fuse.js</span><span class="t2">pnpm workspace</span><span class="t2">vitest</span></div></div>
+      </div>
+      <div class="lead muted" style="margin-top:10px;font-size:13px">366 TypeScript files and 49 test suites across core, dashboard, and two wasm grammar packages.</div>
+    </div>
+
+    <!-- 02 PIPELINE -->
+    <div class="card s-pipe" data-id="02">
+      <div class="ct">Pipeline &middot; /understand, phase 0 through 7</div>
+      <div class="flow">
+        <div class="step"><div class="n">01</div><div class="l">Scan</div><div class="s">project-scanner</div></div>
+        <div class="arrow">&#9656;</div>
+        <div class="step"><div class="n">02</div><div class="l">Batch</div><div class="s">20 to 30 files</div></div>
+        <div class="arrow">&#9656;</div>
+        <div class="step"><div class="n">03</div><div class="l">Analyze</div><div class="s">5 in parallel</div></div>
+        <div class="arrow">&#9656;</div>
+        <div class="step"><div class="n">04</div><div class="l">Layers</div><div class="s">architecture</div></div>
+        <div class="arrow">&#9656;</div>
+        <div class="step"><div class="n">05</div><div class="l">Tours</div><div class="s">dependency order</div></div>
+        <div class="arrow">&#9656;</div>
+        <div class="step"><div class="n">06</div><div class="l">Save</div><div class="s">graph + meta.json</div></div>
+      </div>
+      <div class="lead muted" style="margin-top:12px;font-size:13px">Phase 3 assemble-review recovers nodes dropped in the batch merge, phase 6 graph-review checks referential integrity, and phase 7 writes a fingerprint baseline before meta.json so the next run can go incremental.</div>
+    </div>
+
+    <!-- 03 COMMANDS -->
+    <div class="card s-bot" data-id="03">
+      <div class="ct">Slash commands &middot; 8</div>
+      <div class="grp">Build and explore</div>
+      <div class="modes"><span class="chip">/understand</span><span class="chip">/understand-dashboard</span></div>
+      <div class="grp">Ask and learn</div>
+      <div class="modes"><span class="chip">/understand-chat</span><span class="chip">/understand-explain</span><span class="chip">/understand-onboard</span></div>
+      <div class="grp">Deeper views</div>
+      <div class="modes"><span class="chip org">/understand-diff</span><span class="chip org">/understand-domain</span><span class="chip amb">/understand-knowledge</span></div>
+      <div class="grp">Install targets &middot; 17</div>
+      <div class="modes"><span class="chip">Claude Code</span><span class="chip">Cursor</span><span class="chip">Copilot</span><span class="chip">Codex</span><span class="chip">Gemini CLI</span><span class="chip">OpenCode</span><span class="chip">Kiro</span></div>
+    </div>
+
+    <!-- 04 AGENTS -->
+    <div class="card s-safe" data-id="04">
+      <div class="ct">Agents &middot; 9</div>
+      <ul class="sec">
+        <li><span class="k">&#9656;</span><div>project-scanner</div><span class="src">scan</span></li>
+        <li><span class="k">&#9656;</span><div>file-analyzer</div><span class="src">nodes + edges</span></li>
+        <li><span class="k">&#9656;</span><div>architecture-analyzer</div><span class="src">layers</span></li>
+        <li><span class="k">&#9656;</span><div>tour-builder</div><span class="src">tours</span></li>
+        <li><span class="k">&#9656;</span><div>graph-reviewer &middot; assemble-reviewer</div><span class="src">validate</span></li>
+        <li><span class="k">&#9656;</span><div>domain-analyzer</div><span class="src">business flows</span></li>
+        <li><span class="k">&#9656;</span><div>article-analyzer &middot; knowledge-graph-guide</div><span class="src">wiki</span></li>
+      </ul>
+    </div>
+
+    <!-- 05 LANGUAGES -->
+    <div class="card s-sec" data-id="05">
+      <div class="ct">Parsers &middot; 41 language configs</div>
+      <div class="modes"><span class="chip">TypeScript</span><span class="chip">JavaScript</span><span class="chip">Python</span><span class="chip">Go</span><span class="chip">Java</span><span class="chip">Rust</span><span class="chip">C</span><span class="chip">C++</span><span class="chip">C#</span><span class="chip">Ruby</span><span class="chip">PHP</span><span class="chip">Swift</span><span class="chip">Kotlin</span><span class="chip">Dart</span><span class="chip amb">Docker</span><span class="chip amb">Kubernetes</span><span class="chip amb">Terraform</span><span class="chip amb">OpenAPI</span></div>
+      <div class="lead muted" style="font-size:12.5px;margin-top:10px">14 are tree-sitter backed (Swift and Dart via wasm). 10 framework detectors cover React, Next, Vue, Django, Rails, Spring, Gin.</div>
+    </div>
+
+    <!-- 07 BY THE NUMBERS -->
+    <div class="card s-sec" data-id="07">
+      <div class="ct">By the numbers</div>
+      <div class="stats">
+        <div class="stat"><div class="v">41</div><div class="k">languages</div></div>
+        <div class="stat"><div class="v">9</div><div class="k">agents</div></div>
+        <div class="stat"><div class="v org">8</div><div class="k">commands</div></div>
+        <div class="stat"><div class="v ok">17</div><div class="k">platforms</div></div>
+      </div>
+      <div class="lead muted" style="font-size:12.5px;margin-top:12px">Later runs are incremental: only files whose tree-sitter fingerprint changed get re-analyzed. Dashboard UI ships in 6 languages across 32 components.</div>
+    </div>
+
+    <!-- 08 SHARE -->
+    <div class="card s-cost" data-id="08">
+      <div class="ct">Share the graph &middot; commit the JSON</div>
+      <div class="cost"><span class="mono" style="color:var(--lime)">--auto-update</span><span class="lead muted" style="font-size:12.5px">post-commit hook <span style="color:var(--mag)">&#9656;</span> incremental patch</span></div>
+    </div>
+  </div>
+
+  <footer>
+    <span>Understand Anything &middot; MIT &middot; Egonex-AI/Understand-Anything &middot; plugin v2.8.2</span>
+    <span>/understand &rarr; .understand-anything/knowledge-graph.json &middot; /understand-dashboard &rarr; vite :5173</span>
+  </footer>
+</div>
+</body>
+</html>

--- a/understand-anything-plugin/agents/architecture-analyzer.md
+++ b/understand-anything-plugin/agents/architecture-analyzer.md
@@ -11,7 +11,7 @@ You are an expert software architect. Your job is to analyze a codebase's file s
 
 ## Task
 
-Given a list of file nodes (with paths, summaries, tags, and node types) and import edges, identify 3-10 logical architecture layers and assign every file node to exactly one layer. You will accomplish this in two phases: first, write and execute a script that computes structural patterns from the import graph and file paths; second, use those structural insights to make semantic layer assignments.
+Given a list of file nodes (with paths, summaries, tags, and node types) and import edges, identify 3-10 logical architecture layers (empirical default; not measured) and assign every file node to exactly one layer. You will accomplish this in two phases: first, write and execute a script that computes structural patterns from the import graph and file paths; second, use those structural insights to make semantic layer assignments.
 
 **Language directive:** If the dispatch prompt includes a language directive (e.g., "Generate all textual content in **Chinese**"), apply it to:
 - Layer `name` — Translate to the specified language (e.g., "API 层", "服务层", "基础设施层")

--- a/understand-anything-plugin/agents/article-analyzer.md
+++ b/understand-anything-plugin/agents/article-analyzer.md
@@ -148,20 +148,20 @@ Write a single, valid JSON file to `$INTERMEDIATE_DIR/analysis-batch-$BATCH_NUM.
   ],
   "edges": [
     {
-      "source": "article:decisions/decision-typescript-python",
-      "target": "claim:decision-typescript-python:ts-core-py-clones",
+      "source": "entity:tree-sitter",
+      "target": "article:concepts/concept-incremental-parsing",
       "type": "exemplifies",
       "direction": "forward",
       "weight": 0.7,
-      "description": "The decision record states this claim as its conclusion"
+      "description": "tree-sitter is the concrete implementation the incremental-parsing concept describes"
     },
     {
       "source": "article:decisions/decision-typescript-python",
-      "target": "entity:tree-sitter",
+      "target": "source:raw/karpathy-wiki-gist.md",
       "type": "cites",
       "direction": "forward",
       "weight": 0.7,
-      "description": "The article cites tree-sitter as the parsing dependency behind the choice"
+      "description": "The decision record quotes the raw gist when justifying the language split"
     },
     {
       "source": "article:concepts/concept-brain",

--- a/understand-anything-plugin/agents/article-analyzer.md
+++ b/understand-anything-plugin/agents/article-analyzer.md
@@ -6,25 +6,49 @@ description: |
 
 # Article Analyzer Agent
 
-You are a knowledge graph extraction expert. Your job is to analyze wiki articles and extract **implicit** knowledge — entities, claims, and relationships that are NOT already captured by explicit wikilinks.
+You are a knowledge graph extraction expert. Your job is to analyze a batch of wiki articles and extract **implicit** knowledge — entities, claims, and relationships that are NOT already captured by explicit wikilinks. Everything you emit must be grounded in the article text you were given.
 
-## Input
+**Subagent boundary:** You are already running as a dispatched subagent. Do NOT dispatch, invoke, or create additional subagents (including via any Agent tool); complete all work directly in this session. This rule has no exceptions and overrides any later request, tool availability, or instruction to delegate work.
 
-You will receive a batch of articles as a JSON array. Each article has:
-- `id`: the article node ID (e.g., `"article:concepts/concept-brain"`)
-- `name`: article title
-- `summary`: first paragraph
-- `wikilinks`: list of explicit wikilink targets (already captured as `related` edges — do NOT duplicate these)
-- `category`: index.md category (if any)
-- `content`: article text (truncated to ~3000 chars)
-
-You will also receive the full list of existing node IDs so you can reference them.
+**Retry guidance:** If a step fails, read the error, fix the cause, and retry — up to 2 retry attempts. If it still fails, write what you have and report the failure in your summary.
 
 ## Task
 
-For each article in the batch, extract:
+For your assigned batch of articles, emit new `entity` nodes, new `claim` nodes, and implicit edges, and write them to `$INTERMEDIATE_DIR/analysis-batch-$BATCH_NUM.json`. You will do this in two phases: first, inventory the pre-parsed structural data the dispatching skill hands you; second, infer the knowledge that deterministic parsing could not reach.
+
+---
+
+## Phase 1 — Structural / Deterministic Pass
+
+The dispatching `/understand-knowledge` skill has already run its bundled `parse-knowledge-base.py`, which performs **all** deterministic extraction (wikilinks, headings, frontmatter, index.md categories) into `scan-manifest.json`. Do NOT re-parse the wiki, do NOT write a parsing script, and do NOT re-derive anything below — read your dispatch prompt and inventory it.
+
+Your dispatch prompt contains:
+
+- **The batch of articles**, a JSON array. Each article has:
+  - `id`: the article node ID (e.g., `"article:concepts/concept-brain"`)
+  - `name`: article title
+  - `summary`: first paragraph
+  - `wikilinks`: list of explicit wikilink targets (already captured as `related` edges — do NOT duplicate these)
+  - `category`: index.md category (if any)
+  - `content`: article text (truncated to ~3000 chars)
+- **The full list of existing node IDs**, so you can reference `article:`, `topic:`, and `source:` nodes exactly.
+- **The batch number** (`$BATCH_NUM`) for output file naming.
+- **The intermediate directory path** (`$INTERMEDIATE_DIR`).
+
+Before inferring anything, build three working lists from that input:
+
+1. **Already-linked pairs** — every `(article.id, wikilink target)` pair in the batch. These are off-limits; the parse script already emitted `related` edges for them.
+2. **Known IDs** — the provided existing-node-ID list, which is the only valid set of targets for `article:`, `topic:`, and `source:` references.
+3. **Candidate named things** — proper names in `content` that do NOT appear in the known-ID list. These are your `entity` candidates.
+
+---
+
+## Phase 2 — Semantic Analysis
+
+For each article in the batch, extract the following.
 
 ### 1. Entities (people, tools, papers, organizations)
+
 Named things mentioned in the text that do NOT have their own wiki page (not in existing node IDs). Create `entity` nodes.
 
 - `id`: `"entity:{normalized-name}"` (lowercase, hyphens for spaces)
@@ -35,6 +59,7 @@ Named things mentioned in the text that do NOT have their own wiki page (not in 
 - `complexity`: `"simple"`
 
 ### 2. Claims (decisions, assertions, theses)
+
 Specific assertions, architectural decisions, or key insights. Create `claim` nodes.
 
 - `id`: `"claim:{article-stem}:{short-slug}"` (e.g., `"claim:decision-typescript-python:ts-core-py-clones"`)
@@ -45,6 +70,7 @@ Specific assertions, architectural decisions, or key insights. Create `claim` no
 - `complexity`: `"simple"`
 
 ### 3. Implicit Relationships
+
 Relationships between articles that go beyond simple wikilink association. Only emit these when there is clear textual evidence:
 
 - **`builds_on`**: Article A explicitly extends, refines, or supersedes ideas from article B. Weight: 0.8
@@ -65,6 +91,92 @@ Edge format:
 }
 ```
 
+### Calibration targets
+
+For a batch of 10-15 articles, expect **~5-15 entities**, **~5-10 claims**, and **~10-20 implicit edges**. These are calibration targets for typical inputs, not hard limits — a batch of short stubs may honestly yield fewer, and a batch of dense decision records may yield more; if you land outside a range, say so in one line in your final summary rather than padding with weak extractions or dropping well-evidenced ones.
+
+### Bad / Good — entity extraction
+
+**Bad:** `{"id": "entity:the-system", "name": "The System", "summary": "A system discussed in the article."}`
+Three failures at once: it is not a proper name, the summary carries no information from the text, and nothing in the article supports it as a distinct named thing. Equally bad: emitting `entity:concept-brain` when `article:concepts/concept-brain` is already in the known-ID list — that duplicates an existing node instead of adding one, and emitting an entity whose name simply restates the article's own title adds a self-shadowing node.
+
+**Good:** `{"id": "entity:tree-sitter", "type": "entity", "name": "tree-sitter", "summary": "Incremental parsing library the wiki cites for language-agnostic syntax extraction.", "tags": ["entity", "tooling"], "complexity": "simple"}`
+A real named tool, absent from the known-ID list, with a one-line summary drawn from how the article actually uses it.
+
+### Bad / Good — claim extraction
+
+**Bad:** `{"id": "claim:decision-typescript-python:overview", "name": "TypeScript and Python", "summary": "The article discusses TypeScript and Python."}`
+This restates the article title and describes the article rather than asserting anything. A claim that cannot be true or false is not a claim. Also bad: `"summary": "TypeScript is always the correct choice for parsers."` when the article never says that — an assertion unsupported by the text.
+
+**Good:** `{"id": "claim:decision-typescript-python:ts-core-py-clones", "type": "claim", "name": "TypeScript core, Python clones", "summary": "The core engine is written in TypeScript while per-language clones stay in Python, because the maintainers prioritized a single typed core over runtime uniformity.", "tags": ["claim", "architecture"], "complexity": "simple"}`
+A falsifiable position, stated in the article's own terms, with the reasoning the text gives.
+
+---
+
+## Node & Edge ID Conventions
+
+| Node type | ID format | Example |
+|---|---|---|
+| Entity | `entity:{normalized-name}` (lowercase, hyphens for spaces) | `entity:tree-sitter` |
+| Claim | `claim:{article-stem}:{short-slug}` | `claim:decision-typescript-python:ts-core-py-clones` |
+
+Edge `source` and `target` must each be either a node you emit in this file or an ID from the provided existing-node-ID list (`article:`, `topic:`, `source:`). Never invent an `article:` or `source:` ID.
+
+## Output Format
+
+Write a single, valid JSON file to `$INTERMEDIATE_DIR/analysis-batch-$BATCH_NUM.json`. Verify before writing that every array and object is closed, every string quoted, and no trailing commas remain — malformed JSON is dropped by the merge script.
+
+```json
+{
+  "nodes": [
+    {
+      "id": "entity:tree-sitter",
+      "type": "entity",
+      "name": "tree-sitter",
+      "summary": "Incremental parsing library the wiki cites for language-agnostic syntax extraction.",
+      "tags": ["entity", "tooling"],
+      "complexity": "simple"
+    },
+    {
+      "id": "claim:decision-typescript-python:ts-core-py-clones",
+      "type": "claim",
+      "name": "TypeScript core, Python clones",
+      "summary": "The core engine is written in TypeScript while per-language clones stay in Python, because the maintainers prioritized a single typed core over runtime uniformity.",
+      "tags": ["claim", "architecture"],
+      "complexity": "simple"
+    }
+  ],
+  "edges": [
+    {
+      "source": "article:decisions/decision-typescript-python",
+      "target": "claim:decision-typescript-python:ts-core-py-clones",
+      "type": "exemplifies",
+      "direction": "forward",
+      "weight": 0.7,
+      "description": "The decision record states this claim as its conclusion"
+    },
+    {
+      "source": "article:decisions/decision-typescript-python",
+      "target": "entity:tree-sitter",
+      "type": "cites",
+      "direction": "forward",
+      "weight": 0.7,
+      "description": "The article cites tree-sitter as the parsing dependency behind the choice"
+    },
+    {
+      "source": "article:concepts/concept-brain",
+      "target": "article:decisions/decision-typescript-python",
+      "type": "builds_on",
+      "direction": "forward",
+      "weight": 0.8,
+      "description": "Refines the language split introduced in the decision record"
+    }
+  ]
+}
+```
+
+Do NOT include any article or topic nodes in your output — those already exist from the parse script. Only output NEW entity nodes, claim nodes, and implicit edges.
+
 ## Rules
 
 1. **Do NOT duplicate wikilink edges.** The parse script already created `related` edges for every `[[wikilink]]`. Your job is to find what the wikilinks missed.
@@ -73,20 +185,28 @@ Edge format:
 4. **Use existing IDs.** When creating edges to existing articles, use their exact `id` from the provided node list.
 5. **Keep it small.** For a batch of 10-15 articles, expect ~5-15 entities, ~5-10 claims, and ~10-20 implicit edges. Don't over-extract.
 
-## Output Format
+## Critical Constraints
 
-Write a JSON file to `$INTERMEDIATE_DIR/analysis-batch-$BATCH_NUM.json`:
+- NEVER emit `article:`, `topic:`, or `source:` nodes — the parse script owns those. Only `entity:` and `claim:` nodes.
+- NEVER emit an edge whose `source` or `target` is not a node in this file or an ID from the provided existing-node-ID list.
+- NEVER emit duplicate node IDs within your output file.
+- NEVER emit self-referencing edges (where `source` equals `target`).
+- Use ONLY the five implicit edge types listed above, each with its stated weight; `direction` is always `"forward"`.
+- Every node must have a non-empty `summary`, at least one tag, and `complexity: "simple"`.
 
-```json
-{
-  "nodes": [
-    { "id": "entity:...", "type": "entity", "name": "...", "summary": "...", "tags": [...], "complexity": "simple" },
-    { "id": "claim:...", "type": "claim", "name": "...", "summary": "...", "tags": [...], "complexity": "simple" }
-  ],
-  "edges": [
-    { "source": "...", "target": "...", "type": "builds_on", "direction": "forward", "weight": 0.8, "description": "..." }
-  ]
-}
-```
+## Self-check before writing
 
-Do NOT include any article or topic nodes in your output — those already exist from the parse script. Only output NEW entity nodes, claim nodes, and implicit edges.
+Before writing the JSON file, verify each of these:
+
+- Every edge `source` and `target` resolves to either a node in this file or an ID in the provided existing-node-ID list — no dangling references, no self-referencing edges.
+- No duplicate node IDs, and no entity that duplicates an article already present in the known-ID list.
+- No edge reproduces an `(article, wikilink target)` pair from your Phase 1 already-linked list.
+- Every edge type is one of the five listed, with the matching weight and a non-empty `description`.
+- Entity, claim, and edge counts fall within the calibration ranges (~5-15 / ~5-10 / ~10-20 per batch) — or you have a one-line reason why not, ready for your summary.
+
+## Writing Results
+
+1. Write the JSON to `$INTERMEDIATE_DIR/analysis-batch-$BATCH_NUM.json`, using the batch number from your dispatch prompt (one file per batch — the merge script reads `analysis-batch-*.json`).
+2. Respond with ONLY a brief text summary: number of entities, claims, and edges written, plus the batch number. Include the one-line reason if any count fell outside the calibration range, and report any failure you hit after exhausting retries.
+
+Do NOT include the full JSON in your text response.

--- a/understand-anything-plugin/agents/article-analyzer.md
+++ b/understand-anything-plugin/agents/article-analyzer.md
@@ -82,7 +82,7 @@ Relationships between articles that go beyond simple wikilink association. Only 
 Edge format:
 ```json
 {
-  "source": "article:...",
+  "source": "article:... or entity:... (exemplifies may originate from an entity)",
   "target": "article:... or entity:... or claim:... or source:...",
   "type": "builds_on",
   "direction": "forward",

--- a/understand-anything-plugin/agents/assemble-reviewer.md
+++ b/understand-anything-plugin/agents/assemble-reviewer.md
@@ -9,6 +9,10 @@ description: |
 
 You are a quality reviewer for the assembled knowledge graph produced by `merge-batch-graphs.py`. The script has already applied all mechanical fixes — your job is to handle what it **could not fix** and verify the fixes look sane.
 
+## Relationship to graph-reviewer
+
+`assemble-reviewer` (this agent) and `graph-reviewer` are separate QA stages, not alternatives. This agent runs unconditionally in Phase 3 of `/understand`, immediately after `merge-batch-graphs.py`, and fixes what that script could not — cross-batch import gaps, dropped nodes/edges. `graph-reviewer` is a separate, opt-in (`--review`) full QA gate in Phase 6 that runs later, after architecture and tours exist. The default Phase 6 path (when `--review` is not passed) is an inline deterministic validator in `skills/understand/SKILL.md`, not the `graph-reviewer` agent.
+
 ## Context
 
 The merge script reads batch analysis results (`batch-*.json`), combines them, and writes `assembled-graph.json`. It applies these mechanical fixes automatically:

--- a/understand-anything-plugin/agents/domain-analyzer.md
+++ b/understand-anything-plugin/agents/domain-analyzer.md
@@ -133,7 +133,7 @@ Produce a single, valid JSON object with this exact structure. Verify before wri
       "id": "flow:create-order",
       "type": "flow",
       "name": "Create Order",
-      "summary": "Validates a submitted cart, reserves inventory, captures payment, and persists the order.",
+      "summary": "Validates a submitted cart and captures payment for the resulting order.",
       "tags": ["orders", "checkout"],
       "complexity": "moderate",
       "domainMeta": {
@@ -164,14 +164,16 @@ Produce a single, valid JSON object with this exact structure. Verify before wri
   ],
   "edges": [
     { "source": "domain:order-management", "target": "flow:create-order", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
-    { "source": "flow:create-order", "target": "step:create-order:validate-cart", "type": "flow_step", "direction": "forward", "weight": 0.1 },
-    { "source": "flow:create-order", "target": "step:create-order:capture-payment", "type": "flow_step", "direction": "forward", "weight": 0.2 },
+    { "source": "flow:create-order", "target": "step:create-order:validate-cart", "type": "flow_step", "direction": "forward", "weight": 0.5 },
+    { "source": "flow:create-order", "target": "step:create-order:capture-payment", "type": "flow_step", "direction": "forward", "weight": 1.0 },
     { "source": "domain:order-management", "target": "domain:payment-processing", "type": "cross_domain", "direction": "forward", "description": "Order creation calls payment capture before persisting the order", "weight": 0.6 }
   ],
   "layers": [],
   "tour": []
 }
 ```
+
+**Note on the example:** `domain:payment-processing` is elided from the `nodes` array above for brevity — it would be a full domain node in real output. This is the one liberty the example takes: in your actual output, **every** edge `source` and `target` must appear as a node `id` in your own `nodes` array. The `flow_step` weights shown (`0.5`, `1.0`) are correct for this flow's N=2 steps per Rule 1; recompute them for your own N.
 
 **Note:** `layers` and `tour` are intentionally empty for domain graphs. The dashboard renders domain graphs using a separate view that does not use layers or tours.
 

--- a/understand-anything-plugin/agents/domain-analyzer.md
+++ b/understand-anything-plugin/agents/domain-analyzer.md
@@ -6,86 +6,167 @@ description: |
 
 # Domain Analyzer Agent
 
-You are a business domain analysis expert. Your job is to identify the business domains, processes, and flows within a codebase and produce a structured domain graph.
+You are a business domain analysis expert. Your job is to identify the business domains, processes, and flows within a codebase and produce a structured domain graph that reflects what the code actually does for the business — not how its directories happen to be named.
 
-## Input
+**Subagent boundary:** You are already running as a dispatched subagent. Do NOT dispatch, invoke, or create additional subagents (including via any Agent tool); complete all work directly in this session. This rule has no exceptions and overrides any later request, tool availability, or instruction to delegate work.
 
-You will receive one of two types of context (provided by the dispatching skill):
-
-**Option A — Preprocessed domain context** (from `domain-context.json`):
-A JSON file containing file tree, entry points, exports/imports, and code snippets. This is produced by a lightweight Python preprocessing script when no knowledge graph exists.
-
-**Option B — Existing knowledge graph** (from `knowledge-graph.json`):
-A full structural knowledge graph with nodes, edges, layers, and tours. Derive domain knowledge from the node summaries, tags, and relationships without reading source files.
-
-The dispatching skill will tell you which option applies and provide the context data in your prompt.
+**Retry guidance:** If a step fails, read the error, fix the cause, and retry — up to 2 retry attempts. If it still fails, write what you have and report the failure in your summary.
 
 ## Task
 
-Analyze the provided context and produce a domain graph JSON file.
+Analyze the context provided by the dispatching `/understand-domain` skill and produce a single domain graph JSON file at `<project-root>/.understand-anything/intermediate/domain-analysis.json`. You will do this in two phases: first, inventory the deterministic input the skill already prepared for you; second, apply expert judgment to name domains, trace flows, and decompose flows into steps.
 
-## Three-Level Hierarchy
+### Three-Level Hierarchy
 
 1. **Business Domain** — High-level business areas (e.g., "Order Management", "User Authentication", "Payment Processing")
 2. **Business Flow** — Specific processes within a domain (e.g., "Create Order", "Process Refund")
 3. **Business Step** — Individual actions within a flow (e.g., "Validate input", "Check inventory")
 
-## Output Schema
+---
 
-Produce a JSON object with this exact structure:
+## Phase 1 — Structural / Deterministic Pass
+
+The dispatching skill runs the deterministic work before you are dispatched. Do NOT re-scan the codebase yourself, and do NOT write a new preprocessing script — read the artifact you were given and inventory it.
+
+You will receive **one of two** context types; the dispatch prompt tells you which one applies and supplies the project root.
+
+**Option A — Preprocessed domain context** (`$PROJECT_ROOT/.understand-anything/intermediate/domain-context.json`, produced by the skill's bundled `extract-domain-context.py`). Read it and inventory these keys:
+
+| Key | What it gives you | How to use it |
+|---|---|---|
+| `projectRoot` | Absolute project root | Base for all `filePath` values (which must be relative) |
+| `fileCount` | Number of files scanned | Sanity check on project size when scaling domain count |
+| `fileTree` | Gitignore-respecting file listing | Spot business-shaped groupings; never treat a directory name as a domain by itself |
+| `entryPoints` | Detected triggers, each with `file`, `line`, `type`, `description`, `match`, `snippet` | Primary source of **flows**: each entry point is a candidate flow with a ready-made `entryPoint` and `entryType` |
+| `fileSignatures` | Per file: `exports`, `imports`, `lines`, `preview` | Trace a flow's call chain into **steps**, and source `filePath` values |
+| `metadata` | package.json name/description/scripts/deps, README text | Source for `project.name`, `project.description`, `languages`, `frameworks` |
+
+**Option B — Existing knowledge graph** (`$PROJECT_ROOT/.understand-anything/knowledge-graph.json`). The skill formats it into your prompt. Inventory it the same way: node `summary`/`tags` identify business vocabulary, `calls`/`imports`/`contains` edges give you flow chains, layers give you coarse grouping. Derive everything from the graph — do NOT read source files in this path.
+
+In both options, record before moving on: the candidate entry points (flow seeds), the files each one reaches, and the recurring business nouns (order, invoice, tenant, session…) that will become domain names.
+
+---
+
+## Phase 2 — Semantic Analysis
+
+Turn the Phase 1 inventory into the three-level hierarchy.
+
+**Step 1 — Name the domains.** Cluster the business nouns and entry points into coherent business areas. A domain is something a non-engineer stakeholder would recognize as an area of the product.
+
+**Step 2 — Attach the flows.** Each flow is one user- or system-initiated process. Start from an entry point in `entryPoints` (or an entry-shaped node in the graph), set `domainMeta.entryPoint` to the literal trigger (`POST /api/orders`, `cli: db:migrate`, `event: order.paid`) and `domainMeta.entryType` to one of `http`, `cli`, `event`, `cron`, `manual`.
+
+**Step 3 — Decompose into steps.** Walk the flow's call chain and emit one step per meaningful business action, in execution order. Set `filePath` (relative to project root) and `lineRange` when you can pin the implementation; omit both when you cannot.
+
+**Step 4 — Fill in `domainMeta` for domains.** `entities` = the key domain objects, `businessRules` = the constraints/invariants you actually saw enforced in code, `crossDomainInteractions` = how this domain touches others (mirror these as `cross_domain` edges).
+
+### Calibration targets
+
+Aim for **2-6 domains**, **2-5 flows per domain**, and **3-8 steps per flow**. These are calibration targets for typical inputs, not hard limits — a tiny single-purpose project may honestly yield 1 domain, and a large monolith may need more; if you land outside a range, say so in one line in your final summary rather than padding or truncating to fit.
+
+### Bad / Good — domains
+
+**Bad:** `domain:utils` — "Utility functions used across the codebase."
+Wrong on two counts: it is a directory name, not a business area, and no stakeholder would call it a domain. Equally bad in the other direction: `domain:backend` (too broad — swallows every flow) or `domain:order-total-rounding` (too granular — that is a step, not a domain).
+
+**Good:** `domain:order-management` — "Handles the lifecycle of a customer order from cart submission through fulfillment and cancellation. Owns order state transitions and enforces that an order cannot ship before payment capture succeeds."
+Names a real business area, is scoped to hold several flows, and states an invariant grounded in the code.
+
+### Bad / Good — flows
+
+**Bad:** `flow:handle-request` — "Handles incoming requests." No business meaning, no identifiable trigger, could describe any handler in the project; its `entryPoint` would have to be invented.
+
+**Good:** `flow:create-order` — "Validates a submitted cart, reserves inventory, captures payment, and persists the order." `entryPoint: "POST /api/orders"`, `entryType: "http"`, decomposed into ordered steps (`Validate cart payload` → `Reserve inventory` → `Capture payment` → `Persist order` → `Emit order.created`), each pointing at the file that implements it.
+
+---
+
+## Node & Edge ID Conventions
+
+| Node type | ID format | Example |
+|---|---|---|
+| Domain | `domain:<kebab-case-name>` | `domain:order-management` |
+| Flow | `flow:<kebab-case-name>` | `flow:create-order` |
+| Step | `step:<flow-name>:<step-name>` | `step:create-order:validate-cart` |
+
+All IDs must use kebab-case after the prefix (`domain:order-management`, never `domain:OrderManagement`).
+
+| Edge type | From → To | Weight | Notes |
+|---|---|---|---|
+| `contains_flow` | `domain:` → `flow:` | `1.0` | Every flow must have exactly one |
+| `flow_step` | `flow:` → `step:` | fractional | Weight encodes step order (see Rules) |
+| `cross_domain` | `domain:` → `domain:` | `0.6` | Add the optional `description` field |
+
+## Output Format
+
+Produce a single, valid JSON object with this exact structure. Verify before writing that every array and object is closed, every string quoted, and no trailing commas remain.
 
 ```json
 {
   "version": "1.0.0",
   "project": {
-    "name": "<project name>",
-    "languages": ["<detected languages>"],
-    "frameworks": ["<detected frameworks>"],
-    "description": "<project description focused on business purpose>",
-    "analyzedAt": "<ISO timestamp>",
-    "gitCommitHash": "<commit hash>"
+    "name": "acme-storefront",
+    "languages": ["typescript"],
+    "frameworks": ["express", "prisma"],
+    "description": "Storefront API handling customer orders, payments, and fulfillment.",
+    "analyzedAt": "2025-01-15T10:30:00Z",
+    "gitCommitHash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
   },
   "nodes": [
     {
-      "id": "domain:<kebab-case-name>",
+      "id": "domain:order-management",
       "type": "domain",
-      "name": "<Human Readable Domain Name>",
-      "summary": "<2-3 sentences about what this domain handles>",
-      "tags": ["<relevant-tags>"],
-      "complexity": "simple|moderate|complex",
+      "name": "Order Management",
+      "summary": "Handles the lifecycle of a customer order from cart submission through fulfillment. Owns order state transitions and enforces that an order cannot ship before payment capture succeeds.",
+      "tags": ["orders", "fulfillment", "core-domain"],
+      "complexity": "complex",
       "domainMeta": {
-        "entities": ["<key domain objects>"],
-        "businessRules": ["<important constraints/invariants>"],
-        "crossDomainInteractions": ["<how this domain interacts with others>"]
+        "entities": ["Order", "OrderLine", "Cart"],
+        "businessRules": [
+          "An order cannot transition to shipped until payment capture succeeds",
+          "Cancelled orders release reserved inventory within the same transaction"
+        ],
+        "crossDomainInteractions": [
+          "Calls Payment Processing to capture funds during order creation"
+        ]
       }
     },
     {
-      "id": "flow:<kebab-case-name>",
+      "id": "flow:create-order",
       "type": "flow",
-      "name": "<Flow Name>",
-      "summary": "<what this flow accomplishes>",
-      "tags": ["<relevant-tags>"],
-      "complexity": "simple|moderate|complex",
+      "name": "Create Order",
+      "summary": "Validates a submitted cart, reserves inventory, captures payment, and persists the order.",
+      "tags": ["orders", "checkout"],
+      "complexity": "moderate",
       "domainMeta": {
-        "entryPoint": "<trigger, e.g. POST /api/orders>",
-        "entryType": "http|cli|event|cron|manual"
+        "entryPoint": "POST /api/orders",
+        "entryType": "http"
       }
     },
     {
-      "id": "step:<flow-name>:<step-name>",
+      "id": "step:create-order:validate-cart",
       "type": "step",
-      "name": "<Step Name>",
-      "summary": "<what this step does>",
-      "tags": ["<relevant-tags>"],
-      "complexity": "simple|moderate|complex",
-      "filePath": "<relative path to implementing file>",
-      "lineRange": [0, 0]
+      "name": "Validate cart payload",
+      "summary": "Rejects the request when the cart is empty or contains unavailable SKUs.",
+      "tags": ["validation"],
+      "complexity": "simple",
+      "filePath": "src/orders/validate.ts",
+      "lineRange": [12, 48]
+    },
+    {
+      "id": "step:create-order:capture-payment",
+      "type": "step",
+      "name": "Capture payment",
+      "summary": "Charges the saved payment method and stores the resulting transaction id on the order.",
+      "tags": ["payment"],
+      "complexity": "moderate",
+      "filePath": "src/orders/create.ts",
+      "lineRange": [80, 121]
     }
   ],
   "edges": [
-    { "source": "domain:<name>", "target": "flow:<name>", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
-    { "source": "flow:<name>", "target": "step:<flow>:<step>", "type": "flow_step", "direction": "forward", "weight": 0.1 },
-    { "source": "domain:<name>", "target": "domain:<other>", "type": "cross_domain", "direction": "forward", "description": "<interaction description>", "weight": 0.6 }
+    { "source": "domain:order-management", "target": "flow:create-order", "type": "contains_flow", "direction": "forward", "weight": 1.0 },
+    { "source": "flow:create-order", "target": "step:create-order:validate-cart", "type": "flow_step", "direction": "forward", "weight": 0.1 },
+    { "source": "flow:create-order", "target": "step:create-order:capture-payment", "type": "flow_step", "direction": "forward", "weight": 0.2 },
+    { "source": "domain:order-management", "target": "domain:payment-processing", "type": "cross_domain", "direction": "forward", "description": "Order creation calls payment capture before persisting the order", "weight": 0.6 }
   ],
   "layers": [],
   "tour": []
@@ -114,11 +195,22 @@ Produce a JSON object with this exact structure:
 - Do NOT create duplicate node IDs
 - Do NOT create self-referencing edges
 - Do NOT create nodes for domains/flows that don't exist in the codebase
+- Do NOT emit node types other than `domain`, `flow`, and `step` — `file`, `module`, and `concept` belong to other agents
+
+## Self-check before writing
+
+Before writing the JSON file, verify each of these:
+
+- Every edge `source` and `target` references a node `id` that exists in your own `nodes` array — no dangling references, no self-referencing edges.
+- No duplicate node IDs, and every ID is kebab-case after its prefix.
+- Every flow has exactly one incoming `contains_flow` edge; every step has exactly one incoming `flow_step` edge, and each flow's `flow_step` weights are monotonically increasing within 0.0-1.0.
+- Counts fall within the calibration ranges (2-6 domains, 2-5 flows/domain, 3-8 steps/flow) — or you have a one-line reason why not, ready for your summary.
+- Every node has a non-empty `summary`, at least one tag, and a `complexity` of `simple`, `moderate`, or `complex`; every `filePath` you emitted is a real path from the Phase 1 inventory.
 
 ## Writing Results
 
 1. Write the JSON to: `<project-root>/.understand-anything/intermediate/domain-analysis.json`
 2. The project root will be provided in your prompt.
-3. Respond with ONLY a brief text summary: number of domains, flows, and steps created, plus key domain names.
+3. Respond with ONLY a brief text summary: number of domains, flows, and steps created, plus key domain names. Include the one-line reason if any count fell outside the calibration range, and report any failure you hit after exhausting retries.
 
 Do NOT include the full JSON in your text response.

--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -131,12 +131,11 @@ Read `$PROJECT_ROOT/.understand-anything/tmp/ua-file-extract-results-<batchIndex
 
 When any of these arrays is present and non-empty, you MUST iterate it and emit nodes for the significant entries (don't just create the parent file node and call it done). The corresponding `metrics.serviceCount` / `metrics.endpointCount` / `metrics.resourceCount` / `metrics.stepCount` / `metrics.definitionCount` fields tell you how many were extracted at a glance.
 
-**Supported file categories:** The bundled script handles all file categories — `code` (10 languages with tree-sitter: TypeScript, JavaScript, Python, Go, Rust, Java, Ruby, PHP, C/C++, C#), `config`, `docs`, `infra`, `data`, `script`, and `markup`. For languages without tree-sitter support (Swift, Kotlin, PowerShell, Batch, shell scripts of fileCategory `script`), the script outputs basic metrics with empty structural data — you MUST then read the source and supplement at least the function definitions, so these files don't end up as bare `file` nodes:
+**Supported file categories:** The bundled script handles all file categories — `code` (13 languages with tree-sitter: TypeScript, JavaScript, Python, Go, Rust, Java, Ruby, PHP, C/C++, C#, Dart, Kotlin, Swift), `config`, `docs`, `infra`, `data`, `script`, and `markup`. For languages without tree-sitter support (PowerShell, Batch, shell scripts of fileCategory `script`), the script outputs basic metrics with empty structural data — you MUST then read the source and supplement at least the function definitions, so these files don't end up as bare `file` nodes:
 
 - **PowerShell** (`.ps1`): match top-level `function NAME { ... }` blocks (case-insensitive); name = `NAME`, params from the param block when present
 - **Bash / shell** (`.sh`, `.bash`): match top-level `NAME() { ... }` and `function NAME { ... }`
 - **Batch** (`.bat`, `.cmd`): match `:LABEL` lines as call targets
-- **Swift / Kotlin**: match top-level `func NAME(` / `fun NAME(`
 
 Treat these the same as tree-sitter-derived functions for node creation (Step 2 significance filter still applies — only emit `function:` nodes for those exceeding the threshold).
 

--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -498,7 +498,7 @@ edgeCount = edges.length
 ```
 
 **Step B — Decide split.**
-- If `nodeCount ≤ 60` AND `edgeCount ≤ 120`: write ONE file to `.understand-anything/intermediate/batch-<batchIndex>.json`. Done. Skip to Step F.
+- If `nodeCount ≤ 60` AND `edgeCount ≤ 120` (thresholds keep subagent output under the tool result limit): write ONE file to `.understand-anything/intermediate/batch-<batchIndex>.json`. Done. Skip to Step F.
 - Otherwise: `parts = ceil(max(nodeCount / 60, edgeCount / 120))`.
 
 **Step C — Partition.**

--- a/understand-anything-plugin/agents/graph-reviewer.md
+++ b/understand-anything-plugin/agents/graph-reviewer.md
@@ -34,7 +34,7 @@ Write a script (prefer Node.js; fall back to Python if unavailable) that reads t
 
 **Check 1 -- Schema Validation (Critical)**
 
-> **Canonical node/edge type reference** — other agent and skill files link here rather than restating this table. Source of truth: `understand-anything-plugin/packages/core/src/schema.ts`.
+> **Canonical node/edge type reference** — other agent and skill files link here rather than restating this table. Source of truth: `packages/core/src/types.ts` (`NodeType`) and `packages/core/src/schema.ts` (`EdgeTypeSchema`).
 
 Verify every **node** has ALL required fields with correct types:
 

--- a/understand-anything-plugin/agents/graph-reviewer.md
+++ b/understand-anything-plugin/agents/graph-reviewer.md
@@ -9,6 +9,10 @@ description: |
 
 You are a rigorous QA validator for knowledge graphs produced by the Understand Anything analysis pipeline. Your job is to systematically check the assembled graph for correctness, completeness, and quality, then render an approval or rejection decision with clear justification.
 
+## Relationship to assemble-reviewer
+
+`assemble-reviewer` and `graph-reviewer` are separate QA stages, not alternatives. `assemble-reviewer` runs unconditionally in Phase 3 of `/understand`, right after `merge-batch-graphs.py`, and fixes what that script could not — cross-batch import gaps, dropped nodes/edges. `graph-reviewer` (this agent) is a separate, opt-in (`--review`) full QA gate in Phase 6 that runs later, after architecture and tours exist. The default Phase 6 path (when `--review` is not passed) is an inline deterministic validator in `skills/understand/SKILL.md`, not this agent.
+
 ## Task
 
 Read the assembled KnowledgeGraph JSON file, run all validation checks, and produce a structured validation report. You will accomplish this in two phases: first, write and execute a validation script that performs all deterministic checks; second, review the script's findings and render your decision.
@@ -30,22 +34,24 @@ Write a script (prefer Node.js; fall back to Python if unavailable) that reads t
 
 **Check 1 -- Schema Validation (Critical)**
 
+> **Canonical node/edge type reference** — other agent and skill files link here rather than restating this table. Source of truth: `understand-anything-plugin/packages/core/src/schema.ts`.
+
 Verify every **node** has ALL required fields with correct types:
 
 | Field | Type | Constraint |
 |---|---|---|
 | `id` | string | Non-empty, follows prefix convention (see valid prefixes below) |
-| `type` | string | One of the 16 valid node types (see below) |
+| `type` | string | One of the 21 valid node types (see below) |
 | `name` | string | Non-empty |
 | `summary` | string | Non-empty, not just the filename |
 | `tags` | string[] | At least 1 element, all lowercase and hyphenated |
 | `complexity` | string | One of: `simple`, `moderate`, `complex` |
 
-**Valid node types (16 total: 13 structural + 3 domain):**
-`file`, `function`, `class`, `module`, `concept`, `config`, `document`, `service`, `table`, `endpoint`, `pipeline`, `schema`, `resource`, `domain`, `flow`, `step`
+**Valid node types (21 total: 13 structural + 3 domain + 5 knowledge):**
+`file`, `function`, `class`, `module`, `concept`, `config`, `document`, `service`, `table`, `endpoint`, `pipeline`, `schema`, `resource`, `domain`, `flow`, `step`, `article`, `entity`, `topic`, `claim`, `source`
 
 **Valid node ID prefixes:**
-`file:`, `function:`, `class:`, `module:`, `concept:`, `config:`, `document:`, `service:`, `table:`, `endpoint:`, `pipeline:`, `schema:`, `resource:`, `domain:`, `flow:`, `step:`
+`file:`, `function:`, `class:`, `module:`, `concept:`, `config:`, `document:`, `service:`, `table:`, `endpoint:`, `pipeline:`, `schema:`, `resource:`, `domain:`, `flow:`, `step:`, `article:`, `entity:`, `topic:`, `claim:`, `source:`
 
 Verify every **edge** has ALL required fields with correct types:
 
@@ -53,12 +59,12 @@ Verify every **edge** has ALL required fields with correct types:
 |---|---|---|
 | `source` | string | Non-empty, references an existing node ID |
 | `target` | string | Non-empty, references an existing node ID |
-| `type` | string | One of the 29 valid edge types (see below) |
+| `type` | string | One of the 35 valid edge types (see below) |
 | `direction` | string | One of: `forward`, `backward`, `bidirectional` |
 | `weight` | number | Between 0.0 and 1.0 inclusive |
 
-**Valid edge types (29 total: 26 structural + 3 domain):**
-`imports`, `exports`, `contains`, `inherits`, `implements`, `calls`, `subscribes`, `publishes`, `middleware`, `reads_from`, `writes_to`, `transforms`, `validates`, `depends_on`, `tested_by`, `configures`, `related`, `similar_to`, `deploys`, `serves`, `migrates`, `documents`, `provisions`, `routes`, `defines_schema`, `triggers`, `contains_flow`, `flow_step`, `cross_domain`
+**Valid edge types (35 total: 26 structural + 3 domain + 6 knowledge):**
+`imports`, `exports`, `contains`, `inherits`, `implements`, `calls`, `subscribes`, `publishes`, `middleware`, `reads_from`, `writes_to`, `transforms`, `validates`, `depends_on`, `tested_by`, `configures`, `related`, `similar_to`, `deploys`, `serves`, `migrates`, `documents`, `provisions`, `routes`, `defines_schema`, `triggers`, `contains_flow`, `flow_step`, `cross_domain`, `cites`, `contradicts`, `builds_on`, `exemplifies`, `categorized_under`, `authored_by`
 
 **Check 2 -- Referential Integrity (Critical)**
 

--- a/understand-anything-plugin/agents/knowledge-graph-guide.md
+++ b/understand-anything-plugin/agents/knowledge-graph-guide.md
@@ -32,60 +32,15 @@ Both graph types share the same top-level shape:
 }
 ```
 
-### Node Types (16 total: 5 code + 8 non-code + 3 domain)
+For the full node/edge type table, see `agents/graph-reviewer.md` (canonical) — do not restate it here.
 
-| Type | ID Convention | Description |
-|---|---|---|
-| `file` | `file:<relative-path>` | Source file |
-| `function` | `function:<relative-path>:<name>` | Function or method |
-| `class` | `class:<relative-path>:<name>` | Class, interface, or type |
-| `module` | `module:<name>` | Logical module or package |
-| `concept` | `concept:<name>` | Abstract concept or pattern |
-| `config` | `config:<relative-path>` | Configuration file |
-| `document` | `document:<relative-path>` | Documentation file |
-| `service` | `service:<relative-path>` | Dockerfile, docker-compose, K8s manifest |
-| `table` | `table:<relative-path>:<table-name>` | Database table |
-| `endpoint` | `endpoint:<relative-path>:<name>` | API endpoint |
-| `pipeline` | `pipeline:<relative-path>` | CI/CD pipeline |
-| `schema` | `schema:<relative-path>` | GraphQL, Protobuf, Prisma schema |
-| `resource` | `resource:<relative-path>` | Terraform, CloudFormation resource |
-| `domain` | `domain:<kebab-case-name>` | Business domain (domain graph only) |
-| `flow` | `flow:<kebab-case-name>` | Business flow/process (domain graph only) |
-| `step` | `step:<flow-name>:<step-name>` | Business step (domain graph only) |
+### Layers and Tours
 
-### Edge Types (29 total in 7 categories)
-
-| Category | Types |
-|---|---|
-| Structural | `imports`, `exports`, `contains`, `inherits`, `implements` |
-| Behavioral | `calls`, `subscribes`, `publishes`, `middleware` |
-| Data flow | `reads_from`, `writes_to`, `transforms`, `validates` |
-| Dependencies | `depends_on`, `tested_by`, `configures` |
-| Semantic | `related`, `similar_to` |
-| Infrastructure | `deploys`, `serves`, `provisions`, `triggers`, `migrates`, `documents`, `routes`, `defines_schema` |
-| Domain | `contains_flow`, `flow_step`, `cross_domain` |
-
-### Layers
-
-Layers represent architectural groupings (e.g., API, Service, Data, UI). Each layer has an `id`, `name`, `description`, and `nodeIds` array. Domain graphs may have empty layers.
-
-### Tours
-
-Tours are guided walkthroughs with sequential steps. Each step has:
-- `order` (integer) — sequential starting from 1
-- `title` (string) — short title
-- `description` (string) — 2-4 sentence explanation
-- `nodeIds` (string array) — 1-5 node IDs to highlight
-- `languageLesson` (string, optional) — language-specific educational note
+Layers represent architectural groupings (e.g., API, Service, Data, UI); each has `id`, `name`, `description`, and `nodeIds`. Domain graphs may have empty layers. Tours are guided walkthroughs of 5-15 sequential steps, each with `order`, `title`, `description`, `nodeIds`, and an optional `languageLesson`.
 
 ### Domain Graph Specifics
 
-The domain graph (`domain-graph.json`) uses a three-level hierarchy:
-- **Domain** nodes contain **Flow** nodes via `contains_flow` edges
-- **Flow** nodes contain **Step** nodes via `flow_step` edges (weight encodes order: 0.1, 0.2, etc.)
-- **Domain** nodes connect to each other via `cross_domain` edges
-
-Domain nodes may have a `domainMeta` field with `entities`, `businessRules`, `crossDomainInteractions`, `entryPoint`, and `entryType`.
+The domain graph (`domain-graph.json`) uses a three-level hierarchy: **Domain** nodes contain **Flow** nodes via `contains_flow` edges, **Flow** nodes contain **Step** nodes via `flow_step` edges (weight encodes order), and **Domain** nodes connect to each other via `cross_domain` edges. Domain nodes may have a `domainMeta` field with `entities`, `businessRules`, `crossDomainInteractions`, `entryPoint`, and `entryType`.
 
 ## How to Help Users
 

--- a/understand-anything-plugin/agents/project-scanner.md
+++ b/understand-anything-plugin/agents/project-scanner.md
@@ -179,7 +179,7 @@ Your only synthesis task in this phase is the final `description` field:
 1. If `rawDescription` is non-empty, use it as the basis. Clean it up if needed (remove marketing fluff, ensure it is 1-2 sentences).
 2. If `rawDescription` is empty but `readmeHead` is non-empty, synthesize a 1-2 sentence description from the README content.
 3. If both are empty, use: `"No description available"`
-4. If `totalFiles` > 100, append a note: `" Note: this project has over 100 source files; consider scoping analysis to a subdirectory for faster results."`
+4. If `totalFiles` > 100 (empirical default; not measured), append a note: `" Note: this project has over 100 source files; consider scoping analysis to a subdirectory for faster results."`
 
 Then assemble the final output JSON:
 

--- a/understand-anything-plugin/agents/tour-builder.md
+++ b/understand-anything-plugin/agents/tour-builder.md
@@ -7,7 +7,7 @@ description: |
 
 # Tour Builder
 
-You are an expert technical educator who designs learning paths through codebases. Your job is to create a guided tour of 5-15 steps that teaches someone the project's architecture and key concepts in a logical, pedagogical order. Each step should build on previous ones, creating a coherent narrative that takes a newcomer from "What is this project?" to "I understand how it works."
+You are an expert technical educator who designs learning paths through codebases. Your job is to create a guided tour of 5-15 steps (empirical default; not measured) that teaches someone the project's architecture and key concepts in a logical, pedagogical order. Each step should build on previous ones, creating a coherent narrative that takes a newcomer from "What is this project?" to "I understand how it works."
 
 ## Task
 

--- a/understand-anything-plugin/skills/understand-knowledge/SKILL.md
+++ b/understand-anything-plugin/skills/understand-knowledge/SKILL.md
@@ -65,7 +65,7 @@ Dispatch `article-analyzer` subagents to extract implicit knowledge:
    
    The agent will write `analysis-batch-{N}.json` to the intermediate directory.
 
-4. Run up to 3 batches concurrently. Wait for all batches to complete.
+4. Run up to 3 batches concurrently (empirical default; not measured). Wait for all batches to complete.
 
 5. If any batch fails, log a warning but continue — the scan-manifest provides a solid base graph even without LLM analysis.
 

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -14,7 +14,7 @@ Analyze the current codebase and produce a `knowledge-graph.json` file in `.unde
   - `--full` — Force a full rebuild, ignoring any existing graph
   - `--auto-update` — Enable automatic graph updates on commit (writes `autoUpdate: true` to `.understand-anything/config.json`)
   - `--no-auto-update` — Disable automatic graph updates (writes `autoUpdate: false` to `.understand-anything/config.json`)
-  - `--review` — Run full LLM graph-reviewer instead of inline deterministic validation
+  - `--review` — Run full LLM graph-reviewer instead of inline deterministic validation. Opt-in because it adds a subagent dispatch's cost and latency to Phase 6; the default inline validator covers the same critical checks deterministically for free.
   - `--language <lang>` — Generate all textual content (summaries, descriptions, tags, titles, languageNotes, languageLesson) in the specified language. Accepts ISO 639-1 codes (`zh`, `ja`, `ko`, `en`, `es`, `fr`, `de`, etc.) or friendly names (`chinese`, `japanese`, `korean`, `english`, `spanish`, etc.). Locale variants supported: `zh-TW`, `zh-HK`, etc. Defaults to `en` (English). Stores preference in `.understand-anything/config.json` for consistency across incremental updates.
   - `--version` — Print the installed plugin version and stop; runs no preflight, no build, and no pipeline phase
   - `--doctor` — Check that Node.js and pnpm are installed at a supported version and report whether the plugin is built, then stop; performs no writes and does not trigger the build
@@ -338,7 +338,7 @@ Load `.understand-anything/intermediate/batches.json` (produced by Phase 1.5). I
 
 Report: `[Phase 2/7] Analyzing files — <totalFiles> files in <totalBatches> batches (up to 5 concurrent)...`
 
-For each batch, dispatch a subagent using the `file-analyzer` agent definition (at `agents/file-analyzer.md`). Run up to **5 subagents concurrently**. Append the following additional context:
+For each batch, dispatch a subagent using the `file-analyzer` agent definition (at `agents/file-analyzer.md`). Run up to **5 subagents concurrently** (empirical default; not measured). Append the following additional context:
 
 > **Additional context from main session:**
 >
@@ -852,33 +852,7 @@ Report to the user: `[Phase 7/7] Saving knowledge graph...`
 
 ## Reference: KnowledgeGraph Schema
 
-### Node Types (13 total)
-| Type | Description | ID Convention |
-|---|---|---|
-| `file` | Source code file | `file:<relative-path>` |
-| `function` | Function or method | `function:<relative-path>:<name>` |
-| `class` | Class, interface, or type | `class:<relative-path>:<name>` |
-| `module` | Logical module or package | `module:<name>` |
-| `concept` | Abstract concept or pattern | `concept:<name>` |
-| `config` | Configuration file (YAML, JSON, TOML, env) | `config:<relative-path>` |
-| `document` | Documentation file (Markdown, RST, TXT) | `document:<relative-path>` |
-| `service` | Deployable service definition (Dockerfile, K8s) | `service:<relative-path>` |
-| `table` | Database table or migration | `table:<relative-path>:<table-name>` |
-| `endpoint` | API endpoint or route definition | `endpoint:<relative-path>:<endpoint-name>` |
-| `pipeline` | CI/CD pipeline configuration | `pipeline:<relative-path>` |
-| `schema` | Schema definition (GraphQL, Protobuf, Prisma) | `schema:<relative-path>` |
-| `resource` | Infrastructure resource (Terraform, CloudFormation) | `resource:<relative-path>` |
-
-### Edge Types (26 total)
-| Category | Types |
-|---|---|
-| Structural | `imports`, `exports`, `contains`, `inherits`, `implements` |
-| Behavioral | `calls`, `subscribes`, `publishes`, `middleware` |
-| Data flow | `reads_from`, `writes_to`, `transforms`, `validates` |
-| Dependencies | `depends_on`, `tested_by`, `configures` |
-| Semantic | `related`, `similar_to` |
-| Infrastructure | `deploys`, `serves`, `provisions`, `triggers` |
-| Schema/Data | `migrates`, `documents`, `routes`, `defines_schema` |
+There are 21 node types (13 structural + 3 domain + 5 knowledge) and 35 edge types (26 structural + 3 domain + 6 knowledge) in the current schema. Full type table: see `agents/graph-reviewer.md` (canonical).
 
 ### Edge Weight Conventions
 | Edge Type | Weight |

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -14,7 +14,7 @@ Analyze the current codebase and produce a `knowledge-graph.json` file in `.unde
   - `--full` — Force a full rebuild, ignoring any existing graph
   - `--auto-update` — Enable automatic graph updates on commit (writes `autoUpdate: true` to `.understand-anything/config.json`)
   - `--no-auto-update` — Disable automatic graph updates (writes `autoUpdate: false` to `.understand-anything/config.json`)
-  - `--review` — Run full LLM graph-reviewer instead of inline deterministic validation. Opt-in because it adds a subagent dispatch's cost and latency to Phase 6; the default inline validator covers the same critical checks deterministically for free.
+  - `--review` — Run full LLM graph-reviewer instead of inline deterministic validation. Opt-in because it adds a subagent dispatch's cost and latency to Phase 6; the default inline validator covers referential integrity, duplicate IDs, required fields and layer coverage deterministically for free; the LLM reviewer adds type-enum validation and quality judgment on top, at the cost of latency and tokens.
   - `--language <lang>` — Generate all textual content (summaries, descriptions, tags, titles, languageNotes, languageLesson) in the specified language. Accepts ISO 639-1 codes (`zh`, `ja`, `ko`, `en`, `es`, `fr`, `de`, etc.) or friendly names (`chinese`, `japanese`, `korean`, `english`, `spanish`, etc.). Locale variants supported: `zh-TW`, `zh-HK`, etc. Defaults to `en` (English). Stores preference in `.understand-anything/config.json` for consistency across incremental updates.
   - `--version` — Print the installed plugin version and stop; runs no preflight, no build, and no pipeline phase
   - `--doctor` — Check that Node.js and pnpm are installed at a supported version and report whether the plugin is built, then stop; performs no writes and does not trigger the build
@@ -119,8 +119,10 @@ Determine whether to run a full analysis or incremental update.
    **`--version`.** If `--version` is in `$ARGUMENTS`, print the plugin version and stop here — do not run the preflight below, do not build, do not run any pipeline phase:
 
    ```bash
+   command -v node >/dev/null 2>&1 || { echo "Error: Node.js is not installed or not on PATH. Install Node.js >= 22 (https://nodejs.org) and re-run /understand."; exit 1; }
    VERSION=$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).version)' "$PLUGIN_ROOT/.claude-plugin/plugin.json")
    echo "understand-anything $VERSION"
+   exit 0
    ```
 
    **Preflight.** Run this check only if `$PLUGIN_ROOT/packages/core/dist/index.js` does not exist yet, or `--doctor` is in `$ARGUMENTS`. Users with an already-built plugin who did not pass `--doctor` skip this entirely — they must not pay its cost or risk a false failure:
@@ -152,7 +154,7 @@ Determine whether to run a full analysis or incremental update.
 
    The preflight above prints an actionable error and exits 1 the moment it finds a problem. If it fires, surface that error to the user verbatim and stop — do not attempt to install Node.js or pnpm on the user's behalf.
 
-   **`--doctor`.** If `--doctor` is in `$ARGUMENTS`, the preflight above just ran unconditionally (whether or not the plugin is built) and passed. Print a status report and stop here — do not build, do not run any pipeline phase. `--doctor` performs no writes:
+   **`--doctor`.** If `--doctor` is in `$ARGUMENTS`, the preflight above ran regardless of build state. If it passed, print this status report and stop — do not build, do not run any pipeline phase. `--doctor` performs no writes:
 
    ```bash
    echo "Plugin root: $PLUGIN_ROOT"
@@ -164,6 +166,7 @@ Determine whether to run a full analysis or incremental update.
    else
      echo "Build status: not built — will build on first /understand run"
    fi
+   exit 0
    ```
 
    Otherwise, continue:

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: understand
 description: Analyze a codebase to produce an interactive knowledge graph for understanding architecture, components, and relationships
-argument-hint: "[path] [--full|--auto-update|--no-auto-update|--review|--language <lang>]"
+argument-hint: "[path] [--full|--auto-update|--no-auto-update|--review|--language <lang>|--version|--doctor]"
 ---
 
 # /understand
@@ -16,6 +16,8 @@ Analyze the current codebase and produce a `knowledge-graph.json` file in `.unde
   - `--no-auto-update` — Disable automatic graph updates (writes `autoUpdate: false` to `.understand-anything/config.json`)
   - `--review` — Run full LLM graph-reviewer instead of inline deterministic validation
   - `--language <lang>` — Generate all textual content (summaries, descriptions, tags, titles, languageNotes, languageLesson) in the specified language. Accepts ISO 639-1 codes (`zh`, `ja`, `ko`, `en`, `es`, `fr`, `de`, etc.) or friendly names (`chinese`, `japanese`, `korean`, `english`, `spanish`, etc.). Locale variants supported: `zh-TW`, `zh-HK`, etc. Defaults to `en` (English). Stores preference in `.understand-anything/config.json` for consistency across incremental updates.
+  - `--version` — Print the installed plugin version and stop; runs no preflight, no build, and no pipeline phase
+  - `--doctor` — Check that Node.js and pnpm are installed at a supported version and report whether the plugin is built, then stop; performs no writes and does not trigger the build
   - A directory path (e.g. `/path/to/repo` or `../other-project`) — Analyze the given directory instead of the current working directory
 
 ---
@@ -112,13 +114,65 @@ Determine whether to run a full analysis or incremental update.
      echo "Make sure the plugin is installed correctly."
      exit 1
    fi
+   ```
 
+   **`--version`.** If `--version` is in `$ARGUMENTS`, print the plugin version and stop here — do not run the preflight below, do not build, do not run any pipeline phase:
+
+   ```bash
+   VERSION=$(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).version)' "$PLUGIN_ROOT/.claude-plugin/plugin.json")
+   echo "understand-anything $VERSION"
+   ```
+
+   **Preflight.** Run this check only if `$PLUGIN_ROOT/packages/core/dist/index.js` does not exist yet, or `--doctor` is in `$ARGUMENTS`. Users with an already-built plugin who did not pass `--doctor` skip this entirely — they must not pay its cost or risk a false failure:
+
+   ```bash
+   if ! command -v node >/dev/null 2>&1; then
+     echo "Error: Node.js is not installed or not on PATH. Install Node.js >= 22 (https://nodejs.org) and re-run /understand."
+     exit 1
+   fi
+   NODE_MAJOR=$(node -v)
+   NODE_MAJOR="${NODE_MAJOR#v}"
+   NODE_MAJOR="${NODE_MAJOR%%.*}"
+   if [ "$NODE_MAJOR" -lt 22 ]; then
+     echo "Error: Node.js $(node -v) is too old. understand-anything needs Node.js >= 22."
+     exit 1
+   fi
+
+   if ! command -v pnpm >/dev/null 2>&1; then
+     echo "Error: pnpm is not installed or not on PATH. Install pnpm >= 10 (e.g. \`npm install -g pnpm\` or \`corepack enable\`) and re-run /understand."
+     exit 1
+   fi
+   PNPM_MAJOR=$(pnpm -v)
+   PNPM_MAJOR="${PNPM_MAJOR%%.*}"
+   if [ "$PNPM_MAJOR" -lt 10 ]; then
+     echo "Error: pnpm $(pnpm -v) is too old. understand-anything needs pnpm >= 10."
+     exit 1
+   fi
+   ```
+
+   The preflight above prints an actionable error and exits 1 the moment it finds a problem. If it fires, surface that error to the user verbatim and stop — do not attempt to install Node.js or pnpm on the user's behalf.
+
+   **`--doctor`.** If `--doctor` is in `$ARGUMENTS`, the preflight above just ran unconditionally (whether or not the plugin is built) and passed. Print a status report and stop here — do not build, do not run any pipeline phase. `--doctor` performs no writes:
+
+   ```bash
+   echo "Plugin root: $PLUGIN_ROOT"
+   echo "Plugin version: $(node -e 'console.log(JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).version)' "$PLUGIN_ROOT/.claude-plugin/plugin.json")"
+   echo "node -v: $(node -v)"
+   echo "pnpm -v: $(pnpm -v)"
+   if [ -f "$PLUGIN_ROOT/packages/core/dist/index.js" ]; then
+     echo "Build status: built"
+   else
+     echo "Build status: not built — will build on first /understand run"
+   fi
+   ```
+
+   Otherwise, continue:
+
+   ```bash
    if [ ! -f "$PLUGIN_ROOT/packages/core/dist/index.js" ]; then
      cd "$PLUGIN_ROOT" && (pnpm install --frozen-lockfile 2>/dev/null || pnpm install) && pnpm --filter @understand-anything/core build
    fi
    ```
-
-   If `pnpm` is missing, report to the user: "Install Node.js ≥ 22 and pnpm ≥ 10, then re-run `/understand`."
 
 2. Get the current git commit hash:
    ```bash


### PR DESCRIPTION
## Summary

Polish pass on the two things a first-time user actually experiences: whether `/understand` installs and runs cleanly on a cold machine, and whether the nine pipeline agents are specified consistently. No behavior change for users whose plugin is already built; no version bump (left for the maintainer per the template).

**Install reliability**
- **CI guards for known packaging gotchas** — `tests/install/version-sync.test.mjs` fails `pnpm test` if the five manifests' `version` fields drift or if `marketplace.json` ever gains a `version` key; `tests/install/agent-frontmatter.test.mjs` fails if any `agents/*.md` frontmatter gains `model`/`tools` (regression guard for #167) or has a `name` ≠ filename. Both were previously manual checklist items only.
- **Deterministic first-run preflight** in `/understand` Phase 0 — scripted `node`/`pnpm` presence + version checks (Node ≥ 22, pnpm ≥ 10) with actionable error strings and `exit 1`, gated so it only runs when `packages/core/dist/` is missing (i.e. a genuinely fresh install) or `--doctor` is passed. Replaces the prose-only "if pnpm is missing, tell the user…" fallback.
- **`/understand --version` and `/understand --doctor`** — the bug-report template already told users to run `--version`; it didn't exist. `--doctor` prints plugin root, version, `node -v`, `pnpm -v`, and built/not-built status, performs no writes, and never triggers the build.
- **README Prerequisites + Troubleshooting** for installing users (requirements previously lived only in `CLAUDE.md`/`CONTRIBUTING.md`).
- **CI matrix → 3 OS × 2 Node** (adds `macos-latest`, Node 24). Early warning for prebuild gaps in the 11 native tree-sitter grammar packages that `node-gyp-build` on install — the exact failure `CLAUDE.md`'s Gotchas section describes.

**Agent prompt quality**
- `agents/domain-analyzer.md` and `agents/article-analyzer.md` brought up to the two-phase template the other agents already use (Phase 1/2 split, retry guidance, subagent-boundary guardrail, Bad/Good calibration examples, self-check list). Every existing rule, field, ID convention and output path preserved; frontmatter untouched.
- **Schema single source of truth** — `agents/graph-reviewer.md` now holds the canonical node/edge type table, derived from `packages/core/src/types.ts` (`NodeType`) and `schema.ts` (`EdgeTypeSchema`): **21 node types / 35 edge types**. The three prose copies disagreed with each other (13/26, 16/29) and all were stale vs. the code. `skills/understand/SKILL.md` and `agents/knowledge-graph-guide.md` now point at the canonical table instead of restating it.
- `assemble-reviewer` ↔ `graph-reviewer` cross-referenced in both files (unconditional Phase 3 repair vs. opt-in `--review` Phase 6 QA gate) so the sequencing is legible from `agents/` alone; the `--review` bullet now states accurately what the default inline validator does and doesn't cover.
- Honest rationale clauses on six hardcoded thresholds (60/120 batch split, 5 and 3 concurrency caps, 3-10 layers, 5-15 tour steps, >100-file gate) — "empirical default; not measured" where that's the truth. No numbers changed.
- `agents/file-analyzer.md` language tiers corrected to match the shipped parsers (Dart/Kotlin/Swift are tree-sitter, not regex fallback).

## Linked issue(s)

Refs #167 (agent `model` frontmatter regression guard). No tracking issue for the rest.

## How I tested this

- `pnpm lint` clean; `pnpm test` → 20 files, 272 passed, 1 skipped (baseline on `main` was 18 / 222 / 1; the +50 are the two new test files).
- Both new tests verified to **fail** on deliberately broken input (a `9.9.9` in one manifest; `model: inherit` in one agent) and pass on the real tree, then reverted.
- Preflight and `--version` bash blocks extracted and run for real: `bash -n` clean; pass silently with Node 22.23.0 / pnpm 10.6.2 on PATH; with `PATH=/usr/bin:/bin` they print the Node-missing error and exit 1. `--version` prints `understand-anything 2.8.2`.
- CI matrix parsed with js-yaml → 6 legs.
- Grep checks: `13 node types`/`26 edge types` → zero hits in plugin `.md` files; `Canonical node/edge type reference` → exactly one hit.
- **Not run:** a full `/understand` against a real repo with the rewritten agents — the changes to those two agents are structural/instructional and preserve the output contract, but a maintainer smoke run of `/understand-domain` and `/understand-knowledge` would be a sensible pre-merge check.

- [x] `pnpm lint`
- [x] `pnpm --filter @understand-anything/core test`
- [x] `pnpm test`
- [ ] Manual smoke test — preflight/`--version` bash verified standalone (above); full pipeline smoke run not performed

## Versioning

- [ ] Version bumped in all five manifests, OR
- [x] N/A — left at `2.8.2` for the maintainer to bump on merge. Note this PR does add user-visible flags (`--version`, `--doctor`) and a first-run preflight, so a minor bump is probably warranted rather than a patch.

## Heads-up for reviewers

- **Expect the `macos-latest × Node 24` CI leg to go red** — that's the matrix doing its job. `CLAUDE.md` already documents that native tree-sitter bindings fail on darwin/arm64 + Node 24; this PR makes CI say so instead of leaving it for a user's first run. `fail-fast: false` keeps the other five legs reporting. CI runtime goes from 2 legs to 6.
- **Follow-ups surfaced but deliberately out of scope here** (happy to open issues):
  1. `domain-analyzer.md` Rule 1's `flow_step` weight formula `round(1/N,1)` collapses to repeated `0.1` at N≥15, which its own (new) self-check on monotonic weights would flag. Preserved as-is because this PR doesn't re-spec rules.
  2. `--doctor` exits at the first preflight failure, so a user with missing Node/pnpm gets only that error and not the rest of the diagnostic report.
  3. `packages/core/src/types.test.ts:120,132` test descriptions still say "13 node types"/"26 edge types"; `packages/core/src/plugins/tree-sitter-plugin.ts` class doc-comment still omits Dart/Kotlin/Swift.
  4. Consider porting the 11 native tree-sitter grammar deps to WASM-only wrappers like `packages/tree-sitter-dart-wasm`/`-swift-wasm` — that would remove the native-install risk entirely instead of just detecting it.

## Disclosure

Authored with Claude Code (Claude Fable 5.1 / Sonnet 5 / Opus 5 subagents) driven from a human-approved plan; every task was independently reviewed by a separate agent, the full branch had a final review, and the human reviewed the plan, the decisions, and this diff before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
