### PR TITLE
fix: make incremental updates correct and token-efficient

### DIFF
--- a/tests/skill/understand/test_compute_batches.test.mjs
+++ b/tests/skill/understand/test_compute_batches.test.mjs
@@ -749,7 +749,8 @@ describe('compute-batches.mjs — --changed-files', () => {
     const changedPath = join(root, 'changed.txt');
     // Only two files in the auth clique are changed. Use CRLF plus one
     // backslash path to cover Windows git diff/path-list inputs.
-    writeFileSync(changedPath, ['src\\auth\\login.ts', 'src/auth/tokens.ts'].join('\r\n'));
+    const loginPath = process.platform === 'win32' ? 'src\\auth\\login.ts' : 'src/auth/login.ts';
+    writeFileSync(changedPath, [loginPath, 'src/auth/tokens.ts'].join('\r\n'));
 
     const result = runScript(root, [`--changed-files=${changedPath}`]);
     expect(result.status).toBe(0);
@@ -793,6 +794,38 @@ describe('compute-batches.mjs — --changed-files', () => {
       'src/auth/tokens.ts',
     ]);
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves a newline-containing path from a JSON changed-file list',
+    () => {
+      root = mkdtempSync(join(tmpdir(), 'ua-cb-newline-'));
+      const intermediate = join(root, '.understand-anything', 'intermediate');
+      const sourcePath = 'src/line\nbreak.ts';
+      mkdirSync(intermediate, { recursive: true });
+      mkdirSync(join(root, 'src'), { recursive: true });
+      writeFileSync(join(root, sourcePath), 'export const value = 1;\n');
+      writeFileSync(
+        join(intermediate, 'scan-result.json'),
+        JSON.stringify({
+          files: [{
+            path: sourcePath,
+            language: 'typescript',
+            sizeLines: 1,
+            fileCategory: 'code',
+          }],
+          importMap: { [sourcePath]: [] },
+        }),
+      );
+      const changedPath = join(root, 'changed-files.json');
+      writeFileSync(changedPath, JSON.stringify([sourcePath]));
+
+      const result = runScript(root, [`--changed-files=${changedPath}`]);
+      expect(result.status, result.stderr).toBe(0);
+      expect(readBatches(root).batches.flatMap(batch => batch.files)).toEqual([
+        expect.objectContaining({ path: sourcePath }),
+      ]);
+    },
+  );
 
   it('emits only changed files inside retained batches while preserving unchanged neighbor context', () => {
     root = mkdtempSync(join(tmpdir(), 'ua-cb-changed-nbr-'));

--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -1583,6 +1583,9 @@ describe('extract-import-map.mjs — per-file failure resilience', () => {
     expect(result.output.importMap['src/other.ts']).toEqual([]);
     // Missing file is in importMap with []
     expect(result.output.importMap['src/missing.ts']).toEqual([]);
+    expect(result.output.failures).toEqual([
+      expect.objectContaining({ path: 'src/missing.ts', stage: 'file-read' }),
+    ]);
     // A warning was emitted on stderr for the missing file
     expect(result.stderr).toMatch(/Warning: extract-import-map: import resolution failed for src\/missing\.ts/);
     expect(result.stderr).toMatch(/importMap\[src\/missing\.ts\]=\[\]/);
@@ -1638,6 +1641,7 @@ describe('extract-import-map.mjs — output schema invariants', () => {
     });
 
     expect(result.status).toBe(0);
+    expect(result.output.failures).toEqual([]);
     expect(Object.keys(result.output.importMap).sort()).toEqual([
       'Dockerfile', 'README.md', 'a.ts', 'package.json',
     ]);
@@ -1933,6 +1937,9 @@ describe('extract-import-map.mjs — tsconfig parse resilience', () => {
     expect(result.stderr).toMatch(/path aliases.*will not be applied/);
     // Aliased import unresolved; relative import still resolves.
     expect(result.output.importMap['src/index.ts']).toEqual(['src/sibling.ts']);
+    expect(result.output.failures).toEqual([
+      expect.objectContaining({ path: 'tsconfig.json', stage: 'resolver-config-parse' }),
+    ]);
   });
 
   it('falls back to raw-text parse when a paths value contains "//" that the stripper would damage', () => {
@@ -2083,6 +2090,9 @@ describe('extract-import-map.mjs — tree-sitter init graceful failure', () => {
     expect(result.output.stats.filesScanned).toBe(2);
     expect(result.output.stats.filesWithImports).toBe(0);
     expect(result.output.stats.totalEdges).toBe(0);
+    expect(result.output.failures).toEqual([
+      expect.objectContaining({ path: null, stage: 'tree-sitter-init' }),
+    ]);
   });
 });
 

--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -111,7 +111,7 @@ describe('extract-import-map.mjs — TypeScript / JavaScript resolver', () => {
         { path: 'src/stable.ts', language: 'typescript', fileCategory: 'code' },
         { path: 'src/untouched.ts', language: 'typescript', fileCategory: 'code' },
       ],
-      analysisPaths: ['src\\changed.ts'],
+      analysisPaths: [process.platform === 'win32' ? 'src\\changed.ts' : 'src/changed.ts'],
     });
 
     expect(result.status, result.stderr).toBe(0);
@@ -159,6 +159,26 @@ describe('extract-import-map.mjs — TypeScript / JavaScript resolver', () => {
     expect(result.output.importMap).toEqual({});
     expect(result.output.stats.filesScanned).toBe(0);
   });
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves literal backslashes in POSIX filenames',
+    () => {
+      projectRoot = setupTree({
+        'src/foo\\bar.js': 'module.exports = 1;\n',
+      });
+
+      const result = runScript(projectRoot, {
+        projectRoot,
+        files: [
+          { path: 'src/foo\\bar.js', language: 'javascript', fileCategory: 'code' },
+        ],
+        analysisPaths: ['src/foo\\bar.js'],
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.output.importMap).toEqual({ 'src/foo\\bar.js': [] });
+    },
+  );
 
   it('orders Unicode import targets by locale-independent UTF-16 code units', () => {
     projectRoot = setupTree({

--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -1962,6 +1962,36 @@ describe('extract-import-map.mjs — tsconfig parse resilience', () => {
     ]);
   });
 
+  it('accepts JSONC comments and trailing commas without reporting a failure', () => {
+    projectRoot = setupTree({
+      'tsconfig.json': `{
+        // aliases may point at URL-like strings without losing // in quotes
+        "compilerOptions": {
+          "baseUrl": ".",
+          "paths": {
+            "@/*": ["src/*",],
+            "@url/*": ["https://example.test/*",],
+          },
+        },
+      }`,
+      'src/index.ts': `import { value } from '@/value';\n`,
+      'src/value.ts': 'export const value = 1;\n',
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'tsconfig.json', language: 'json', fileCategory: 'config' },
+        { path: 'src/index.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/value.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.output.failures).toEqual([]);
+    expect(result.output.importMap['src/index.ts']).toEqual(['src/value.ts']);
+  });
+
   it('falls back to raw-text parse when a paths value contains "//" that the stripper would damage', () => {
     // tsconfig with NO comments but a string literal containing "//". The
     // naive stripper would chew the second `//` away and break the JSON;

--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -180,6 +180,57 @@ describe('extract-import-map.mjs — TypeScript / JavaScript resolver', () => {
     },
   );
 
+  it.skipIf(process.platform === 'win32')(
+    'accepts Windows-looking paths as project-relative POSIX filenames',
+    () => {
+      projectRoot = setupTree({
+        'C:/drive-slash.js': 'module.exports = 1;\n',
+        'C:\\drive-backslash.js': 'module.exports = 2;\n',
+        '\\root-backslash.js': 'module.exports = 3;\n',
+      });
+
+      const paths = [
+        'C:/drive-slash.js',
+        'C:\\drive-backslash.js',
+        '\\root-backslash.js',
+      ];
+      const result = runScript(projectRoot, {
+        projectRoot,
+        files: paths.map(path => ({
+          path,
+          language: 'javascript',
+          fileCategory: 'code',
+        })),
+        analysisPaths: paths,
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.output.importMap).toEqual(Object.fromEntries(
+        paths.map(path => [path, []]),
+      ));
+    },
+  );
+
+  it('rejects host-absolute analysis paths', () => {
+    projectRoot = setupTree({
+      'src/index.ts': 'export const value = 1;\n',
+    });
+    const absolutePath = process.platform === 'win32'
+      ? 'C:\\outside\\index.ts'
+      : '/outside/index.ts';
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'src/index.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+      analysisPaths: [absolutePath],
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('analysisPaths entry must be project-relative');
+  });
+
   it('orders Unicode import targets by locale-independent UTF-16 code units', () => {
     projectRoot = setupTree({
       'src/index.ts': `import './ä';\nimport './Z';\nimport './a';\n`,

--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -1454,7 +1454,7 @@ describe('extract-import-map.mjs — C/C++ resolver', () => {
   });
 });
 
-describe('extract-import-map.mjs — Swift resolver', () => {
+describe('extract-import-map.mjs — Swift resolver', { timeout: 20_000 }, () => {
   let projectRoot;
 
   afterEach(() => {

--- a/tests/skill/understand/test_extract_import_map.test.mjs
+++ b/tests/skill/understand/test_extract_import_map.test.mjs
@@ -97,6 +97,69 @@ describe('extract-import-map.mjs — TypeScript / JavaScript resolver', () => {
     expect(result.output.stats.totalEdges).toBe(2);
   });
 
+  it('uses the full inventory for resolution while emitting only analysisPaths', () => {
+    projectRoot = setupTree({
+      'src/changed.ts': `import { stable } from './stable';\nexport const changed = stable;\n`,
+      'src/stable.ts': `export const stable = 1;\n`,
+      'src/untouched.ts': `import './stable';\n`,
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'src/changed.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/stable.ts', language: 'typescript', fileCategory: 'code' },
+        { path: 'src/untouched.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+      analysisPaths: ['src\\changed.ts'],
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.output.importMap).toEqual({
+      'src/changed.ts': ['src/stable.ts'],
+    });
+    expect(result.output.stats).toEqual({
+      filesScanned: 1,
+      filesWithImports: 1,
+      totalEdges: 1,
+    });
+  });
+
+  it('rejects analysisPaths that are absent from the current inventory', () => {
+    projectRoot = setupTree({
+      'src/index.ts': 'export const value = 1;\n',
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'src/index.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+      analysisPaths: ['src/missing.ts'],
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('analysisPaths entry is not present in files');
+  });
+
+  it('supports an empty analysisPaths list without emitting full-scan entries', () => {
+    projectRoot = setupTree({
+      'src/index.ts': 'export const value = 1;\n',
+    });
+
+    const result = runScript(projectRoot, {
+      projectRoot,
+      files: [
+        { path: 'src/index.ts', language: 'typescript', fileCategory: 'code' },
+      ],
+      analysisPaths: [],
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.output.importMap).toEqual({});
+    expect(result.output.stats.filesScanned).toBe(0);
+  });
+
   it('orders Unicode import targets by locale-independent UTF-16 code units', () => {
     projectRoot = setupTree({
       'src/index.ts': `import './ä';\nimport './Z';\nimport './a';\n`,

--- a/tests/skill/understand/test_incremental_skill_contract.test.mjs
+++ b/tests/skill/understand/test_incremental_skill_contract.test.mjs
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const skill = readFileSync(
+  resolve(__dirname, '../../../understand-anything-plugin/skills/understand/SKILL.md'),
+  'utf-8',
+);
+const hook = readFileSync(
+  resolve(__dirname, '../../../understand-anything-plugin/hooks/auto-update-prompt.md'),
+  'utf-8',
+);
+
+describe('incremental execution contract', () => {
+  it.each([skill, hook])('routes inventory and baseline updates through bundled helpers', content => {
+    expect(content).toContain('prepare-incremental.mjs');
+    expect(content).toContain('finalize-incremental.mjs');
+    expect(content).toContain('filesToReanalyze');
+    expect(content).toContain('batch-existing.json');
+    expect(content).toContain('generated-artifact-only');
+  });
+
+  it('skips whole-graph LLM phases for ordinary partial updates', () => {
+    expect(skill).toContain('Both incremental actions skip assemble-reviewer');
+    expect(skill).toContain('For `PARTIAL_UPDATE`, dispatch no architecture agent');
+    expect(skill).toContain('For `PARTIAL_UPDATE`, dispatch no tour agent');
+    expect(skill).toContain('Without `--review`');
+    expect(skill).toContain('Do not run Phase 6');
+  });
+
+  it('keeps explicit review and architecture escalation behavior', () => {
+    expect(skill).toContain('The user-facing `--review` option is still honored');
+    expect(skill).toContain('where `rerunArchitecture === true`');
+    expect(skill).toContain('where `rerunTour === true`');
+    expect(skill).toContain('`FULL_UPDATE`');
+  });
+});

--- a/tests/skill/understand/test_incremental_skill_contract.test.mjs
+++ b/tests/skill/understand/test_incremental_skill_contract.test.mjs
@@ -35,5 +35,7 @@ describe('incremental execution contract', () => {
     expect(skill).toContain('where `rerunArchitecture === true`');
     expect(skill).toContain('where `rerunTour === true`');
     expect(skill).toContain('`FULL_UPDATE`');
+    expect(skill).toContain('With explicit `--review`');
+    expect(skill).toContain('jump to the `--review` graph-reviewer path in Phase 6');
   });
 });

--- a/tests/skill/understand/test_merge_batch_graphs.py
+++ b/tests/skill/understand/test_merge_batch_graphs.py
@@ -60,6 +60,38 @@ def _file_node(path: str, **extra: Any) -> dict[str, Any]:
     return node
 
 
+def _whole_file_node(node_type: str, path: str) -> dict[str, Any]:
+    return _file_node(path, id=f"{node_type}:{path}", type=node_type)
+
+
+class WholeFileImportIndexTests(unittest.TestCase):
+    """Import recovery resolves every valid whole-file node type by path."""
+
+    def test_indexes_supported_whole_file_types(self) -> None:
+        nodes = [
+            _whole_file_node(node_type, f"project/{node_type}.txt")
+            for node_type in sorted(mbg.WHOLE_FILE_NODE_TYPES)
+        ]
+        index, warnings = mbg.build_whole_file_node_index(nodes)
+        self.assertEqual(warnings, [])
+        for node_type in mbg.WHOLE_FILE_NODE_TYPES:
+            path = f"project/{node_type}.txt"
+            self.assertEqual(index[path], f"{node_type}:{path}")
+
+    def test_prefers_file_and_rejects_child_or_malformed_nodes(self) -> None:
+        path = "config/app.json"
+        nodes = [
+            _whole_file_node("config", path),
+            _whole_file_node("file", path),
+            _file_node(path, id=f"table:{path}:users", type="table"),
+            _file_node("bad.json", id="config:not-bad.json", type="config"),
+        ]
+        index, warnings = mbg.build_whole_file_node_index(nodes)
+        self.assertEqual(index, {path: f"file:{path}"})
+        self.assertEqual(len(warnings), 1)
+        self.assertIn(f"selected file:{path}", warnings[0])
+
+
 # ── is_test_path ──────────────────────────────────────────────────────────
 
 class IsTestPathTests(unittest.TestCase):

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -433,9 +433,14 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     const fingerprints = JSON.parse(
       readFileSync(join(root, '.ua', 'fingerprints.json'), 'utf-8'),
     );
+    const graph = JSON.parse(
+      readFileSync(join(root, '.ua', 'knowledge-graph.json'), 'utf-8'),
+    );
     expect(meta.gitCommitHash).toBe(headCommit);
     expect(fingerprints.gitCommitHash).toBe(headCommit);
     expect(Object.keys(fingerprints.files)).toHaveLength(4);
+    expect(graph.project.gitCommitHash).toBe(headCommit);
+    expect(graph.project.analyzedAt).not.toBe('2026-01-01T00:00:00.000Z');
   });
 
   it('removes files newly covered by .understandignore without analyzing them', () => {
@@ -656,6 +661,61 @@ describe('finalize-incremental.mjs', { timeout: 30_000 }, () => {
     expect(readFileSync(graphPath, 'utf-8')).toBe(graphBefore);
     expect(readFileSync(fingerprintPath, 'utf-8')).toBe(fingerprintsBefore);
     expect(readFileSync(metaPath, 'utf-8')).toBe(metaBefore);
+  });
+
+  it('adds a newly introduced language to graph project metadata', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    writeProjectFile(root, 'src/script.py', 'value = 1\n');
+    commit(root, 'add first python file');
+    prepare(root, baseCommit);
+
+    const intermediate = join(root, '.ua', 'intermediate');
+    const retained = JSON.parse(readFileSync(join(intermediate, 'batch-existing.json'), 'utf-8'));
+    writeFileSync(
+      join(intermediate, 'assembled-graph.json'),
+      JSON.stringify({
+        nodes: [
+          ...retained.nodes,
+          {
+            id: 'file:src/script.py',
+            type: 'file',
+            name: 'script.py',
+            filePath: 'src/script.py',
+            summary: 'Python script',
+            tags: ['python'],
+            complexity: 'simple',
+          },
+        ],
+        edges: retained.edges,
+      }),
+      'utf-8',
+    );
+    run(process.execPath, [finalizeScript, root], root);
+
+    const graph = JSON.parse(readFileSync(join(root, '.ua', 'knowledge-graph.json'), 'utf-8'));
+    expect(graph.project.languages).toEqual(['python', 'typescript']);
+  });
+
+  it('removes a language from graph metadata when its last file is deleted', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/script.py': 'value = 1\n',
+    });
+    unlinkSync(join(root, 'src/script.py'));
+    commit(root, 'remove last python file');
+    prepare(root, baseCommit);
+    run(python, [mergeScript, root], root);
+    run(process.execPath, [finalizeScript, root], root);
+
+    const graph = JSON.parse(readFileSync(join(root, '.ua', 'knowledge-graph.json'), 'utf-8'));
+    expect(graph.project.languages).toEqual(['typescript']);
   });
 
   it('does not advance the baseline when analyzer output omits a changed file node', () => {

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -1,0 +1,432 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../..');
+const skillDir = join(repoRoot, 'understand-anything-plugin', 'skills', 'understand');
+const scanScript = join(skillDir, 'scan-project.mjs');
+const importScript = join(skillDir, 'extract-import-map.mjs');
+const fingerprintScript = join(skillDir, 'build-fingerprints.mjs');
+const prepareScript = join(skillDir, 'prepare-incremental.mjs');
+const finalizeScript = join(skillDir, 'finalize-incremental.mjs');
+const mergeScript = join(skillDir, 'merge-batch-graphs.py');
+
+const python = (() => {
+  for (const command of ['python3', 'python']) {
+    const probe = spawnSync(command, ['--version'], { encoding: 'utf-8' });
+    if (probe.status === 0) return command;
+  }
+  throw new Error('Python 3 is required for incremental merge tests');
+})();
+
+const roots = [];
+
+function run(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf-8' });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} failed (${result.status})\n${result.stdout}\n${result.stderr}`,
+    );
+  }
+  return result;
+}
+
+function git(root, args) {
+  return run('git', args, root).stdout.trim();
+}
+
+function writeProjectFile(root, path, content) {
+  const absolute = join(root, path);
+  mkdirSync(dirname(absolute), { recursive: true });
+  writeFileSync(absolute, content, 'utf-8');
+}
+
+function commit(root, message, { forcePaths = [] } = {}) {
+  git(root, ['add', '-A']);
+  for (const path of forcePaths) git(root, ['add', '-f', '--', path]);
+  git(root, ['commit', '-m', message]);
+  return git(root, ['rev-parse', 'HEAD']);
+}
+
+function setupRepository(files) {
+  const root = mkdtempSync(join(tmpdir(), 'ua-incremental-test-'));
+  roots.push(root);
+  git(root, ['init', '-b', 'main']);
+  git(root, ['config', 'user.email', 'test@example.com']);
+  git(root, ['config', 'user.name', 'Test User']);
+  writeProjectFile(root, '.gitignore', '.ua/\n.understand-anything/\n');
+  for (const [path, content] of Object.entries(files)) writeProjectFile(root, path, content);
+  const baseCommit = commit(root, 'baseline');
+  buildBaseline(root, baseCommit);
+  return { root, baseCommit };
+}
+
+function buildBaseline(root, baseCommit) {
+  const intermediate = join(root, '.ua', 'intermediate');
+  mkdirSync(intermediate, { recursive: true });
+  const rawScanPath = join(intermediate, 'baseline-scan.json');
+  run(process.execPath, [scanScript, root, rawScanPath, '--exclude-analysis-data'], root);
+  const rawScan = JSON.parse(readFileSync(rawScanPath, 'utf-8'));
+
+  const importInput = join(intermediate, 'baseline-import-input.json');
+  const importOutput = join(intermediate, 'baseline-import-output.json');
+  writeFileSync(
+    importInput,
+    JSON.stringify({ projectRoot: root, files: rawScan.files }),
+    'utf-8',
+  );
+  run(process.execPath, [importScript, importInput, importOutput], root);
+  const importMap = JSON.parse(readFileSync(importOutput, 'utf-8')).importMap;
+  const scan = {
+    name: 'fixture',
+    description: 'fixture project',
+    languages: [...new Set(rawScan.files.map(file => file.language))].sort(),
+    frameworks: [],
+    contentDigest: rawScan.contentDigest,
+    files: rawScan.files,
+    totalFiles: rawScan.totalFiles,
+    filteredByIgnore: rawScan.filteredByIgnore,
+    estimatedComplexity: rawScan.estimatedComplexity,
+    importMap,
+  };
+  writeFileSync(join(intermediate, 'scan-result.json'), JSON.stringify(scan), 'utf-8');
+
+  const fingerprintInput = join(intermediate, 'fingerprint-input.json');
+  writeFileSync(
+    fingerprintInput,
+    JSON.stringify({
+      projectRoot: root,
+      filePaths: rawScan.files.map(file => file.path),
+      gitCommitHash: baseCommit,
+    }),
+    'utf-8',
+  );
+  run(process.execPath, [fingerprintScript, fingerprintInput], root);
+
+  const nodes = rawScan.files.map(file => ({
+    id: `file:${file.path}`,
+    type: 'file',
+    name: file.path.split('/').at(-1),
+    filePath: file.path,
+    summary: file.path,
+    tags: ['fixture'],
+    complexity: 'simple',
+  }));
+  writeFileSync(
+    join(root, '.ua', 'knowledge-graph.json'),
+    JSON.stringify({
+      version: '1.0.0',
+      project: {
+        name: 'fixture',
+        languages: scan.languages,
+        frameworks: [],
+        description: 'fixture project',
+        analyzedAt: '2026-01-01T00:00:00.000Z',
+        gitCommitHash: baseCommit,
+      },
+      nodes,
+      edges: [],
+      layers: [{
+        id: 'layer:source',
+        name: 'Source',
+        description: 'Source files',
+        nodeIds: nodes.map(node => node.id),
+      }],
+      tour: [{
+        order: 1,
+        title: 'Overview',
+        description: 'Read the project',
+        nodeIds: nodes.map(node => node.id),
+      }],
+    }),
+    'utf-8',
+  );
+  writeFileSync(
+    join(root, '.ua', 'meta.json'),
+    JSON.stringify({ gitCommitHash: baseCommit, analyzedFiles: nodes.length, version: '1.0.0' }),
+    'utf-8',
+  );
+}
+
+function prepare(root, baseCommit) {
+  const result = run(process.execPath, [prepareScript, root, baseCommit], root);
+  const intermediate = join(root, '.ua', 'intermediate');
+  return {
+    result,
+    plan: JSON.parse(readFileSync(join(intermediate, 'incremental-plan.json'), 'utf-8')),
+    scan: JSON.parse(readFileSync(join(intermediate, 'scan-result.json'), 'utf-8')),
+    changedFiles: readFileSync(join(intermediate, 'changed-files.txt'), 'utf-8'),
+  };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
+  it('refreshes imports in the same run and only schedules the structural source', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    writeProjectFile(root, 'src/a.ts', "import { b } from './b';\nexport const a = b;\n");
+    commit(root, 'add import');
+
+    const { plan, scan, changedFiles } = prepare(root, baseCommit);
+    expect(plan.action).toBe('PARTIAL_UPDATE');
+    expect(plan.filesToReanalyze).toEqual(['src/a.ts']);
+    expect(changedFiles).toBe('src/a.ts\n');
+    expect(scan.importMap['src/a.ts']).toEqual(['src/b.ts']);
+    expect(scan.importMap['src/c.ts']).toEqual([]);
+  });
+
+  it('turns a local deletion into cleanup with an empty analyzer list', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    unlinkSync(join(root, 'src/b.ts'));
+    commit(root, 'delete b');
+    writeFileSync(
+      join(root, '.ua', 'intermediate', 'batch-99.json'),
+      JSON.stringify({
+        nodes: [{ id: 'file:src/b.ts', type: 'file', filePath: 'src/b.ts' }],
+        edges: [],
+      }),
+      'utf-8',
+    );
+
+    const { plan, scan, changedFiles } = prepare(root, baseCommit);
+    expect(plan.action).toBe('PARTIAL_UPDATE');
+    expect(plan.filesToReanalyze).toEqual([]);
+    expect(plan.deletedFiles).toEqual(['src/b.ts']);
+    expect(changedFiles).toBe('');
+    expect(scan.files.map(file => file.path)).not.toContain('src/b.ts');
+    expect(scan.importMap).not.toHaveProperty('src/b.ts');
+    expect(() => readFileSync(join(root, '.ua', 'intermediate', 'batch-99.json'))).toThrow();
+    const retained = JSON.parse(
+      readFileSync(join(root, '.ua', 'intermediate', 'batch-existing.json'), 'utf-8'),
+    );
+    expect(retained.nodes.map(node => node.filePath)).not.toContain('src/b.ts');
+
+    run(python, [mergeScript, root], root);
+    run(process.execPath, [finalizeScript, root], root);
+    const graph = JSON.parse(readFileSync(join(root, '.ua', 'knowledge-graph.json'), 'utf-8'));
+    const fingerprints = JSON.parse(
+      readFileSync(join(root, '.ua', 'fingerprints.json'), 'utf-8'),
+    );
+    expect(graph.nodes.map(node => node.filePath)).not.toContain('src/b.ts');
+    expect(graph.layers.flatMap(layer => layer.nodeIds)).not.toContain('file:src/b.ts');
+    expect(graph.tour.flatMap(step => step.nodeIds)).not.toContain('file:src/b.ts');
+    expect(fingerprints.files).not.toHaveProperty('src/b.ts');
+  });
+
+  it('does not recover an import removed during this incremental run', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': "import { b } from './b';\nexport const a = b;\n",
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    writeProjectFile(root, 'src/a.ts', 'export const a = 1;\n');
+    commit(root, 'remove import');
+
+    const { plan, scan } = prepare(root, baseCommit);
+    expect(plan.filesToReanalyze).toEqual(['src/a.ts']);
+    expect(scan.importMap['src/a.ts']).toEqual([]);
+    const intermediate = join(root, '.ua', 'intermediate');
+    const retained = JSON.parse(readFileSync(join(intermediate, 'batch-existing.json'), 'utf-8'));
+    writeFileSync(
+      join(intermediate, 'batch-0.json'),
+      JSON.stringify({
+        nodes: [{
+          id: 'file:src/a.ts',
+          type: 'file',
+          name: 'a.ts',
+          filePath: 'src/a.ts',
+          summary: 'a',
+          tags: ['fixture'],
+          complexity: 'simple',
+        }],
+        edges: [],
+      }),
+      'utf-8',
+    );
+    expect(retained.nodes.map(node => node.filePath)).not.toContain('src/a.ts');
+    run(python, [mergeScript, root], root);
+    const assembled = JSON.parse(
+      readFileSync(join(intermediate, 'assembled-graph.json'), 'utf-8'),
+    );
+    expect(assembled.edges.filter(edge => edge.type === 'imports')).toHaveLength(0);
+  });
+
+  it('classifies implementation-only edits as SKIP and advances fingerprints via finalize', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export function value() { return 1; }\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    writeProjectFile(root, 'src/a.ts', 'export function value() { return 2; }\n');
+    const headCommit = commit(root, 'implementation only');
+
+    const { plan } = prepare(root, baseCommit);
+    expect(plan.action).toBe('SKIP');
+    expect(plan.cosmeticFiles).toEqual(['src/a.ts']);
+    run(process.execPath, [finalizeScript, root], root);
+
+    const meta = JSON.parse(readFileSync(join(root, '.ua', 'meta.json'), 'utf-8'));
+    const fingerprints = JSON.parse(
+      readFileSync(join(root, '.ua', 'fingerprints.json'), 'utf-8'),
+    );
+    expect(meta.gitCommitHash).toBe(headCommit);
+    expect(fingerprints.gitCommitHash).toBe(headCommit);
+    expect(Object.keys(fingerprints.files)).toHaveLength(4);
+  });
+
+  it('removes files newly covered by .understandignore without analyzing them', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'legacy/old.ts': 'export const old = true;\n',
+    });
+    writeProjectFile(root, '.understandignore', 'legacy/\n');
+    commit(root, 'ignore legacy');
+
+    const { plan } = prepare(root, baseCommit);
+    expect(plan.filesToReanalyze).toEqual([]);
+    expect(plan.deletedFiles).toEqual(['legacy/old.ts']);
+    expect(plan.ignoredFiles).toContain('.understandignore');
+    expect(plan.action).toBe('ARCHITECTURE_UPDATE');
+  });
+
+  it('handles renames and spaces as a delete plus add', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/old name.ts': 'export const value = 1;\n',
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+    });
+    renameSync(join(root, 'src/old name.ts'), join(root, 'src/new name.ts'));
+    commit(root, 'rename spaced file');
+
+    const { plan } = prepare(root, baseCommit);
+    expect(plan.deletedFiles).toEqual(['src/old name.ts']);
+    expect(plan.filesToReanalyze).toEqual(['src/new name.ts']);
+  });
+
+  it('keeps the same new-directory decision when preparation is retried', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    writeProjectFile(root, 'new-package/index.ts', 'export const added = true;\n');
+    commit(root, 'add package');
+
+    const first = prepare(root, baseCommit).plan;
+    const second = prepare(root, baseCommit).plan;
+    expect(first.action).toBe('ARCHITECTURE_UPDATE');
+    expect(second.action).toBe(first.action);
+    expect(second.filesToReanalyze).toEqual(['new-package/index.ts']);
+  });
+
+  it('does not advance the baseline for generated-artifact-only commits', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    writeProjectFile(root, '.ua/tracked-generated.json', '{}\n');
+    commit(root, 'generated output', { forcePaths: ['.ua/tracked-generated.json'] });
+
+    const { plan } = prepare(root, baseCommit);
+    expect(plan.action).toBe('SKIP');
+    expect(plan.generatedArtifactFiles).toEqual(['.ua/tracked-generated.json']);
+    run(process.execPath, [finalizeScript, root], root);
+    const meta = JSON.parse(readFileSync(join(root, '.ua', 'meta.json'), 'utf-8'));
+    expect(meta.gitCommitHash).toBe(baseCommit);
+  });
+});
+
+describe('finalize-incremental.mjs', { timeout: 30_000 }, () => {
+  it('preserves local layer/tour text, removes dangling refs, and places new nodes by path', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/api/a.ts': 'export const a = 1;\n',
+      'src/ui/view.ts': 'export const view = 1;\n',
+      'src/other.ts': 'export const other = 1;\n',
+      'docs/readme.md': '# Docs\n',
+    });
+    const graphPath = join(root, '.ua', 'knowledge-graph.json');
+    const previousGraph = JSON.parse(readFileSync(graphPath, 'utf-8'));
+    previousGraph.layers = [
+      {
+        id: 'layer:api',
+        name: 'API',
+        description: 'API files',
+        nodeIds: ['file:src/api/a.ts', 'file:missing.ts'],
+      },
+      {
+        id: 'layer:ui',
+        name: 'UI',
+        description: 'UI files',
+        nodeIds: ['file:src/ui/view.ts', 'file:src/other.ts', 'file:docs/readme.md'],
+      },
+    ];
+    previousGraph.tour[0].nodeIds.push('file:missing.ts');
+    writeFileSync(graphPath, JSON.stringify(previousGraph), 'utf-8');
+    writeProjectFile(root, 'src/api/new.ts', "import { a } from './a';\nexport const value = a;\n");
+    const headCommit = commit(root, 'add api file');
+    const { plan } = prepare(root, baseCommit);
+    expect(plan.action).toBe('PARTIAL_UPDATE');
+
+    const intermediate = join(root, '.ua', 'intermediate');
+    const retained = JSON.parse(readFileSync(join(intermediate, 'batch-existing.json'), 'utf-8'));
+    const newNode = {
+      id: 'file:src/api/new.ts',
+      type: 'file',
+      name: 'new.ts',
+      filePath: 'src/api/new.ts',
+      summary: 'new api',
+      tags: ['api'],
+      complexity: 'simple',
+    };
+    const aId = 'file:src/api/a.ts';
+    writeFileSync(
+      join(intermediate, 'assembled-graph.json'),
+      JSON.stringify({
+        nodes: [...retained.nodes, newNode],
+        edges: [{ source: newNode.id, target: aId, type: 'imports', direction: 'forward', weight: 0.7 }],
+      }),
+      'utf-8',
+    );
+
+    run(process.execPath, [finalizeScript, root], root);
+    const graph = JSON.parse(readFileSync(join(root, '.ua', 'knowledge-graph.json'), 'utf-8'));
+    expect(graph.project.gitCommitHash).toBe(headCommit);
+    expect(graph.layers.find(layer => layer.id === 'layer:api').nodeIds).toContain(newNode.id);
+    expect(graph.layers.flatMap(layer => layer.nodeIds)).not.toContain('file:missing.ts');
+    expect(graph.tour[0].title).toBe('Overview');
+    expect(graph.tour[0].description).toBe('Read the project');
+    expect(graph.tour[0].nodeIds.every(id => graph.nodes.some(node => node.id === id))).toBe(true);
+  });
+});

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -187,8 +187,12 @@ function prepare(root, baseCommit, extraArgs = []) {
   };
 }
 
-afterEach(() => {
+afterEach(async () => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  // These integration tests intentionally use synchronous child processes.
+  // Yield between cases so Vitest workers can service task-update RPC replies,
+  // especially on slower Windows runners where the full file exceeds 60s.
+  await new Promise(resolve => setImmediate(resolve));
 });
 
 describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -576,6 +576,25 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     expect(plan.filesToReanalyze).toEqual(['src/new name.ts']);
   });
 
+  it.skipIf(process.platform === 'win32')(
+    'preserves literal backslashes in POSIX project paths',
+    () => {
+      const literalPath = 'src/foo\\bar.js';
+      const { root, baseCommit } = setupRepository({
+        [literalPath]: 'function before() { return 1; }\nmodule.exports = before;\n',
+        'src/a.js': 'module.exports = 1;\n',
+        'src/b.js': 'module.exports = 2;\n',
+        'src/c.js': 'module.exports = 3;\n',
+      });
+      writeProjectFile(root, literalPath, 'function after() { return 1; }\nmodule.exports = after;\n');
+      commit(root, 'change literal backslash path');
+
+      const { plan, scan } = prepare(root, baseCommit);
+      expect(plan.filesToReanalyze).toEqual([literalPath]);
+      expect(scan.files.map(file => file.path)).toContain(literalPath);
+    },
+  );
+
   it('keeps the same new-directory decision when preparation is retried', () => {
     const { root, baseCommit } = setupRepository({
       'src/a.ts': 'export const a = 1;\n',

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -729,6 +729,49 @@ describe('finalize-incremental.mjs', { timeout: 30_000 }, () => {
     expect(readFileSync(metaPath, 'utf-8')).toBe(metaBefore);
   });
 
+  it.each([
+    ['table', 'db/schema.sql', 'users'],
+    ['endpoint', 'api/openapi.yaml', 'GET-users'],
+  ])('accepts a valid %s node as analyzed-file coverage', (nodeType, changedPath, name) => {
+    const initialContent = nodeType === 'table'
+      ? 'CREATE TABLE users (id INT);\n'
+      : 'openapi: 3.0.0\npaths: {}\n';
+    const changedContent = nodeType === 'table'
+      ? 'CREATE TABLE users (id INT, name TEXT);\n'
+      : 'openapi: 3.0.0\npaths:\n  /users: {}\n';
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      [changedPath]: initialContent,
+    });
+    writeProjectFile(root, changedPath, changedContent);
+    const headCommit = commit(root, `change ${nodeType} file`);
+    prepare(root, baseCommit);
+
+    const intermediate = join(root, '.ua', 'intermediate');
+    const retained = JSON.parse(readFileSync(join(intermediate, 'batch-existing.json'), 'utf-8'));
+    const analyzedNode = {
+      id: `${nodeType}:${changedPath}:${name}`,
+      type: nodeType,
+      name,
+      filePath: changedPath,
+      summary: `${nodeType} definition`,
+      tags: [nodeType],
+      complexity: 'simple',
+    };
+    writeFileSync(
+      join(intermediate, 'assembled-graph.json'),
+      JSON.stringify({ nodes: [...retained.nodes, analyzedNode], edges: retained.edges }),
+      'utf-8',
+    );
+    run(process.execPath, [finalizeScript, root], root);
+
+    const graph = JSON.parse(readFileSync(join(root, '.ua', 'knowledge-graph.json'), 'utf-8'));
+    expect(graph.project.gitCommitHash).toBe(headCommit);
+    expect(graph.nodes).toContainEqual(expect.objectContaining({ id: analyzedNode.id }));
+  });
+
   it('adds a newly introduced language to graph project metadata', () => {
     const { root, baseCommit } = setupRepository({
       'src/a.ts': 'export const a = 1;\n',

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -417,6 +417,24 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     expect(plan.reason).toContain('structural changes');
   });
 
+  it('treats parsed non-code content changes as structural', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'docs/guide.md': '# Guide\n\nOld body.\n',
+    });
+    const fingerprints = JSON.parse(
+      readFileSync(join(root, '.ua', 'fingerprints.json'), 'utf-8'),
+    );
+    expect(fingerprints.files['docs/guide.md'].hasStructuralAnalysis).toBe(false);
+    writeProjectFile(root, 'docs/guide.md', '# Guide\n\nNew body.\n');
+    commit(root, 'update parsed non-code content');
+
+    const { plan } = prepare(root, baseCommit);
+    expect(plan.filesToReanalyze).toEqual(['docs/guide.md']);
+  });
+
   it('classifies implementation-only edits as SKIP and advances fingerprints via finalize', () => {
     const { root, baseCommit } = setupRepository({
       'src/a.ts': 'export function value() { return 1; }\n',

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -342,6 +342,27 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     expect(scan.importMap['src/index.ts']).toEqual(['alternate/foo.ts']);
   });
 
+  it('refreshes supplemental require imports even when fingerprints classify the edit as cosmetic', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/index.js': "const value = require('./a');\nmodule.exports = value;\n",
+      'src/a.js': 'module.exports = 1;\n',
+      'src/b.js': 'module.exports = 2;\n',
+      'src/c.js': 'module.exports = 3;\n',
+    });
+    writeProjectFile(
+      root,
+      'src/index.js',
+      "const value = require('./b');\nmodule.exports = value;\n",
+    );
+    commit(root, 'change supplemental require');
+
+    const { plan, scan } = prepare(root, baseCommit);
+    expect(plan.action).toBe('SKIP');
+    expect(plan.cosmeticFiles).toEqual(['src/index.js']);
+    expect(plan.filesToReanalyze).toEqual([]);
+    expect(scan.importMap['src/index.js']).toEqual(['src/b.js']);
+  });
+
   it('treats LF-to-CRLF conversion as cosmetic and schedules no analyzer', () => {
     const { root, baseCommit } = setupRepository({
       'src/a.ts': 'export function value() {\n  return 1;\n}\n',

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -127,6 +127,18 @@ function buildBaseline(root, baseCommit) {
     tags: ['fixture'],
     complexity: 'simple',
   }));
+  const nodeIdByPath = new Map(nodes.map(node => [node.filePath, node.id]));
+  const edges = Object.entries(importMap).flatMap(([sourcePath, targets]) =>
+    targets
+      .filter(targetPath => nodeIdByPath.has(sourcePath) && nodeIdByPath.has(targetPath))
+      .map(targetPath => ({
+        source: nodeIdByPath.get(sourcePath),
+        target: nodeIdByPath.get(targetPath),
+        type: 'imports',
+        direction: 'forward',
+        weight: 0.7,
+      })),
+  );
   writeFileSync(
     join(root, '.ua', 'knowledge-graph.json'),
     JSON.stringify({
@@ -140,7 +152,7 @@ function buildBaseline(root, baseCommit) {
         gitCommitHash: baseCommit,
       },
       nodes,
-      edges: [],
+      edges,
       layers: [{
         id: 'layer:source',
         name: 'Source',
@@ -308,6 +320,34 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     const { plan, scan } = prepare(root, baseCommit);
     expect(plan.filesToReanalyze).toEqual(['src/foo.ts']);
     expect(scan.importMap['src/index.ts']).toEqual(['src/foo.ts']);
+    const intermediate = join(root, '.ua', 'intermediate');
+    const retained = JSON.parse(readFileSync(join(intermediate, 'batch-existing.json'), 'utf-8'));
+    expect(retained.edges).not.toContainEqual(
+      expect.objectContaining({ source: 'file:src/index.ts', type: 'imports' }),
+    );
+    writeFileSync(
+      join(intermediate, 'batch-0.json'),
+      JSON.stringify({
+        nodes: [{
+          id: 'file:src/foo.ts',
+          type: 'file',
+          name: 'foo.ts',
+          filePath: 'src/foo.ts',
+          summary: 'Preferred TypeScript candidate',
+          tags: ['typescript'],
+          complexity: 'simple',
+        }],
+        edges: [],
+      }),
+      'utf-8',
+    );
+    run(python, [mergeScript, root], root);
+    const assembled = JSON.parse(
+      readFileSync(join(intermediate, 'assembled-graph.json'), 'utf-8'),
+    );
+    expect(assembled.edges.filter(edge => edge.source === 'file:src/index.ts')).toEqual([
+      expect.objectContaining({ target: 'file:src/foo.ts', type: 'imports' }),
+    ]);
   });
 
   it('re-resolves unchanged importers to a fallback when a preferred candidate is deleted', () => {
@@ -364,6 +404,11 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     expect(plan.cosmeticFiles).toEqual(['src/index.js']);
     expect(plan.filesToReanalyze).toEqual([]);
     expect(scan.importMap['src/index.js']).toEqual(['src/b.js']);
+    run(process.execPath, [finalizeScript, root], root);
+    const graph = JSON.parse(readFileSync(join(root, '.ua', 'knowledge-graph.json'), 'utf-8'));
+    expect(graph.edges.filter(edge => edge.source === 'file:src/index.js')).toEqual([
+      expect.objectContaining({ target: 'file:src/b.js', type: 'imports' }),
+    ]);
   });
 
   it('treats LF-to-CRLF conversion as cosmetic and schedules no analyzer', () => {

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -664,6 +665,35 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
 
     const { plan } = prepare(root, baseCommit);
     expect(plan.filesToReanalyze).toEqual(['src/a.ts']);
+  });
+
+  it('aborts rather than treating a transient scan read failure as deletion', () => {
+    if (process.platform === 'win32' || (process.getuid && process.getuid() === 0)) return;
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    const graphPath = join(root, '.ua', 'knowledge-graph.json');
+    const metaPath = join(root, '.ua', 'meta.json');
+    const graphBefore = readFileSync(graphPath, 'utf-8');
+    const metaBefore = readFileSync(metaPath, 'utf-8');
+    writeProjectFile(root, 'src/a.ts', 'export const renamed = 1;\n');
+    commit(root, 'committed structural change');
+    chmodSync(join(root, 'src/b.ts'), 0o000);
+
+    const result = spawnSync(process.execPath, [prepareScript, root, baseCommit], {
+      cwd: root,
+      encoding: 'utf-8',
+    });
+    chmodSync(join(root, 'src/b.ts'), 0o644);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(
+      /(?:Project scan reported failures|Working tree has relevant uncommitted changes): src\/b\.ts/,
+    );
+    expect(readFileSync(graphPath, 'utf-8')).toBe(graphBefore);
+    expect(readFileSync(metaPath, 'utf-8')).toBe(metaBefore);
   });
 });
 

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -616,6 +616,35 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     expect(second.filesToReanalyze).toEqual(['new-package/index.ts']);
   });
 
+  it('reuses the preserved import map when retrying a different head', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/index.js': "const value = require('./a');\nmodule.exports = value;\n",
+      'src/a.js': 'module.exports = 1;\n',
+      'src/b.js': 'module.exports = 2;\n',
+      'src/c.js': 'function c() { return 3; }\nmodule.exports = c;\n',
+    });
+    writeProjectFile(
+      root,
+      'src/index.js',
+      "const value = require('./b');\nmodule.exports = value;\n",
+    );
+    commit(root, 'abandoned head changes import');
+    const abandoned = prepare(root, baseCommit);
+    expect(abandoned.scan.importMap['src/index.js']).toEqual(['src/b.js']);
+
+    git(root, ['reset', '--hard', baseCommit]);
+    writeProjectFile(
+      root,
+      'src/c.js',
+      'function changedC() { return 3; }\nmodule.exports = changedC;\n',
+    );
+    commit(root, 'replacement head changes another file');
+    const replacement = prepare(root, baseCommit);
+
+    expect(replacement.scan.importMap['src/index.js']).toEqual(['src/a.js']);
+    expect(replacement.plan.filesToReanalyze).toEqual(['src/c.js']);
+  });
+
   it('does not advance the baseline for generated-artifact-only commits', () => {
     const { root, baseCommit } = setupRepository({
       'src/a.ts': 'export const a = 1;\n',

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -183,7 +183,7 @@ function prepare(root, baseCommit, extraArgs = []) {
     result,
     plan: JSON.parse(readFileSync(join(intermediate, 'incremental-plan.json'), 'utf-8')),
     scan: JSON.parse(readFileSync(join(intermediate, 'scan-result.json'), 'utf-8')),
-    changedFiles: readFileSync(join(intermediate, 'changed-files.txt'), 'utf-8'),
+    changedFiles: JSON.parse(readFileSync(join(intermediate, 'changed-files.json'), 'utf-8')),
   };
 }
 
@@ -209,7 +209,7 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     const { plan, scan, changedFiles } = prepare(root, baseCommit);
     expect(plan.action).toBe('PARTIAL_UPDATE');
     expect(plan.filesToReanalyze).toEqual(['src/a.ts']);
-    expect(changedFiles).toBe('src/a.ts\n');
+    expect(changedFiles).toEqual(['src/a.ts']);
     expect(scan.importMap['src/a.ts']).toEqual(['src/b.ts']);
     expect(scan.importMap['src/c.ts']).toEqual([]);
   });
@@ -236,7 +236,7 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     expect(plan.action).toBe('PARTIAL_UPDATE');
     expect(plan.filesToReanalyze).toEqual([]);
     expect(plan.deletedFiles).toEqual(['src/b.ts']);
-    expect(changedFiles).toBe('');
+    expect(changedFiles).toEqual([]);
     expect(scan.files.map(file => file.path)).not.toContain('src/b.ts');
     expect(scan.importMap).not.toHaveProperty('src/b.ts');
     expect(() => readFileSync(join(root, '.ua', 'intermediate', 'batch-99.json'))).toThrow();
@@ -464,7 +464,7 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     expect(plan.action).toBe('SKIP');
     expect(plan.cosmeticFiles).toEqual(['src/a.ts']);
     expect(plan.filesToReanalyze).toEqual([]);
-    expect(changedFiles).toBe('');
+    expect(changedFiles).toEqual([]);
   });
 
   it('applies a new explicit exclude against the current inventory at the same commit', () => {
@@ -596,6 +596,29 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
       const { plan, scan } = prepare(root, baseCommit);
       expect(plan.filesToReanalyze).toEqual([literalPath]);
       expect(scan.files.map(file => file.path)).toContain(literalPath);
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'preserves newline-containing paths in the JSON analyzer handoff',
+    () => {
+      const newlinePath = 'src/line\nbreak.js';
+      const { root, baseCommit } = setupRepository({
+        [newlinePath]: 'function before() { return 1; }\nmodule.exports = before;\n',
+        'src/a.js': 'module.exports = 1;\n',
+        'src/b.js': 'module.exports = 2;\n',
+        'src/c.js': 'module.exports = 3;\n',
+      });
+      writeProjectFile(
+        root,
+        newlinePath,
+        'function after() { return 1; }\nmodule.exports = after;\n',
+      );
+      commit(root, 'change newline path');
+
+      const { plan, changedFiles } = prepare(root, baseCommit);
+      expect(plan.filesToReanalyze).toEqual([newlinePath]);
+      expect(changedFiles).toEqual([newlinePath]);
     },
   );
 

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -385,6 +385,40 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     expect(scan.importMap['src/index.ts']).toEqual(['alternate/foo.ts']);
   });
 
+  it('aborts without advancing baselines when import extraction reports a config failure', () => {
+    const { root, baseCommit } = setupRepository({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { baseUrl: '.', paths: { '@/*': ['src/*'] } },
+      }),
+      'src/index.ts': "import { value } from '@/foo';\nexport { value };\n",
+      'src/foo.ts': 'export const value = 1;\n',
+      'src/a.ts': 'export const a = 1;\n',
+    });
+    const graphPath = join(root, '.ua', 'knowledge-graph.json');
+    const fingerprintPath = join(root, '.ua', 'fingerprints.json');
+    const metaPath = join(root, '.ua', 'meta.json');
+    const scanPath = join(root, '.ua', 'intermediate', 'scan-result.json');
+    const graphBefore = readFileSync(graphPath, 'utf-8');
+    const fingerprintsBefore = readFileSync(fingerprintPath, 'utf-8');
+    const metaBefore = readFileSync(metaPath, 'utf-8');
+    const scanBefore = readFileSync(scanPath, 'utf-8');
+    writeProjectFile(root, 'tsconfig.json', '{"compilerOptions":{"paths":');
+    commit(root, 'break resolver config');
+
+    const result = spawnSync(process.execPath, [prepareScript, root, baseCommit], {
+      cwd: root,
+      encoding: 'utf-8',
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      'Import extraction reported failures: tsconfig.json (resolver-config-parse)',
+    );
+    expect(readFileSync(graphPath, 'utf-8')).toBe(graphBefore);
+    expect(readFileSync(fingerprintPath, 'utf-8')).toBe(fingerprintsBefore);
+    expect(readFileSync(metaPath, 'utf-8')).toBe(metaBefore);
+    expect(readFileSync(scanPath, 'utf-8')).toBe(scanBefore);
+  });
+
   it('refreshes supplemental require imports even when fingerprints classify the edit as cosmetic', () => {
     const { root, baseCommit } = setupRepository({
       'src/index.js': "const value = require('./a');\nmodule.exports = value;\n",

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -504,6 +504,62 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
     const meta = JSON.parse(readFileSync(join(root, '.ua', 'meta.json'), 'utf-8'));
     expect(meta.gitCommitHash).toBe(baseCommit);
   });
+
+  it('refuses to stamp HEAD when an analyzable untracked file is present', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    const metaPath = join(root, '.ua', 'meta.json');
+    const metaBefore = readFileSync(metaPath, 'utf-8');
+    writeProjectFile(root, 'src/a.ts', 'export const renamed = 1;\n');
+    commit(root, 'committed structural change');
+    writeProjectFile(root, 'src/uncommitted.ts', 'export const dirty = true;\n');
+
+    const result = spawnSync(process.execPath, [prepareScript, root, baseCommit], {
+      cwd: root,
+      encoding: 'utf-8',
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('relevant uncommitted changes: src/uncommitted.ts');
+    expect(readFileSync(metaPath, 'utf-8')).toBe(metaBefore);
+  });
+
+  it('refuses a partial-commit update when another analyzed file is still unstaged', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    writeProjectFile(root, 'src/a.ts', 'export const renamed = 1;\n');
+    commit(root, 'partial commit');
+    writeProjectFile(root, 'src/b.ts', 'export const stillDirty = 2;\n');
+
+    const result = spawnSync(process.execPath, [prepareScript, root, baseCommit], {
+      cwd: root,
+      encoding: 'utf-8',
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('relevant uncommitted changes: src/b.ts');
+  });
+
+  it('allows uncommitted files excluded by deterministic analysis rules', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    writeProjectFile(root, 'src/a.ts', 'export const renamed = 1;\n');
+    commit(root, 'committed structural change');
+    writeProjectFile(root, 'dist/untracked.js', 'generated();\n');
+
+    const { plan } = prepare(root, baseCommit);
+    expect(plan.filesToReanalyze).toEqual(['src/a.ts']);
+  });
 });
 
 describe('finalize-incremental.mjs', { timeout: 30_000 }, () => {

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -66,6 +66,9 @@ function setupRepository(files) {
   git(root, ['init', '-b', 'main']);
   git(root, ['config', 'user.email', 'test@example.com']);
   git(root, ['config', 'user.name', 'Test User']);
+  // Keep fixture bytes literal on Windows so the LF -> CRLF regression
+  // actually creates a commit instead of being normalized back to LF.
+  git(root, ['config', 'core.autocrlf', 'false']);
   writeProjectFile(root, '.gitignore', '.ua/\n.understand-anything/\n');
   for (const [path, content] of Object.entries(files)) writeProjectFile(root, path, content);
   const baseCommit = commit(root, 'baseline');

--- a/tests/skill/understand/test_prepare_incremental.test.mjs
+++ b/tests/skill/understand/test_prepare_incremental.test.mjs
@@ -160,8 +160,8 @@ function buildBaseline(root, baseCommit) {
   );
 }
 
-function prepare(root, baseCommit) {
-  const result = run(process.execPath, [prepareScript, root, baseCommit], root);
+function prepare(root, baseCommit, extraArgs = []) {
+  const result = run(process.execPath, [prepareScript, root, baseCommit, ...extraArgs], root);
   const intermediate = join(root, '.ua', 'intermediate');
   return {
     result,
@@ -274,6 +274,123 @@ describe('prepare-incremental.mjs', { timeout: 30_000 }, () => {
       readFileSync(join(intermediate, 'assembled-graph.json'), 'utf-8'),
     );
     expect(assembled.edges.filter(edge => edge.type === 'imports')).toHaveLength(0);
+  });
+
+  it('removes a deleted target from unchanged import-map sources', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': "import { b } from './b';\nexport const a = b;\n",
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    unlinkSync(join(root, 'src/b.ts'));
+    commit(root, 'delete imported target');
+
+    const { plan, scan } = prepare(root, baseCommit);
+    expect(plan.filesToReanalyze).toEqual([]);
+    expect(plan.deletedFiles).toEqual(['src/b.ts']);
+    expect(scan.importMap['src/a.ts']).toEqual([]);
+  });
+
+  it('re-resolves unchanged importers when a preferred candidate is added', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/index.ts': "import { value } from './foo';\nexport { value };\n",
+      'src/foo.js': 'export const value = 1;\n',
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+    });
+    writeProjectFile(root, 'src/foo.ts', 'export const value = 2;\n');
+    commit(root, 'add preferred typescript candidate');
+
+    const { plan, scan } = prepare(root, baseCommit);
+    expect(plan.filesToReanalyze).toEqual(['src/foo.ts']);
+    expect(scan.importMap['src/index.ts']).toEqual(['src/foo.ts']);
+  });
+
+  it('re-resolves unchanged importers to a fallback when a preferred candidate is deleted', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/index.ts': "import { value } from './foo';\nexport { value };\n",
+      'src/foo.ts': 'export const value = 2;\n',
+      'src/foo.js': 'export const value = 1;\n',
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+    });
+    unlinkSync(join(root, 'src/foo.ts'));
+    commit(root, 'delete preferred typescript candidate');
+
+    const { plan, scan } = prepare(root, baseCommit);
+    expect(plan.filesToReanalyze).toEqual([]);
+    expect(scan.importMap['src/index.ts']).toEqual(['src/foo.js']);
+  });
+
+  it('re-resolves unchanged importers when resolver configuration changes', () => {
+    const { root, baseCommit } = setupRepository({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { baseUrl: '.', paths: { '@/*': ['src/*'] } },
+      }),
+      'src/index.ts': "import { value } from '@/foo';\nexport { value };\n",
+      'src/foo.ts': 'export const value = 1;\n',
+      'alternate/foo.ts': 'export const value = 2;\n',
+      'src/a.ts': 'export const a = 1;\n',
+    });
+    writeProjectFile(root, 'tsconfig.json', JSON.stringify({
+      compilerOptions: { baseUrl: '.', paths: { '@/*': ['alternate/*'] } },
+    }));
+    commit(root, 'change alias target');
+
+    const { scan } = prepare(root, baseCommit);
+    expect(scan.importMap['src/index.ts']).toEqual(['alternate/foo.ts']);
+  });
+
+  it('treats LF-to-CRLF conversion as cosmetic and schedules no analyzer', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export function value() {\n  return 1;\n}\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    writeProjectFile(root, 'src/a.ts', 'export function value() {\r\n  return 1;\r\n}\r\n');
+    commit(root, 'convert line endings');
+
+    const { plan, changedFiles } = prepare(root, baseCommit);
+    expect(plan.action).toBe('SKIP');
+    expect(plan.cosmeticFiles).toEqual(['src/a.ts']);
+    expect(plan.filesToReanalyze).toEqual([]);
+    expect(changedFiles).toBe('');
+  });
+
+  it('applies a new explicit exclude against the current inventory at the same commit', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'feature/old.ts': 'export const old = true;\n',
+    });
+
+    const { plan, scan } = prepare(root, baseCommit, ['--exclude', 'feature/']);
+    expect(plan.headCommit).toBe(baseCommit);
+    expect(plan.filesToReanalyze).toEqual([]);
+    expect(plan.deletedFiles).toEqual(['feature/old.ts']);
+    expect(scan.files.map(file => file.path)).not.toContain('feature/old.ts');
+  });
+
+  it('conservatively analyzes an existing non-code file missing from a legacy fingerprint baseline', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'docs/guide.md': '# Guide\n\nOld body.\n',
+    });
+    const fingerprintPath = join(root, '.ua', 'fingerprints.json');
+    const fingerprints = JSON.parse(readFileSync(fingerprintPath, 'utf-8'));
+    delete fingerprints.files['docs/guide.md'];
+    writeFileSync(fingerprintPath, JSON.stringify(fingerprints), 'utf-8');
+    writeProjectFile(root, 'docs/guide.md', '# Guide\n\nNew body.\n');
+    commit(root, 'update legacy-unfingerprinted docs');
+
+    const { plan } = prepare(root, baseCommit);
+    expect(plan.filesToReanalyze).toEqual(['docs/guide.md']);
+    expect(plan.reason).toContain('structural changes');
   });
 
   it('classifies implementation-only edits as SKIP and advances fingerprints via finalize', () => {
@@ -428,5 +545,74 @@ describe('finalize-incremental.mjs', { timeout: 30_000 }, () => {
     expect(graph.tour[0].title).toBe('Overview');
     expect(graph.tour[0].description).toBe('Read the project');
     expect(graph.tour[0].nodeIds.every(id => graph.nodes.some(node => node.id === id))).toBe(true);
+    const fingerprints = JSON.parse(
+      readFileSync(join(root, '.ua', 'fingerprints.json'), 'utf-8'),
+    );
+    expect(fingerprints.gitCommitHash).toBe(headCommit);
+    expect(fingerprints.files).toHaveProperty('src/api/new.ts');
+    expect(Object.keys(fingerprints.files)).toHaveLength(5);
+  });
+
+  it('does not advance graph, fingerprints, or meta when assembled output is missing', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    const graphPath = join(root, '.ua', 'knowledge-graph.json');
+    const fingerprintPath = join(root, '.ua', 'fingerprints.json');
+    const metaPath = join(root, '.ua', 'meta.json');
+    const graphBefore = readFileSync(graphPath, 'utf-8');
+    const fingerprintsBefore = readFileSync(fingerprintPath, 'utf-8');
+    const metaBefore = readFileSync(metaPath, 'utf-8');
+    writeProjectFile(root, 'src/a.ts', 'export const renamed = 1;\n');
+    commit(root, 'structural change');
+    prepare(root, baseCommit);
+
+    const result = spawnSync(process.execPath, [finalizeScript, root], {
+      cwd: root,
+      encoding: 'utf-8',
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('assembled-graph.json is missing or invalid');
+    expect(readFileSync(graphPath, 'utf-8')).toBe(graphBefore);
+    expect(readFileSync(fingerprintPath, 'utf-8')).toBe(fingerprintsBefore);
+    expect(readFileSync(metaPath, 'utf-8')).toBe(metaBefore);
+  });
+
+  it('does not advance the baseline when analyzer output omits a changed file node', () => {
+    const { root, baseCommit } = setupRepository({
+      'src/a.ts': 'export const a = 1;\n',
+      'src/b.ts': 'export const b = 2;\n',
+      'src/c.ts': 'export const c = 3;\n',
+      'src/d.ts': 'export const d = 4;\n',
+    });
+    const graphPath = join(root, '.ua', 'knowledge-graph.json');
+    const fingerprintPath = join(root, '.ua', 'fingerprints.json');
+    const metaPath = join(root, '.ua', 'meta.json');
+    const graphBefore = readFileSync(graphPath, 'utf-8');
+    const fingerprintsBefore = readFileSync(fingerprintPath, 'utf-8');
+    const metaBefore = readFileSync(metaPath, 'utf-8');
+    writeProjectFile(root, 'src/a.ts', 'export const renamed = 1;\n');
+    commit(root, 'structural change omitted by analyzer');
+    prepare(root, baseCommit);
+
+    const intermediate = join(root, '.ua', 'intermediate');
+    const retained = JSON.parse(readFileSync(join(intermediate, 'batch-existing.json'), 'utf-8'));
+    writeFileSync(
+      join(intermediate, 'assembled-graph.json'),
+      JSON.stringify(retained),
+      'utf-8',
+    );
+    const result = spawnSync(process.execPath, [finalizeScript, root], {
+      cwd: root,
+      encoding: 'utf-8',
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('missing whole-file nodes for analyzed paths: src/a.ts');
+    expect(readFileSync(graphPath, 'utf-8')).toBe(graphBefore);
+    expect(readFileSync(fingerprintPath, 'utf-8')).toBe(fingerprintsBefore);
+    expect(readFileSync(metaPath, 'utf-8')).toBe(metaBefore);
   });
 });

--- a/tests/skill/understand/test_scan_project.test.mjs
+++ b/tests/skill/understand/test_scan_project.test.mjs
@@ -719,6 +719,7 @@ describe('scan-project.mjs — empty repo', () => {
     const r = runScript(projectRoot);
     expect(r.status).toBe(0);
     expect(r.output.scriptCompleted).toBe(true);
+    expect(r.output.failures).toEqual([]);
     expect(r.output.totalFiles).toBe(0);
     expect(r.output.files).toEqual([]);
     expect(r.output.filteredByIgnore).toBe(0);
@@ -762,6 +763,9 @@ describe('scan-project.mjs — per-file failure resilience', () => {
     const r = runScript(projectRoot);
     expect(r.status).toBe(0);
     expect(r.output.scriptCompleted).toBe(true);
+    expect(r.output.failures).toEqual([
+      expect.objectContaining({ path: 'src/unreadable.ts', stage: 'file-read' }),
+    ]);
     // The good file is in the output.
     expect(byPath(r.output, 'src/good.ts')).toBeDefined();
     // The unreadable file is dropped.
@@ -907,6 +911,7 @@ describe('scan-project.mjs — output schema invariants', () => {
       out.estimatedComplexity,
     );
     expect(out.stats).toBeDefined();
+    expect(out.failures).toEqual([]);
     expect(out.stats.filesScanned).toBe(out.files.length);
     expect(typeof out.stats.byCategory).toBe('object');
     expect(typeof out.stats.byLanguage).toBe('object');

--- a/tests/skill/understand/test_skill_security_snippets.test.mjs
+++ b/tests/skill/understand/test_skill_security_snippets.test.mjs
@@ -44,12 +44,9 @@ describe('skill command hardening', () => {
       'understand-anything-plugin/hooks/auto-update-prompt.md',
     );
 
-    expect(content).toMatch(
-      /Before filtering by extension, remove every path under the selected `\$UA_DIR`/,
-    );
-    expect(content).toMatch(
-      /If no paths remain after removing `\$UA_DIR`[\s\S]*without writing `meta\.json`/,
-    );
+    expect(content).toContain('generated-artifact-only');
+    expect(content).toContain('intentionally advances nothing for generated-only commits');
+    expect(content).toContain('Never update `meta.json` for a generated-artifact-only commit');
   });
 
   it('quotes dashboard cd targets and GRAPH_DIR assignment', () => {

--- a/understand-anything-plugin/hooks/auto-update-prompt.md
+++ b/understand-anything-plugin/hooks/auto-update-prompt.md
@@ -48,7 +48,7 @@ Read `filesToReanalyze` from the plan. It never contains deleted, ignored, cosme
 
   ```bash
   node "$PLUGIN_ROOT/skills/understand/compute-batches.mjs" "$PROJECT_ROOT" \
-    --changed-files="$UA_DIR/intermediate/changed-files.txt"
+    --changed-files="$UA_DIR/intermediate/changed-files.json"
   ```
 
   Dispatch file-analyzer for those batches only, using `agents/file-analyzer.md` and the batch prompt contract from the `/understand` skill. Preserve each original batch index in its output filename. Retry a failed dispatch once; if it still fails, **STOP** without running the finalizer or advancing the baseline.

--- a/understand-anything-plugin/hooks/auto-update-prompt.md
+++ b/understand-anything-plugin/hooks/auto-update-prompt.md
@@ -1,328 +1,99 @@
 # Auto-Update Knowledge Graph (Internal — Hook-Triggered)
 
-Incrementally update the knowledge graph using deterministic structural fingerprinting to minimize token usage. This prompt is triggered automatically by the post-commit hook when `autoUpdate` is enabled. It is NOT a user-facing skill.
+Incrementally update the knowledge graph after a commit. Do not ask the user for confirmation.
 
-**Key principle:** Spend zero LLM tokens when changes are cosmetic (formatting, internal logic). Only invoke LLM agents when structural changes (new/removed functions, classes, imports, exports) are detected.
+**Cost rule:** deletion-only, ignored-only, generated-artifact-only, and cosmetic-only updates dispatch no LLM agent. Local structural updates dispatch file-analyzer only for the current files that actually changed structurally. Whole-graph architecture/tour agents run only when the prepared plan requests them.
 
----
+## Phase 0 — Pre-flight and deterministic preparation
 
-## Phase 0 — Pre-flight (Zero Token Cost)
+1. Set `PROJECT_ROOT` to the current working directory. Resolve the data directory once:
 
-1. Set `PROJECT_ROOT` to the current working directory. **Resolve the data directory `$UA_DIR`** once and reuse it for every read and write below: `UA_DIR="$PROJECT_ROOT/$([ -d "$PROJECT_ROOT/.understand-anything" ] && echo .understand-anything || echo .ua)"` — this selects the legacy `.understand-anything/` when it already exists, otherwise the new `.ua/`. Because each phase may run in a fresh shell, carry `$UA_DIR` forward like `$PROJECT_ROOT`, re-resolving it with the same line if a later command block needs it. Scripts written below that run in Node resolve the same rule in JavaScript.
-
-2. Check that `$UA_DIR/knowledge-graph.json` exists.
-   - If not: report "No existing knowledge graph found. Run `/understand` first to create one." and **STOP**.
-
-3. Check that `$UA_DIR/meta.json` exists and read `gitCommitHash`.
-   - If not: report "No analysis metadata found. Run `/understand` to create a baseline." and **STOP**.
-
-4. Get current commit hash:
    ```bash
-   git rev-parse HEAD
+   UA_DIR="$PROJECT_ROOT/$([ -d "$PROJECT_ROOT/.understand-anything" ] && echo .understand-anything || echo .ua)"
    ```
 
-5. If commit hashes match and `--force` is NOT in `$ARGUMENTS`: report "Knowledge graph is already up to date." and **STOP**.
+2. Require `$UA_DIR/knowledge-graph.json` and `$UA_DIR/meta.json`. If either is missing, report that `/understand` must create a baseline and **STOP**.
+3. Read `gitCommitHash` from meta as `$LAST_COMMIT_HASH`; get `$HEAD_COMMIT` with `git rev-parse HEAD`. If they match, report that the graph is current and **STOP**.
+4. Resolve `$PLUGIN_ROOT` from `$CLAUDE_PLUGIN_ROOT`, then `$HOME/.understand-anything-plugin`, validating that it contains `skills/understand/prepare-incremental.mjs`. If it cannot be found, report the error and **STOP** without changing metadata.
+5. Ensure core is built, then run the bundled helper with parameterized arguments:
 
-6. Get changed files:
    ```bash
-   git diff "<lastCommitHash>..HEAD" --name-only
-   ```
-   If no files changed: update `meta.json` with the new commit hash and **STOP**.
-
-7. Before filtering by extension, remove every path under the selected `$UA_DIR` from the changed-file list. The selected data directory (`.ua/` or legacy `.understand-anything/`) contains generated graph artefacts, not project source changes. Do **not** update `meta.json` merely because files in this directory changed. If no paths remain after removing `$UA_DIR`, report "Only generated graph artefacts changed. The graph baseline remains associated with the analysed source commit." and **STOP** without writing `meta.json`.
-
-8. Filter the remaining paths to source files only (`.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.go`, `.rs`, `.java`, `.rb`, `.cpp`, `.c`, `.h`, `.cs`, `.swift`, `.kt`, `.php`).
-   If no source files changed: update `meta.json` with the new commit hash, report "Only non-source files changed. Metadata updated." and **STOP**.
-
-9. Create intermediate directory:
-   ```bash
-   mkdir -p "$UA_DIR/intermediate"
+   node "$PLUGIN_ROOT/skills/understand/prepare-incremental.mjs" \
+     "$PROJECT_ROOT" \
+     "$LAST_COMMIT_HASH"
    ```
 
-10. **Apply `.understandignore` exclusions** (same semantics as `/understand` Step 2.5 in `agents/project-scanner.md`).
+   The helper is authoritative for `git diff --name-status -z`, renames, spaces, POSIX normalization, the current scan/ignore rules, structural fingerprints, generated artifacts, and selective import-map refresh. Do not recreate or post-filter its decisions.
+6. Read `$UA_DIR/intermediate/incremental-plan.json`.
 
-   Without this step, files in user-excluded paths (migrations, vendored code, tests) are counted as structural changes and can spuriously escalate the action to `FULL_UPDATE` even when the real change set is tiny.
-
-   1. If neither `$UA_DIR/.understandignore` nor `$PROJECT_ROOT/.understandignore` exists, the step 7 extension filter is sufficient — skip to Phase 1.
-
-   2. Write the step 7 file list to `$UA_DIR/intermediate/changed-files-pre.json` as a JSON array of relative paths.
-
-   3. Resolve `$PLUGIN_ROOT`:
-      - Use `$CLAUDE_PLUGIN_ROOT` if set (Claude Code's hook context sets this).
-      - Otherwise try `$HOME/.understand-anything-plugin`.
-      - Validate the chosen candidate by checking `$candidate/packages/core/dist/ignore-filter.js` exists.
-      - If neither resolves: report "Cannot locate plugin install at `$CLAUDE_PLUGIN_ROOT` or `$HOME/.understand-anything-plugin`; auto-update aborted. Run `/understand` to re-baseline." and **STOP**. Do **not** silently skip — silent skip reproduces issue #153.
-
-   4. Write `$UA_DIR/intermediate/ignore-filter.mjs`:
-      ```javascript
-      import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-      import { pathToFileURL } from 'node:url';
-      import path from 'node:path';
-
-      const PROJECT_ROOT = process.cwd();
-      // Data directory: legacy `.understand-anything/` when present, else new `.ua/`.
-      const UA_DIR = existsSync(path.join(PROJECT_ROOT, '.understand-anything')) ? '.understand-anything' : '.ua';
-      const PLUGIN_ROOT = process.argv[2];
-      const inputPath = process.argv[3];
-
-      const modUrl = pathToFileURL(
-        path.join(PLUGIN_ROOT, 'packages/core/dist/ignore-filter.js'),
-      ).href;
-      const { createIgnoreFilter } = await import(modUrl);
-      const filter = createIgnoreFilter(PROJECT_ROOT);
-
-      const input = JSON.parse(readFileSync(inputPath, 'utf-8'));
-      const kept = input.filter((p) => !filter.isIgnored(p));
-      const removed = input.length - kept.length;
-
-      writeFileSync(
-        path.join(PROJECT_ROOT, UA_DIR, 'intermediate/changed-files.json'),
-        JSON.stringify({ kept, removed, total: input.length }, null, 2),
-      );
-      console.log(`.understandignore: kept ${kept.length}/${input.length} (removed ${removed})`);
-      ```
-
-   5. Run it:
-      ```bash
-      node "$UA_DIR/intermediate/ignore-filter.mjs" \
-        "$PLUGIN_ROOT" \
-        "$UA_DIR/intermediate/changed-files-pre.json"
-      ```
-
-   6. Read `$UA_DIR/intermediate/changed-files.json`. Pass the `kept` array as the input file list for Phase 1's fingerprint-check script.
-
-   7. If `kept.length === 0`: update `meta.json` with the new commit hash, report "All changed source files are in ignored paths. Metadata updated." and **STOP**.
-
----
-
-## Phase 1 — Structural Fingerprint Check (Zero LLM Tokens)
-
-This phase runs a deterministic Node.js script that compares file structures against stored fingerprints. It costs **zero LLM tokens** — only the script execution cost.
-
-1. Write and execute a Node.js script (`$UA_DIR/intermediate/fingerprint-check.mjs`):
-
-```javascript
-// The script should:
-// 1. Read fingerprints.json from the data directory (.ua/fingerprints.json, or .understand-anything/fingerprints.json when that legacy directory is present — resolve UA_DIR the same way as the other scripts)
-// 2. For each changed source file:
-//    a. Read the file content
-//    b. Compute SHA-256 content hash
-//    c. If content hash matches stored hash → NONE (skip)
-//    d. Extract structural elements via regex:
-//       - Functions: match patterns like `function NAME(`, `const NAME = (`, `export function NAME(`
-//       - Classes: match `class NAME`, `export class NAME`
-//       - Imports: match `import ... from '...'`, `import '...'`
-//       - Exports: match `export { ... }`, `export default`, `export function`, `export class`, `export const`
-//    e. Compare extracted elements against stored fingerprint
-//    f. Classify as NONE, COSMETIC, or STRUCTURAL
-// 3. For new files (not in fingerprints.json): classify as STRUCTURAL
-// 4. For deleted files (in fingerprints.json but not on disk): classify as STRUCTURAL
-// 5. Determine overall decision:
-//    - All NONE/COSMETIC → action: "SKIP"
-//    - Some STRUCTURAL, ≤10 files, same directories → action: "PARTIAL_UPDATE"
-//    - New/deleted directories or >10 structural files → action: "ARCHITECTURE_UPDATE"
-//    - >30 structural files or >50% of graph → action: "FULL_UPDATE"
-// 6. Write result to <UA_DIR>/intermediate/change-analysis.json (.ua/, or .understand-anything/ when that legacy directory is present)
-```
-
-The output JSON should have this shape:
-```json
-{
-  "action": "SKIP | PARTIAL_UPDATE | ARCHITECTURE_UPDATE | FULL_UPDATE",
-  "filesToReanalyze": ["src/new-feature.ts"],
-  "rerunArchitecture": false,
-  "rerunTour": false,
-  "reason": "1 file has structural changes (new function added)",
-  "fileChanges": [
-    { "filePath": "src/utils.ts", "changeLevel": "COSMETIC", "details": ["internal logic changed"] },
-    { "filePath": "src/new-feature.ts", "changeLevel": "STRUCTURAL", "details": ["new function: handleRequest"] }
-  ]
-}
-```
-
-2. Read `$UA_DIR/intermediate/change-analysis.json`.
-
-3. **Decision gate:**
-
-   | Action | What to do |
+   | Action | Required behavior |
    |---|---|
-   | `SKIP` | Update `meta.json` with new commit hash. Report: "No structural changes detected. Graph metadata updated. Zero tokens spent." **STOP.** |
-   | `FULL_UPDATE` | Report: "Major structural changes detected (reason). Recommend running `/understand --full` for a complete rebuild." **STOP.** |
-   | `PARTIAL_UPDATE` | Proceed to Phase 2 with `filesToReanalyze` |
-   | `ARCHITECTURE_UPDATE` | Proceed to Phase 2 with `filesToReanalyze`, flag architecture re-run |
+   | `SKIP` | Run the finalizer below. It advances scan/fingerprint/meta for safe cosmetic or irrelevant changes and intentionally advances nothing for generated-only commits. Report zero tokens spent and **STOP**. |
+   | `PARTIAL_UPDATE` | Continue with targeted analysis. |
+   | `ARCHITECTURE_UPDATE` | Continue with targeted analysis, then rerun architecture and tour. |
+   | `FULL_UPDATE` | Immediately invoke `/understand --full`; do not patch the incremental baseline. |
 
----
+   SKIP finalizer:
 
-## Phase 2 — Targeted Re-Analysis (Minimal Token Cost)
-
-Only re-analyze files with structural changes. This is the **only** phase that costs LLM tokens.
-
-1. Read the existing knowledge graph from `$UA_DIR/knowledge-graph.json`.
-
-2. Batch the files from `filesToReanalyze` (from Phase 1). Use a single batch if ≤10 files, otherwise batch into groups of 5-10.
-
-3. For each batch, dispatch a subagent using the `file-analyzer` agent definition (at `agents/file-analyzer.md`). Append:
-
-   > **Additional context from main session:**
-   >
-   > Project: `<projectName from existing graph>` — `<projectDescription>`
-   > Frameworks detected: `<frameworks from existing graph>`
-   > Languages: `<languages from existing graph>`
-   >
-   > **IMPORTANT:** This is an incremental update. Only the files listed below have structural changes. Analyze them thoroughly but do not invent nodes for files not in this batch.
-
-   Fill in batch-specific parameters:
-
-   > Analyze these source files and produce GraphNode and GraphEdge objects.
-   > Project root: `$PROJECT_ROOT`
-   > Project: `<projectName>`
-   > Languages: `<languages>`
-   > Batch index: `1`
-   > Write output to: `$UA_DIR/intermediate/batch-1.json`
-   >
-   > All project files (for import resolution):
-   > `<file list from existing graph nodes>`
-   >
-   > Files to analyze in this batch:
-   > 1. `<path>` (`<sizeLines>` lines)
-   > ...
-
-4. After batch(es) complete, read each `batch-<N>.json` and merge results.
-
-5. **Merge with existing graph:**
-   - Remove old nodes whose `filePath` matches any file in `filesToReanalyze` or in the deleted files list
-   - Remove old edges whose `source` or `target` references a removed node
-   - Add new nodes and edges from the fresh analysis
-   - Deduplicate nodes by ID (keep latest), edges by `source + target + type`
-   - Remove any edge with dangling `source` or `target` references
-
----
-
-## Phase 3 — Conditional Architecture/Tour + Save
-
-### 3a. Architecture update (only if `rerunArchitecture === true`)
-
-If the change analysis flagged `ARCHITECTURE_UPDATE`:
-
-1. Dispatch a subagent using the `architecture-analyzer` agent definition (at `agents/architecture-analyzer.md`), passing the full merged node set and import edges. Include previous layer definitions for naming consistency:
-
-   > Previous layer definitions (for naming consistency):
-   > ```json
-   > [previous layers from existing graph]
-   > ```
-   > Maintain the same layer names and IDs where possible. Only add/remove layers if the file structure has materially changed.
-
-2. After completion, read and normalize layers (same normalization as `/understand` Phase 4).
-
-3. Optionally re-run tour builder if layers changed significantly.
-
-### 3b. Lite layer update (if `rerunArchitecture === false`)
-
-If only a partial update:
-1. For **new files**: assign them to the most likely existing layer based on directory path matching
-2. For **deleted files**: remove their IDs from layer `nodeIds` arrays
-3. Remove any layer that ends up with zero nodeIds
-
-### 3c. Lite validation
-
-Perform lightweight validation (no graph-reviewer agent):
-1. Remove any edge with dangling `source` or `target`
-2. Remove any layer `nodeIds` entry that doesn't exist in the node set
-3. Ensure every file node appears in exactly one layer (add to a catch-all layer if missing)
-
-### 3d. Save
-
-1. Write the final knowledge graph to `$UA_DIR/knowledge-graph.json`.
-
-2. Write updated metadata to `$UA_DIR/meta.json`:
-   ```json
-   {
-     "lastAnalyzedAt": "<ISO 8601 timestamp>",
-     "gitCommitHash": "<current commit hash>",
-     "version": "1.0.0",
-     "analyzedFiles": <total file count in graph>
-   }
-   ```
-
-3. **Update fingerprints (LOAD-PATCH-SAVE, not OVERWRITE).**
-
-   The most common failure mode here: writing only the freshly-computed batch entries to `fingerprints.json`, discarding every other file's fingerprint. The next auto-update then sees all those files as new (no stored fingerprint), classifies them as STRUCTURAL, and escalates to FULL_UPDATE permanently (issue #152). The script must LOAD ALL existing entries, PATCH only the re-analyzed ones, and SAVE the full dict back.
-
-   Write and execute a Node.js script in this exact ordering:
-
-   ```javascript
-   import { readFileSync, writeFileSync, existsSync } from 'node:fs';
-   import { createHash } from 'node:crypto';
-   import path from 'node:path';
-
-   const UA_DIR = existsSync(path.join(PROJECT_ROOT, '.understand-anything')) ? '.understand-anything' : '.ua';
-   const fpPath = path.join(PROJECT_ROOT, UA_DIR, 'fingerprints.json');
-   const existedAndNonEmpty = existsSync(fpPath) && readFileSync(fpPath, 'utf-8').trim().length > 0;
-
-   // 1. LOAD ALL existing entries (NEVER skip — preserves un-analyzed files)
-   const all = existedAndNonEmpty
-     ? JSON.parse(readFileSync(fpPath, 'utf-8'))
-     : {};
-   const before = Object.keys(all).length;
-
-   // 2. PATCH (file still exists) or REMOVE (file deleted) for each re-analyzed path.
-   //    `filesToReanalyze` may include paths that were deleted in this commit —
-   //    handle both branches inline rather than expecting a separate deleted list.
-   for (const filePath of filesToReanalyze) {
-     const fullPath = path.join(PROJECT_ROOT, filePath);
-     if (!existsSync(fullPath)) {
-       delete all[filePath];
-       continue;
-     }
-     const content = readFileSync(fullPath, 'utf-8');
-     const contentHash = createHash('sha256').update(content).digest('hex');
-     // Extract functions, classes, imports, exports via the same regex as Phase 1.
-     all[filePath] = { contentHash, functions, classes, imports, exports };
-   }
-
-   // 3. GUARD against silent load failure: if fingerprints.json existed and was
-   //    non-empty but `before` came out as 0, refuse to overwrite — something
-   //    went wrong reading the file and writing now would clobber every entry.
-   if (existedAndNonEmpty && before === 0) {
-     throw new Error('fingerprints.json existed and was non-empty but loaded as {} — refusing to overwrite');
-   }
-
-   // 4. SAVE ALL entries back (full dict — not just the patched subset)
-   writeFileSync(fpPath, JSON.stringify(all, null, 2));
-   console.log(`Fingerprints: ${before} → ${Object.keys(all).length}`);
-   ```
-
-   The `existedAndNonEmpty && before === 0` guard catches the silent-load-failure case before it corrupts the store. If the count shrinks from N to a small number that matches the batch size, the LOAD step was skipped — abort the write rather than persist the wrong dict.
-
-4. Clean up intermediate files:
    ```bash
-   INTERMEDIATE_DIR="$UA_DIR/intermediate"
-   if [ -n "$PROJECT_ROOT" ] && [ -d "$INTERMEDIATE_DIR" ]; then
-     rm -rf "$INTERMEDIATE_DIR"
-   fi
+   node "$PLUGIN_ROOT/skills/understand/finalize-incremental.mjs" "$PROJECT_ROOT"
    ```
 
-5. Report a summary:
-   - Files checked: N (total changed)
-   - Structural changes found: N files
-   - Cosmetic-only changes: N files (skipped)
-   - Nodes updated: N
-   - Action taken: PARTIAL_UPDATE / ARCHITECTURE_UPDATE
-   - Path to output: `$UA_DIR/knowledge-graph.json`
+## Phase 1 — Targeted file analysis
 
----
+Read `filesToReanalyze` from the plan. It never contains deleted, ignored, cosmetic, or generated-artifact paths.
 
-## Error Handling
+- If the list is empty, dispatch no agent and create no new batch file. Continue directly to merge; `batch-existing.json` already contains the pruned graph. This covers deletion-only updates at zero token cost.
+- Otherwise compute only changed batches:
 
-- If the fingerprint check script fails: fall back to treating all changed files as STRUCTURAL (conservative approach).
-- If `fingerprints.json` doesn't exist: treat all changed files as STRUCTURAL and regenerate fingerprints after the update.
-- If a subagent dispatch fails: retry once. If it fails again, save partial results and report the error.
-- ALWAYS save partial results — a partially updated graph is better than no update.
+  ```bash
+  node "$PLUGIN_ROOT/skills/understand/compute-batches.mjs" "$PROJECT_ROOT" \
+    --changed-files="$UA_DIR/intermediate/changed-files.txt"
+  ```
 
----
+  Dispatch file-analyzer for those batches only, using `agents/file-analyzer.md` and the batch prompt contract from the `/understand` skill. Preserve each original batch index in its output filename. Retry a failed dispatch once; if it still fails, **STOP** without running the finalizer or advancing the baseline.
 
-## Notes
+## Phase 2 — Merge
 
-- This skill reuses the same `file-analyzer` and `architecture-analyzer` agent definitions as `/understand` — no separate agent prompts needed.
-- The fingerprint comparison in Phase 1 uses regex-based extraction (not tree-sitter) because it runs as a temporary Node.js script and doesn't need full AST accuracy — just signature-level detection.
-- The authoritative fingerprints stored in `fingerprints.json` are generated by `/understand` Phase 7 using the core `fingerprint.ts` module (which uses tree-sitter for precise extraction).
+Run the deterministic merge in both empty and non-empty analyzer cases:
+
+```bash
+python "$PLUGIN_ROOT/skills/understand/merge-batch-graphs.py" "$PROJECT_ROOT"
+```
+
+It combines `batch-existing.json` with fresh batches and recovers imports from the refreshed `scan-result.json`, including `config:`, `schema:`, `service:`, and other valid whole-file nodes. Require `$UA_DIR/intermediate/assembled-graph.json`; on failure, report it and **STOP** without advancing fingerprints or meta.
+
+Do not dispatch assemble-reviewer or graph-reviewer for automatic updates.
+
+## Phase 3 — Conditional architecture and tour
+
+- For `PARTIAL_UPDATE`, dispatch neither agent. The finalizer preserves existing layer assignments and tour prose, removes dangling references/empty layers, and assigns new nodes deterministically by directory depth, graph connectivity, then prior layer order.
+- For `ARCHITECTURE_UPDATE`, dispatch architecture-analyzer on the full merged node/edge set, including previous layers for naming stability, and write `$UA_DIR/intermediate/layers.json`. Then dispatch tour-builder and write `$UA_DIR/intermediate/tour.json`.
+
+Retry either required agent once. If it still fails, **STOP** without advancing the baseline.
+
+## Phase 4 — Atomic save and baseline patch
+
+Run:
+
+```bash
+node "$PLUGIN_ROOT/skills/understand/finalize-incremental.mjs" "$PROJECT_ROOT"
+```
+
+The finalizer performs deterministic graph/layer/tour validation, atomically saves `knowledge-graph.json`, patches changed fingerprints while preserving untouched entries, removes deleted fingerprints, and only then writes `meta.json`. A graph-save failure must never advance the fingerprint or commit baseline.
+
+Report:
+
+- action taken;
+- files structurally analyzed;
+- deleted/ignored/cosmetic/generated counts from the plan;
+- whether architecture/tour ran;
+- output path.
+
+## Error handling
+
+- Never fall back to a hand-written regex fingerprint script or an extension-only changed-file filter.
+- Never pass a deleted or ignored path to file-analyzer.
+- Never update `meta.json` after a failed graph/agent phase.
+- Never update `meta.json` for a generated-artifact-only commit.
+- Surface every warning or failure; a subsequent run can safely retry because the helper reconstructs the previous inventory from scan results, graph node `filePath` values, and fingerprints.

--- a/understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts
@@ -143,6 +143,22 @@ describe("classifyUpdate", () => {
     expect(decision.action).toBe("PARTIAL_UPDATE");
   });
 
+  it.skipIf(process.platform === "win32")(
+    "does not treat a literal POSIX backslash as a directory separator",
+    () => {
+      const analysis = makeAnalysis({ newFiles: ["foo\\bar.js"] });
+
+      const decision = classifyUpdate(
+        analysis,
+        20,
+        ["index.js"],
+        ["index.js", "foo\\bar.js"],
+      );
+
+      expect(decision.action).toBe("PARTIAL_UPDATE");
+    },
+  );
+
   it("does NOT trigger ARCHITECTURE_UPDATE for new file in existing directory", () => {
     const analysis = makeAnalysis({
       newFiles: ["src/newfile.ts"],

--- a/understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/change-classifier.test.ts
@@ -95,6 +95,54 @@ describe("classifyUpdate", () => {
     expect(decision.rerunArchitecture).toBe(true);
   });
 
+  it("compares explicit before and after inventories for removed directories", () => {
+    const analysis = makeAnalysis({
+      deletedFiles: ["legacy/removed.ts"],
+    });
+
+    const decision = classifyUpdate(
+      analysis,
+      20,
+      ["src/index.ts", "legacy/removed.ts"],
+      ["src/index.ts"],
+    );
+
+    expect(decision.action).toBe("ARCHITECTURE_UPDATE");
+    expect(decision.filesToReanalyze).toEqual([]);
+  });
+
+  it("keeps deletion-only changes partial when the top-level directory remains", () => {
+    const analysis = makeAnalysis({
+      deletedFiles: ["src/removed.ts"],
+    });
+
+    const decision = classifyUpdate(
+      analysis,
+      20,
+      ["src/index.ts", "src/removed.ts"],
+      ["src/index.ts"],
+    );
+
+    expect(decision.action).toBe("PARTIAL_UPDATE");
+    expect(decision.filesToReanalyze).toEqual([]);
+    expect(decision.rerunArchitecture).toBe(false);
+  });
+
+  it("normalizes Windows separators when comparing top-level directories", () => {
+    const analysis = makeAnalysis({
+      newFiles: ["src\\new.ts"],
+    });
+
+    const decision = classifyUpdate(
+      analysis,
+      20,
+      ["src\\existing.ts"],
+      ["src\\existing.ts", "src\\new.ts"],
+    );
+
+    expect(decision.action).toBe("PARTIAL_UPDATE");
+  });
+
   it("does NOT trigger ARCHITECTURE_UPDATE for new file in existing directory", () => {
     const analysis = makeAnalysis({
       newFiles: ["src/newfile.ts"],

--- a/understand-anything-plugin/packages/core/src/__tests__/fingerprint.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/fingerprint.test.ts
@@ -5,6 +5,7 @@ import {
   extractFileFingerprint,
   compareFingerprints,
   analyzeChanges,
+  buildFingerprintStore,
   type FileFingerprint,
   type FingerprintStore,
 } from "../fingerprint.js";
@@ -22,6 +23,34 @@ const mockedExistsSync = vi.mocked(existsSync);
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("buildFingerprintStore", () => {
+  it("uses content-only fingerprints when parser structure is not fully represented", () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue('{"enabled":true}');
+    const registry = {
+      analyzeFile: vi.fn().mockReturnValue({
+        functions: [],
+        classes: [],
+        imports: [],
+        exports: [],
+        definitions: [{ name: "enabled", kind: "property" }],
+      }),
+      getLanguageForFile: vi.fn().mockReturnValue("json"),
+    } as any;
+
+    const store = buildFingerprintStore(
+      "/project",
+      ["config.json"],
+      registry,
+      "abc123",
+      { structuralFingerprintLanguages: new Set(["typescript"]) },
+    );
+
+    expect(store.files["config.json"].hasStructuralAnalysis).toBe(false);
+    expect(store.files["config.json"].contentHash).toBe(contentHash('{"enabled":true}'));
+  });
 });
 
 describe("contentHash", () => {

--- a/understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts
+++ b/understand-anything-plugin/packages/core/src/__tests__/ignore-filter.test.ts
@@ -26,6 +26,10 @@ describe("IgnoreFilter", () => {
       expect(DEFAULT_IGNORE_PATTERNS).toContain(".git/");
     });
 
+    it("contains the .understandignore control file", () => {
+      expect(DEFAULT_IGNORE_PATTERNS).toContain(".understandignore");
+    });
+
     it("contains obj for .NET", () => {
       expect(DEFAULT_IGNORE_PATTERNS).toContain("obj/");
     });

--- a/understand-anything-plugin/packages/core/src/change-classifier.ts
+++ b/understand-anything-plugin/packages/core/src/change-classifier.ts
@@ -21,7 +21,8 @@ export interface UpdateDecision {
 export function classifyUpdate(
   analysis: ChangeAnalysis,
   totalFilesInGraph: number,
-  allKnownFiles: string[] = [],
+  previousFiles: string[] = [],
+  currentFiles?: string[],
 ): UpdateDecision {
   const { newFiles, deletedFiles, structurallyChangedFiles, cosmeticOnlyFiles } = analysis;
   const structuralCount = structurallyChangedFiles.length + newFiles.length + deletedFiles.length;
@@ -62,7 +63,12 @@ export function classifyUpdate(
   }
 
   // Check if directory structure changed (new/deleted top-level directories)
-  const hasDirectoryChanges = detectDirectoryChanges(newFiles, deletedFiles, allKnownFiles);
+  const hasDirectoryChanges = detectDirectoryChanges(
+    newFiles,
+    deletedFiles,
+    previousFiles,
+    currentFiles,
+  );
 
   if (hasDirectoryChanges || structuralCount > 10) {
     return {
@@ -94,23 +100,38 @@ export function classifyUpdate(
 function detectDirectoryChanges(
   newFiles: string[],
   deletedFiles: string[],
-  allKnownFiles: string[],
+  previousFiles: string[],
+  currentFiles?: string[],
 ): boolean {
-  const existingDirs = new Set(
-    allKnownFiles.map((f) => topDirectory(f)).filter(Boolean),
-  );
+  // Older callers only provided one inventory. Reconstruct both sides from
+  // the change analysis so that the optional fourth argument remains fully
+  // backwards compatible while still fixing deletion-only directory changes.
+  const before = new Set(previousFiles);
+  for (const file of deletedFiles) before.add(file);
 
-  for (const f of newFiles) {
-    const dir = topDirectory(f);
-    if (dir && !existingDirs.has(dir)) return true;
+  const after = currentFiles === undefined
+    ? new Set(previousFiles.filter(file => !deletedFiles.includes(file)))
+    : new Set(currentFiles);
+  if (currentFiles === undefined) {
+    for (const file of newFiles) after.add(file);
   }
 
-  for (const f of deletedFiles) {
-    const dir = topDirectory(f);
-    if (dir && !existingDirs.has(dir)) return true;
+  const beforeDirs = topDirectories(before);
+  const afterDirs = topDirectories(after);
+  if (beforeDirs.size !== afterDirs.size) return true;
+  for (const dir of beforeDirs) {
+    if (!afterDirs.has(dir)) return true;
   }
-
   return false;
+}
+
+function topDirectories(files: Iterable<string>): Set<string> {
+  const dirs = new Set<string>();
+  for (const file of files) {
+    const dir = topDirectory(file.replaceAll("\\", "/"));
+    if (dir) dirs.add(dir);
+  }
+  return dirs;
 }
 
 /**

--- a/understand-anything-plugin/packages/core/src/change-classifier.ts
+++ b/understand-anything-plugin/packages/core/src/change-classifier.ts
@@ -128,7 +128,8 @@ function detectDirectoryChanges(
 function topDirectories(files: Iterable<string>): Set<string> {
   const dirs = new Set<string>();
   for (const file of files) {
-    const dir = topDirectory(file.replaceAll("\\", "/"));
+    const platformPath = process.platform === "win32" ? file.replaceAll("\\", "/") : file;
+    const dir = topDirectory(platformPath);
     if (dir) dirs.add(dir);
   }
   return dirs;

--- a/understand-anything-plugin/packages/core/src/fingerprint.ts
+++ b/understand-anything-plugin/packages/core/src/fingerprint.ts
@@ -45,6 +45,15 @@ export interface FingerprintStore {
   files: Record<string, FileFingerprint>;
 }
 
+export interface FingerprintBuildOptions {
+  /**
+   * Languages whose StructuralAnalysis fields are fully represented by
+   * FileFingerprint. Other languages receive content-only fingerprints so a
+   * content change is classified conservatively instead of as cosmetic.
+   */
+  structuralFingerprintLanguages?: ReadonlySet<string>;
+}
+
 export type ChangeLevel = "NONE" | "COSMETIC" | "STRUCTURAL";
 
 export interface FileChangeResult {
@@ -255,6 +264,7 @@ export function buildFingerprintStore(
   filePaths: string[],
   registry: PluginRegistry,
   gitCommitHash: string,
+  options: FingerprintBuildOptions = {},
 ): FingerprintStore {
   const files: Record<string, FileFingerprint> = {};
 
@@ -264,8 +274,14 @@ export function buildFingerprintStore(
 
     const content = readFileSync(absolutePath, "utf-8");
     const analysis = registry.analyzeFile(filePath, content);
+    let fingerprintCoversAnalysis = true;
+    if (options.structuralFingerprintLanguages !== undefined) {
+      const language = registry.getLanguageForFile(filePath);
+      fingerprintCoversAnalysis =
+        language !== null && options.structuralFingerprintLanguages.has(language);
+    }
 
-    if (analysis) {
+    if (analysis && fingerprintCoversAnalysis) {
       files[filePath] = extractFileFingerprint(filePath, content, analysis);
     } else {
       // No tree-sitter support: content hash only (conservative)

--- a/understand-anything-plugin/packages/core/src/ignore-filter.ts
+++ b/understand-anything-plugin/packages/core/src/ignore-filter.ts
@@ -64,6 +64,7 @@ export const DEFAULT_IGNORE_PATTERNS: string[] = [
   // Misc
   "LICENSE",
   ".gitignore",
+  ".understandignore",
   ".editorconfig",
   ".prettierrc",
   ".eslintrc*",

--- a/understand-anything-plugin/packages/core/src/index.ts
+++ b/understand-anything-plugin/packages/core/src/index.ts
@@ -98,6 +98,7 @@ export {
   type ImportFingerprint,
   type FileFingerprint,
   type FingerprintStore,
+  type FingerprintBuildOptions,
   type ChangeLevel,
   type FileChangeResult,
   type ChangeAnalysis,

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -210,7 +210,7 @@ Determine whether to run a full analysis or incremental update.
    The helper uses parameterized `git diff --name-status -z`, performs a fresh deterministic scan with the current `.understandignore` / `--exclude` rules, compares structural fingerprints, selectively refreshes imports, and atomically writes:
    - `$UA_DIR/intermediate/incremental-plan.json`
    - `$UA_DIR/intermediate/scan-result.json`
-   - `$UA_DIR/intermediate/changed-files.txt`
+   - `$UA_DIR/intermediate/changed-files.json`
    - `$UA_DIR/intermediate/batch-existing.json` for partial/architecture updates
 
    Read `incremental-plan.json` and store its `action`, `filesToReanalyze`, `deletedFiles`, `rerunArchitecture`, and `rerunTour` values. Follow this gate:
@@ -318,7 +318,7 @@ For `PARTIAL_UPDATE` or `ARCHITECTURE_UPDATE`, inspect `filesToReanalyze` from t
 
   ```bash
   node "<SKILL_DIR>/compute-batches.mjs" "$PROJECT_ROOT" \
-    --changed-files="$UA_DIR/intermediate/changed-files.txt"
+    --changed-files="$UA_DIR/intermediate/changed-files.json"
   ```
 
 Both forms read the freshly reconciled `$UA_DIR/intermediate/scan-result.json` and write `$UA_DIR/intermediate/batches.json`.

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -185,6 +185,7 @@ Determine whether to run a full analysis or incremental update.
    |---|---|
    | `--full` flag in `$ARGUMENTS` | Full analysis (all phases) |
    | No existing graph or meta | Full analysis (all phases) |
+   | Existing graph + explicit `--exclude` | Run deterministic incremental preparation even when the commit hash is unchanged, so the new inventory rules take effect immediately |
    | `--review` flag + existing graph + unchanged commit hash | Skip to Phase 6 (review-only — reuse existing assembled graph) |
    | Existing graph + unchanged commit hash | Ask the user: "The graph is up to date at this commit. Would you like to: **(a)** run a full rebuild (`--full`), **(b)** run the LLM graph reviewer (`--review`), or **(c)** do nothing?" Then follow their choice. If they pick (c), STOP. |
    | Existing graph + changed files | Run deterministic incremental preparation below |

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -168,7 +168,7 @@ Determine whether to run a full analysis or incremental update.
     - Split on commas, trim whitespace from each pattern, and filter out empty entries.
     - Store the patterns as `$EXCLUDE_PATTERNS` (comma-joined for passing to downstream scripts: `"tests/*,docs/*"`).
     - These patterns take highest priority — they are applied on top of default patterns and `.understandignore` rules. Use `!` prefix to force-include files that would otherwise be excluded.
-    - **Note:** Newly added `--exclude` patterns require a `--full` scan to take effect.
+    - Incremental preparation re-scans the current inventory, so newly supplied exclusions take effect immediately and remove any previously analyzed files they now cover.
 
 4. **Check for subdomain knowledge graphs to merge:**
    List all `*knowledge-graph*.json` files in `$UA_DIR/` **excluding** `knowledge-graph.json` itself (e.g. `frontend-knowledge-graph.json`, `backend-knowledge-graph.json`). If any subdomain graphs exist, run the merge script bundled with this skill (located next to this SKILL.md file — use the skill directory path, not the project root):
@@ -178,7 +178,7 @@ Determine whether to run a full analysis or incremental update.
    The script discovers subdomain graphs, loads the existing `knowledge-graph.json` as a base (if present), and merges everything into `knowledge-graph.json` (deduplicating nodes and edges). Report the merge summary to the user, then continue with the merged graph.
 
 5. Check if `$UA_DIR/knowledge-graph.json` exists. If it does, read it.
-6. Check if `$UA_DIR/meta.json` exists. If it does, read it to get `gitCommitHash`.
+6. Check if `$UA_DIR/meta.json` exists. If it does, read its `gitCommitHash` and store it as `$LAST_COMMIT_HASH`.
 7. **Decision logic:**
 
    | Condition | Action |
@@ -187,15 +187,41 @@ Determine whether to run a full analysis or incremental update.
    | No existing graph or meta | Full analysis (all phases) |
    | `--review` flag + existing graph + unchanged commit hash | Skip to Phase 6 (review-only — reuse existing assembled graph) |
    | Existing graph + unchanged commit hash | Ask the user: "The graph is up to date at this commit. Would you like to: **(a)** run a full rebuild (`--full`), **(b)** run the LLM graph reviewer (`--review`), or **(c)** do nothing?" Then follow their choice. If they pick (c), STOP. |
-   | Existing graph + changed files | Incremental update (re-analyze changed files only) |
+   | Existing graph + changed files | Run deterministic incremental preparation below |
 
    **Review-only path:** Copy the existing `knowledge-graph.json` to `$UA_DIR/intermediate/assembled-graph.json`, then jump directly to Phase 6 step 3.
 
-   For incremental updates, get the changed file list:
+   For incremental updates, do **not** construct the changed-file list by hand. Run the bundled reconciliation helper with the previous analyzed commit. Pass `--exclude "$EXCLUDE_PATTERNS"` only when the option is non-empty:
    ```bash
-   git diff <lastCommitHash>..HEAD --name-only
+   node "<SKILL_DIR>/prepare-incremental.mjs" \
+     "$PROJECT_ROOT" \
+     "$LAST_COMMIT_HASH"
    ```
-   If this returns no files, report "Graph is up to date" and STOP.
+
+   With explicit exclusions:
+   ```bash
+   node "<SKILL_DIR>/prepare-incremental.mjs" \
+     "$PROJECT_ROOT" \
+     "$LAST_COMMIT_HASH" \
+     --exclude "$EXCLUDE_PATTERNS"
+   ```
+
+   The helper uses parameterized `git diff --name-status -z`, performs a fresh deterministic scan with the current `.understandignore` / `--exclude` rules, compares structural fingerprints, selectively refreshes imports, and atomically writes:
+   - `$UA_DIR/intermediate/incremental-plan.json`
+   - `$UA_DIR/intermediate/scan-result.json`
+   - `$UA_DIR/intermediate/changed-files.txt`
+   - `$UA_DIR/intermediate/batch-existing.json` for partial/architecture updates
+
+   Read `incremental-plan.json` and store its `action`, `filesToReanalyze`, `deletedFiles`, `rerunArchitecture`, and `rerunTour` values. Follow this gate:
+
+   | Prepared action | Next step |
+   |---|---|
+   | `SKIP` | Run `node "<SKILL_DIR>/finalize-incremental.mjs" "$PROJECT_ROOT"`. It updates scan/fingerprints/meta for cosmetic or irrelevant changes, but intentionally advances nothing for generated-artifact-only commits. Report zero LLM tokens spent and **STOP**. |
+   | `PARTIAL_UPDATE` | Skip Phase 0.5 and Phase 1; continue with the incremental Phase 1.5/2 path. |
+   | `ARCHITECTURE_UPDATE` | Skip Phase 0.5 and Phase 1; continue with incremental analysis, then rerun Phase 4 and Phase 5. |
+   | `FULL_UPDATE` | Switch to the existing full pipeline beginning at Phase 0.5. Do not patch fingerprints or metadata from the incremental helper. |
+
+   `filesToReanalyze` contains only current, non-ignored files with structural changes. Deletions, newly ignored files, cosmetic changes, and generated artifacts are never passed to file-analyzer.
 
 8. **Collect project context for subagent injection:**
    - Read `README.md` (or `README.rst`, `readme.md`) from `$PROJECT_ROOT` if it exists. Store as `$README_CONTENT` (first 3000 characters).
@@ -209,9 +235,9 @@ Determine whether to run a full analysis or incremental update.
 
 ---
 
-## Phase 0.5 — Ignore Configuration
+## Phase 0.5 — Ignore Configuration (full analysis only)
 
-Set up and verify the `.understandignore` file before scanning.
+Set up and verify the `.understandignore` file before a full scan. Incremental preparation already applies the current ignore rules and must skip this confirmation phase.
 
 1. Check if `$UA_DIR/.understandignore` exists.
 2. **If it does NOT exist**, generate a starter file by invoking the bundled script (delegates to `generateStarterIgnoreFile` in `@understand-anything/core`, which reads `.gitignore`, deduplicates against built-in defaults, and emits language-grouped test-file suggestions). Pass `$PLUGIN_ROOT` via the env so the script doesn't have to re-derive it from its own path (which breaks for copied skill installs):
@@ -279,12 +305,22 @@ If the scan result includes `filteredByIgnore > 0`, report:
 
 Report: `[Phase 1.5/7] Computing semantic batches...`
 
-Run the bundled batching script:
+For a full analysis, run the bundled batching script:
 ```bash
 node "<SKILL_DIR>/compute-batches.mjs" "$PROJECT_ROOT"
 ```
 
-Reads `$UA_DIR/intermediate/scan-result.json`, writes `$UA_DIR/intermediate/batches.json`.
+For `PARTIAL_UPDATE` or `ARCHITECTURE_UPDATE`, inspect `filesToReanalyze` from the prepared plan:
+
+- If it is empty, skip batching and file-analyzer entirely. `batch-existing.json` already contains the deletion/ignore cleanup baseline; continue to the merge step in Phase 2. This is the zero-token deletion path.
+- Otherwise run batching against the helper-produced file, which contains only structurally changed current files:
+
+  ```bash
+  node "<SKILL_DIR>/compute-batches.mjs" "$PROJECT_ROOT" \
+    --changed-files="$UA_DIR/intermediate/changed-files.txt"
+  ```
+
+Both forms read the freshly reconciled `$UA_DIR/intermediate/scan-result.json` and write `$UA_DIR/intermediate/batches.json`.
 
 Capture stderr. Append any line starting with `Warning:` to `$PHASE_WARNINGS` for the final report.
 
@@ -360,33 +396,23 @@ Include the script's warnings in `$PHASE_WARNINGS` for the reviewer.
 
 ### Incremental update path
 
-Write the changed-files list (one path per line) to a temp file:
-```bash
-git diff "<lastCommitHash>..HEAD" --name-only > "$UA_DIR/tmp/changed-files.txt"
-```
+`prepare-incremental.mjs` has already refreshed the complete file inventory and `importMap`, written the exact analyzer list, and pruned changed/deleted paths from the old graph into `batch-existing.json`.
 
-Run compute-batches with `--changed-files`:
-```bash
-node "<SKILL_DIR>/compute-batches.mjs" "$PROJECT_ROOT" \
-  --changed-files="$UA_DIR/tmp/changed-files.txt"
-```
+1. If `filesToReanalyze` is non-empty, dispatch file-analyzer only for the batches from the incremental `batches.json`, using the same prompt template as the full path. Never add `deletedFiles`, `cosmeticFiles`, `ignoredFiles`, or `generatedArtifactFiles` to a prompt.
+2. If `filesToReanalyze` is empty, dispatch no agent and create no new batch file.
+3. Run the merge script in both cases:
 
-This produces a `batches.json` that contains only batches with changed files, but neighborMap entries still reference unchanged files (with their full-graph batchIndex) so cross-batch edges remain emittable.
-
-Then dispatch file-analyzer subagents per the same template as the full path.
-
-After batches complete:
-1. Remove old nodes whose `filePath` matches any changed file from the existing graph
-2. Remove old edges whose `source` or `target` references a removed node
-3. Write the pruned existing nodes/edges as `batch-existing.json` in the intermediate directory
-4. Run the same merge script — it will combine `batch-existing.json` with the fresh `batch-*.json` files:
    ```bash
    python "<SKILL_DIR>/merge-batch-graphs.py" "$PROJECT_ROOT"
    ```
 
+The merge combines `batch-existing.json` with any fresh batch output. Its import recovery reads the already-refreshed `scan-result.json`, so added and removed imports are reflected during this same run. Verify `assembled-graph.json` exists before continuing.
+
 ---
 
 ## Phase 3 — ASSEMBLE REVIEW
+
+Run this phase for **full analysis only**. Both incremental actions skip assemble-reviewer: their deterministic merge/reconciliation checks replace this whole-graph LLM pass. The user-facing `--review` option is still honored later by the graph-reviewer in Phase 6.
 
 Report to the user: `[Phase 3/7] Reviewing assembled graph...`
 
@@ -414,6 +440,8 @@ After the subagent completes, read `$UA_DIR/intermediate/assemble-review.json` a
 ---
 
 ## Phase 4 — ARCHITECTURE
+
+Run this phase for full analysis and for incremental plans where `rerunArchitecture === true`. For `PARTIAL_UPDATE`, dispatch no architecture agent; `finalize-incremental.mjs` preserves surviving assignments, removes dangling/empty layers, and assigns new nodes deterministically by deepest common parent directory, then graph connectivity, then previous layer order.
 
 Report to the user: `[Phase 4/7] Identifying architectural layers...`
 
@@ -483,7 +511,7 @@ Each element of the final `layers` array MUST have this shape:
 
 All four fields (`id`, `name`, `description`, `nodeIds`) are required.
 
-**For incremental updates:** Always re-run architecture analysis on the full merged node set, since layer assignments may shift when files change.
+**For architecture incremental updates:** Re-run architecture analysis on the full merged node set. Ordinary partial updates use the deterministic placement described at the start of this phase.
 
 **Context for incremental updates:** When re-running architecture analysis, also inject the previous layer definitions:
 
@@ -497,6 +525,8 @@ All four fields (`id`, `name`, `description`, `nodeIds`) are required.
 ---
 
 ## Phase 5 — TOUR
+
+Run this phase for full analysis and for incremental plans where `rerunTour === true`. For `PARTIAL_UPDATE`, dispatch no tour agent and do not rewrite the narrative; finalization only removes dangling node IDs from the existing steps.
 
 Report to the user: `[Phase 5/7] Building guided tour...`
 
@@ -567,11 +597,26 @@ Each element of the final `tour` array MUST have this shape:
 
 Required fields: `order`, `title`, `description`, `nodeIds`. Preserve optional `languageLesson` when present.
 
+### Incremental deterministic save gate
+
+After the applicable Phase 4/5 work is complete, finalize either incremental action:
+
+```bash
+node "<SKILL_DIR>/finalize-incremental.mjs" "$PROJECT_ROOT"
+```
+
+This helper validates/deduplicates nodes and edges, reconciles layers/tour, atomically saves the graph, patches only changed fingerprints while preserving all others, removes deleted fingerprints, and only then advances `meta.json`.
+
+- Without `--review`, report the incremental summary and **STOP**. Do not run Phase 6 or the full-save Phase 7; this is what prevents the ordinary local update from paying for whole-graph review.
+- With `--review`, copy the newly saved `$UA_DIR/knowledge-graph.json` to `$UA_DIR/intermediate/assembled-graph.json`, then continue to the full graph-reviewer path in Phase 6. Do not run the inline default reviewer.
+
 ---
 
 ## Phase 6 — REVIEW
 
 Report to the user: `[Phase 6/7] Validating knowledge graph...`
+
+For incremental `--review`, the save gate already copied a complete KnowledgeGraph to `assembled-graph.json`. Do not reconstruct it from node/edge-only merge output; skip directly to the `--review` graph-reviewer path below. The default inline path is for full analysis only.
 
 Assemble the full KnowledgeGraph JSON object:
 
@@ -747,7 +792,7 @@ Report to the user: `[Phase 7/7] Saving knowledge graph...`
    const outputPath = process.argv[3];
    const input = {
      projectRoot,
-     sourceFilePaths: [<all source file paths from Phase 1, as JSON array>],
+     filePaths: [<all analyzed file paths from Phase 1, including non-code files, as JSON array>],
      gitCommitHash: "<current commit hash>",
    };
    fs.writeFileSync(outputPath, JSON.stringify(input, null, 2));
@@ -760,7 +805,7 @@ Report to the user: `[Phase 7/7] Saving knowledge graph...`
      "$UA_DIR/intermediate/fingerprint-input.json"
    ```
 
-   The script uses `TreeSitterPlugin + PluginRegistry` exactly like `extract-structure.mjs`, so the baseline matches the comparison logic used during auto-updates.
+   The script uses `TreeSitterPlugin + PluginRegistry` exactly like `extract-structure.mjs`, so the baseline matches incremental comparison. The baseline MUST include every file in `scan-result.json`, not only source-code files; unsupported formats receive conservative content-only fingerprints.
 
    **If the script exits non-zero or stdout does not include `Fingerprints baseline:`, abort Phase 7 and report the error. Do NOT proceed to step 3 (writing `meta.json`).**
 

--- a/understand-anything-plugin/skills/understand/SKILL.md
+++ b/understand-anything-plugin/skills/understand/SKILL.md
@@ -217,7 +217,7 @@ Determine whether to run a full analysis or incremental update.
 
    | Prepared action | Next step |
    |---|---|
-   | `SKIP` | Run `node "<SKILL_DIR>/finalize-incremental.mjs" "$PROJECT_ROOT"`. It updates scan/fingerprints/meta for cosmetic or irrelevant changes, but intentionally advances nothing for generated-artifact-only commits. Report zero LLM tokens spent and **STOP**. |
+   | `SKIP` | Run `node "<SKILL_DIR>/finalize-incremental.mjs" "$PROJECT_ROOT"`. It updates graph metadata, scan, fingerprints, and meta for cosmetic or irrelevant changes, but intentionally advances nothing for generated-artifact-only commits. Without `--review`, report zero LLM tokens spent and **STOP**. With explicit `--review`, copy `$UA_DIR/knowledge-graph.json` to `$UA_DIR/intermediate/assembled-graph.json` and jump to the `--review` graph-reviewer path in Phase 6 instead of stopping. |
    | `PARTIAL_UPDATE` | Skip Phase 0.5 and Phase 1; continue with the incremental Phase 1.5/2 path. |
    | `ARCHITECTURE_UPDATE` | Skip Phase 0.5 and Phase 1; continue with incremental analysis, then rerun Phase 4 and Phase 5. |
    | `FULL_UPDATE` | Switch to the existing full pipeline beginning at Phase 0.5. Do not patch fingerprints or metadata from the incremental helper. |

--- a/understand-anything-plugin/skills/understand/build-fingerprints.mjs
+++ b/understand-anything-plugin/skills/understand/build-fingerprints.mjs
@@ -89,7 +89,10 @@ async function main() {
   registry.register(tsPlugin);
   registerAllParsers(registry);
 
-  const store = buildFingerprintStore(projectRoot, filePaths, registry, gitCommitHash);
+  const structuralFingerprintLanguages = new Set(tsConfigs.map(config => config.id));
+  const store = buildFingerprintStore(projectRoot, filePaths, registry, gitCommitHash, {
+    structuralFingerprintLanguages,
+  });
   saveFingerprints(projectRoot, store);
 
   const fileCount = Object.keys(store.files).length;

--- a/understand-anything-plugin/skills/understand/build-fingerprints.mjs
+++ b/understand-anything-plugin/skills/understand/build-fingerprints.mjs
@@ -17,7 +17,11 @@
  *   node build-fingerprints.mjs <input.json>
  *
  * Input JSON:
- *   { projectRoot: string, sourceFilePaths: string[], gitCommitHash: string }
+ *   { projectRoot: string, filePaths: string[], gitCommitHash: string }
+ *
+ * `sourceFilePaths` remains accepted as a backwards-compatible alias. Full
+ * baselines should pass every analyzed path; unsupported formats receive a
+ * conservative content-only fingerprint from buildFingerprintStore().
  *
  * Writes: <projectRoot>/.ua/fingerprints.json (or legacy
  *   <projectRoot>/.understand-anything/fingerprints.json when that dir exists)
@@ -62,13 +66,15 @@ async function main() {
     process.exit(1);
   }
 
-  const { projectRoot, sourceFilePaths, gitCommitHash } = JSON.parse(
+  const input = JSON.parse(
     readFileSync(inputPath, 'utf-8'),
   );
+  const { projectRoot, gitCommitHash } = input;
+  const filePaths = input.filePaths ?? input.sourceFilePaths;
 
-  if (!projectRoot || !Array.isArray(sourceFilePaths) || typeof gitCommitHash !== 'string') {
+  if (!projectRoot || !Array.isArray(filePaths) || typeof gitCommitHash !== 'string') {
     throw new Error(
-      'Invalid input: requires { projectRoot: string, sourceFilePaths: string[], gitCommitHash: string }',
+      'Invalid input: requires { projectRoot: string, filePaths: string[], gitCommitHash: string }',
     );
   }
 
@@ -83,7 +89,7 @@ async function main() {
   registry.register(tsPlugin);
   registerAllParsers(registry);
 
-  const store = buildFingerprintStore(projectRoot, sourceFilePaths, registry, gitCommitHash);
+  const store = buildFingerprintStore(projectRoot, filePaths, registry, gitCommitHash);
   saveFingerprints(projectRoot, store);
 
   const fileCount = Object.keys(store.files).length;

--- a/understand-anything-plugin/skills/understand/compute-batches.mjs
+++ b/understand-anything-plugin/skills/understand/compute-batches.mjs
@@ -256,11 +256,24 @@ function buildBatchOfMap(allBatches) {
 }
 
 function normalizeRelativePathForMatch(pathText) {
-  return pathText
-    .trim()
-    .replace(/\\/g, '/')
+  if (typeof pathText !== 'string') return '';
+  const platformPath = process.platform === 'win32' ? pathText.replace(/\\/g, '/') : pathText;
+  return platformPath
     .replace(/^\.\/+/, '')
     .replace(/\/+/g, '/');
+}
+
+function parseChangedFileList(content, filePath) {
+  if (filePath.toLowerCase().endsWith('.json') || content.trimStart().startsWith('[')) {
+    const parsed = JSON.parse(content);
+    if (!Array.isArray(parsed) || parsed.some(path => typeof path !== 'string')) {
+      throw new Error('JSON changed-file list must be an array of strings');
+    }
+    return parsed.map(normalizeRelativePathForMatch).filter(Boolean);
+  }
+  // Backwards compatibility for existing newline-delimited callers. New
+  // incremental handoffs use JSON so embedded newlines remain unambiguous.
+  return content.split(/\r?\n/).map(normalizeRelativePathForMatch).filter(Boolean);
 }
 
 // ECMAScript string comparison uses a stable UTF-16 code-unit order and does
@@ -417,11 +430,15 @@ async function main() {
       );
       process.exit(1);
     }
-    const lines = content
-      .split('\n')
-      .map(normalizeRelativePathForMatch)
-      .filter(Boolean);
-    changedFiles = new Set(lines);
+    try {
+      changedFiles = new Set(parseChangedFileList(content, changedFilesPath));
+    } catch (err) {
+      process.stderr.write(
+        `Error: compute-batches: --changed-files contents invalid: ${changedFilesPath} ` +
+        `(${err.message})\n`,
+      );
+      process.exit(1);
+    }
   }
 
   const scanResultValue = helperOptions.get('scan-result');

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -40,7 +40,7 @@
  */
 
 import { createRequire } from 'node:module';
-import { dirname, resolve, join, posix } from 'node:path';
+import { dirname, resolve, join, posix, isAbsolute } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
@@ -128,7 +128,10 @@ function selectAnalysisFiles(files, analysisPaths) {
     if (typeof rawPath !== 'string' || rawPath.length === 0) {
       throw new Error('Invalid input: every analysisPaths entry must be a non-empty string');
     }
-    if (/^(?:[A-Za-z]:[\\/]|[\\/])/.test(rawPath)) {
+    // Use the host's path semantics here. On POSIX, backslashes and drive-like
+    // prefixes are ordinary project-relative filename characters; on Windows,
+    // path.isAbsolute also rejects drive-rooted and root-relative paths.
+    if (isAbsolute(rawPath)) {
       throw new Error(`Invalid input: analysisPaths entry must be project-relative: ${rawPath}`);
     }
     const path = toPosix(rawPath);

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -18,8 +18,14 @@
  * Input JSON:
  *   {
  *     projectRoot: <abs-path>,
- *     files: [{ path, language, fileCategory }, ...]
+ *     files: [{ path, language, fileCategory }, ...],
+ *     analysisPaths?: [<project-relative-path>, ...]
  *   }
+ *
+ * `files` is always the complete current inventory because import resolution
+ * needs it for path/module probes. When `analysisPaths` is present, only those
+ * files are read and emitted in `importMap`; omitting it preserves the original
+ * full-scan behaviour.
  *
  * Output JSON:
  *   {
@@ -94,6 +100,50 @@ const { TreeSitterPlugin, PluginRegistry, builtinLanguageConfigs, registerAllPar
  */
 function toPosix(p) {
   return p.split(/[\\/]/).filter(Boolean).join('/');
+}
+
+/**
+ * Validate and normalize the optional selective-analysis path list. Keeping
+ * this strict prevents an incremental caller from accidentally asking the
+ * extractor to read outside projectRoot or silently miss a typo.
+ */
+function selectAnalysisFiles(files, analysisPaths) {
+  if (analysisPaths === undefined) return files;
+  if (!Array.isArray(analysisPaths)) {
+    throw new Error('Invalid input: analysisPaths must be an array when provided');
+  }
+
+  const filesByPath = new Map();
+  for (const file of files) {
+    if (!file || typeof file.path !== 'string' || file.path.length === 0) {
+      throw new Error('Invalid input: every files entry must contain a non-empty path');
+    }
+    filesByPath.set(toPosix(file.path), file);
+  }
+
+  const selected = [];
+  const seen = new Set();
+  for (const rawPath of analysisPaths) {
+    if (typeof rawPath !== 'string' || rawPath.length === 0) {
+      throw new Error('Invalid input: every analysisPaths entry must be a non-empty string');
+    }
+    if (/^(?:[A-Za-z]:[\\/]|[\\/])/.test(rawPath)) {
+      throw new Error(`Invalid input: analysisPaths entry must be project-relative: ${rawPath}`);
+    }
+    const path = toPosix(rawPath);
+    if (!path || path.split('/').some(part => part === '..')) {
+      throw new Error(`Invalid input: analysisPaths entry escapes projectRoot: ${rawPath}`);
+    }
+    const file = filesByPath.get(path);
+    if (!file) {
+      throw new Error(`Invalid input: analysisPaths entry is not present in files: ${rawPath}`);
+    }
+    if (!seen.has(path)) {
+      seen.add(path);
+      selected.push(file);
+    }
+  }
+  return selected;
 }
 
 // ECMAScript relational string comparison is lexicographic over UTF-16 code
@@ -1806,10 +1856,25 @@ async function main() {
 
   const inputRaw = readFileSync(inputPath, 'utf-8');
   const input = JSON.parse(inputRaw);
-  const { projectRoot, files } = input;
+  const { projectRoot, files, analysisPaths } = input;
 
   if (!projectRoot || !Array.isArray(files)) {
     throw new Error('Invalid input: must contain projectRoot and files array');
+  }
+
+  const analysisFiles = selectAnalysisFiles(files, analysisPaths);
+
+  if (analysisFiles.length === 0) {
+    const output = {
+      scriptCompleted: true,
+      stats: { filesScanned: 0, filesWithImports: 0, totalEdges: 0 },
+      importMap: {},
+    };
+    writeFileSync(outputPath, JSON.stringify(output, null, 2), 'utf-8');
+    process.stderr.write(
+      'extract-import-map: filesScanned=0 filesWithImports=0 totalEdges=0\n',
+    );
+    return;
   }
 
   // Create tree-sitter plugin with all configs that have WASM grammars.
@@ -1848,7 +1913,7 @@ async function main() {
   let filesWithImports = 0;
   let totalEdges = 0;
 
-  for (const file of files) {
+  for (const file of analysisFiles) {
     const path = toPosix(file.path);
 
     // Non-code files always get an empty array
@@ -1941,7 +2006,7 @@ async function main() {
   const output = {
     scriptCompleted: true,
     stats: {
-      filesScanned: files.length,
+      filesScanned: analysisFiles.length,
       filesWithImports,
       totalEdges,
     },
@@ -1955,7 +2020,7 @@ async function main() {
   }
 
   process.stderr.write(
-    `extract-import-map: filesScanned=${files.length} ` +
+    `extract-import-map: filesScanned=${analysisFiles.length} ` +
     `filesWithImports=${filesWithImports} totalEdges=${totalEdges}\n`,
   );
 }

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -263,6 +263,7 @@ function parseTsConfigText(raw) {
 async function loadTsConfigs(projectRoot, files) {
   const out = new Map();
   const warnings = [];
+  const failures = [];
   // Collect the candidate paths in the original file order before reading,
   // so warning emit order matches the previous sequential implementation.
   const candidates = [];
@@ -277,6 +278,7 @@ async function loadTsConfigs(projectRoot, files) {
   const reads = await readFilesParallel(candidates);
   for (const { key: p, raw, err } of reads) {
     if (err) {
+      failures.push({ path: p, stage: 'resolver-config-read', message: err.message });
       // absPath isn't carried through the helper return shape; reconstruct it.
       warnings.push(
         `Warning: extract-import-map: tsconfig.json at ${join(projectRoot, p)} failed ` +
@@ -287,6 +289,11 @@ async function loadTsConfigs(projectRoot, files) {
     }
     const parsed = parseTsConfigText(raw);
     if (!parsed) {
+      failures.push({
+        path: p,
+        stage: 'resolver-config-parse',
+        message: 'invalid tsconfig.json',
+      });
       warnings.push(
         `Warning: extract-import-map: tsconfig.json at ${join(projectRoot, p)} failed ` +
         `to parse — path aliases from this config will not be applied ` +
@@ -296,7 +303,7 @@ async function loadTsConfigs(projectRoot, files) {
     }
     out.set(dirOf(p), parsed);
   }
-  return { configs: out, warnings };
+  return { configs: out, warnings, failures };
 }
 
 /**
@@ -331,6 +338,7 @@ async function loadGoModules(projectRoot, files) {
   // so the concurrent caller in buildResolutionContext can drain them
   // uniformly in canonical order.
   const warnings = [];
+  const failures = [];
   const candidates = [];
   for (const f of files) {
     const p = toPosix(f.path);
@@ -342,7 +350,14 @@ async function loadGoModules(projectRoot, files) {
   }
   const reads = await readFilesParallel(candidates);
   for (const { key: p, raw, err } of reads) {
-    if (err) continue;
+    if (err) {
+      failures.push({ path: p, stage: 'resolver-config-read', message: err.message });
+      warnings.push(
+        `Warning: extract-import-map: go.mod at ${join(projectRoot, p)} failed ` +
+        `to read (${err.message}) — Go module imports may not resolve\n`,
+      );
+      continue;
+    }
     let moduleName = '';
     for (const line of raw.split(/\r?\n/)) {
       const trimmed = line.replace(/\/\/.*$/, '').trim();
@@ -350,10 +365,21 @@ async function loadGoModules(projectRoot, files) {
       moduleName = trimmed.slice('module '.length).trim();
       break;
     }
-    if (!moduleName) continue;
+    if (!moduleName) {
+      failures.push({
+        path: p,
+        stage: 'resolver-config-parse',
+        message: 'module directive missing',
+      });
+      warnings.push(
+        `Warning: extract-import-map: go.mod at ${join(projectRoot, p)} has no ` +
+        `module directive — Go module imports may not resolve\n`,
+      );
+      continue;
+    }
     out.set(dirOf(p), moduleName);
   }
-  return { modules: out, warnings };
+  return { modules: out, warnings, failures };
 }
 
 /**
@@ -425,6 +451,7 @@ function parseSwiftPackageTargets(raw) {
 async function loadSwiftPackageTargets(projectRoot, files) {
   const targets = new Map();
   const warnings = [];
+  const failures = [];
   const candidates = [];
 
   for (const f of files) {
@@ -438,7 +465,14 @@ async function loadSwiftPackageTargets(projectRoot, files) {
 
   const reads = await readFilesParallel(candidates);
   for (const { key: p, raw, err } of reads) {
-    if (err) continue;
+    if (err) {
+      failures.push({ path: p, stage: 'resolver-config-read', message: err.message });
+      warnings.push(
+        `Warning: extract-import-map: Package.swift at ${join(projectRoot, p)} failed ` +
+        `to read (${err.message}) — Swift module imports may not resolve\n`,
+      );
+      continue;
+    }
     const packageDir = dirOf(p);
     for (const target of parseSwiftPackageTargets(raw)) {
       const targetPath = resolveRelative(packageDir, target.path.replace(/\\/g, '/'));
@@ -448,7 +482,7 @@ async function loadSwiftPackageTargets(projectRoot, files) {
     }
   }
 
-  return { targets, warnings };
+  return { targets, warnings, failures };
 }
 
 /**
@@ -558,6 +592,12 @@ async function buildResolutionContext(projectRoot, files) {
     scalaPackageIndex,
     csIndex,
     swiftModuleIndex,
+    failures: [
+      ...tsResult.failures,
+      ...goResult.failures,
+      ...phpResult.failures,
+      ...swiftResult.failures,
+    ],
     phpAutoloads,
     // Dedupe Sets for one-time-per-file warnings. Keyed by importer file
     // path. Mutated by resolvers.
@@ -1490,6 +1530,7 @@ function parseComposerAutoloadText(raw) {
 async function loadPhpAutoloads(projectRoot, files) {
   const out = new Map();
   const warnings = [];
+  const failures = [];
   const candidates = [];
   for (const f of files) {
     const p = toPosix(f.path);
@@ -1502,6 +1543,7 @@ async function loadPhpAutoloads(projectRoot, files) {
   const reads = await readFilesParallel(candidates);
   for (const { key: p, raw, err } of reads) {
     if (err) {
+      failures.push({ path: p, stage: 'resolver-config-read', message: err.message });
       warnings.push(
         `Warning: extract-import-map: composer.json at ${join(projectRoot, p)} failed ` +
         `to read (${err.message}) — PSR-4 namespace mapping from this ` +
@@ -1512,6 +1554,11 @@ async function loadPhpAutoloads(projectRoot, files) {
     }
     const parsed = parseComposerAutoloadText(raw);
     if (parsed === null) {
+      failures.push({
+        path: p,
+        stage: 'resolver-config-parse',
+        message: 'invalid composer.json',
+      });
       warnings.push(
         `Warning: extract-import-map: composer.json at ${join(projectRoot, p)} failed ` +
         `to parse — PSR-4 namespace mapping unavailable — PHP imports ` +
@@ -1521,7 +1568,7 @@ async function loadPhpAutoloads(projectRoot, files) {
     }
     out.set(dirOf(p), parsed);
   }
-  return { autoloads: out, warnings };
+  return { autoloads: out, warnings, failures };
 }
 
 /**
@@ -1868,6 +1915,7 @@ async function main() {
     const output = {
       scriptCompleted: true,
       stats: { filesScanned: 0, filesWithImports: 0, totalEdges: 0 },
+      failures: [],
       importMap: {},
     };
     writeFileSync(outputPath, JSON.stringify(output, null, 2), 'utf-8');
@@ -1888,6 +1936,7 @@ async function main() {
   // (file inventory, exports inferred from filenames, etc.) keeps working.
   let registry = null;
   let treeSitterReady = false;
+  const failures = [];
   try {
     const tsConfigs = builtinLanguageConfigs.filter(c => c.treeSitter);
     const tsPlugin = new TreeSitterPlugin(tsConfigs);
@@ -1897,6 +1946,7 @@ async function main() {
     registerAllParsers(registry);
     treeSitterReady = true;
   } catch (err) {
+    failures.push({ path: null, stage: 'tree-sitter-init', message: err.message });
     process.stderr.write(
       `Warning: extract-import-map: tree-sitter init failed ` +
       `(${err.message}) — all importMap entries will be empty — ` +
@@ -1908,6 +1958,7 @@ async function main() {
   // tsconfig/go.mod/composer.json files inside is parallelised — see
   // `buildResolutionContext`.
   const ctx = await buildResolutionContext(projectRoot, files);
+  failures.push(...ctx.failures);
 
   const importMap = {};
   let filesWithImports = 0;
@@ -1937,6 +1988,7 @@ async function main() {
     try {
       content = readFileSync(absolutePath, 'utf-8');
     } catch (err) {
+      failures.push({ path, stage: 'file-read', message: err.message });
       process.stderr.write(
         `Warning: extract-import-map: import resolution failed for ${path} ` +
         `(read error: ${err.message}) — importMap[${path}]=[]\n`,
@@ -1988,6 +2040,7 @@ async function main() {
           : comparePaths(a, b),
       );
     } catch (err) {
+      failures.push({ path, stage: 'file-analyze', message: err.message });
       process.stderr.write(
         `Warning: extract-import-map: import resolution failed for ${path} ` +
         `(analyze error: ${err.message}) — importMap[${path}]=[]\n`,
@@ -2010,6 +2063,7 @@ async function main() {
       filesWithImports,
       totalEdges,
     },
+    failures,
     importMap,
   };
 

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -204,16 +204,74 @@ function dirOf(p) {
  * with the exact tsconfig path that failed; bubbling the error would
  * conceal which file was at fault when many tsconfigs are loaded.
  */
+function normalizeJsonc(raw) {
+  let withoutComments = '';
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    const next = raw[i + 1];
+    if (inString) {
+      withoutComments += ch;
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      withoutComments += ch;
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      while (i < raw.length && raw[i] !== '\n') i++;
+      if (i < raw.length) withoutComments += '\n';
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      i += 2;
+      while (i < raw.length && !(raw[i] === '*' && raw[i + 1] === '/')) {
+        if (raw[i] === '\n') withoutComments += '\n';
+        i++;
+      }
+      i++;
+      continue;
+    }
+    withoutComments += ch;
+  }
+
+  let normalized = '';
+  inString = false;
+  escaped = false;
+  for (let i = 0; i < withoutComments.length; i++) {
+    const ch = withoutComments[i];
+    if (inString) {
+      normalized += ch;
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      normalized += ch;
+      continue;
+    }
+    if (ch === ',') {
+      let nextIndex = i + 1;
+      while (/\s/.test(withoutComments[nextIndex] ?? '')) nextIndex++;
+      if (withoutComments[nextIndex] === '}' || withoutComments[nextIndex] === ']') continue;
+    }
+    normalized += ch;
+  }
+  return normalized.replace(/^\uFEFF/, '');
+}
+
 function parseTsConfigText(raw) {
-  // tsconfig.json often contains JSONC-style comments; strip line and block
-  // comments before parsing. The strip is naive (it doesn't honor string
-  // contents), so we fall back to the raw text on failure.
-  const stripped = raw
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+  const normalized = normalizeJsonc(raw);
   let parsed;
   try {
-    parsed = JSON.parse(stripped);
+    parsed = JSON.parse(normalized);
   } catch {
     try {
       parsed = JSON.parse(raw);

--- a/understand-anything-plugin/skills/understand/extract-import-map.mjs
+++ b/understand-anything-plugin/skills/understand/extract-import-map.mjs
@@ -99,7 +99,8 @@ const { TreeSitterPlugin, PluginRegistry, builtinLanguageConfigs, registerAllPar
  * cross-platform.
  */
 function toPosix(p) {
-  return p.split(/[\\/]/).filter(Boolean).join('/');
+  const separators = process.platform === 'win32' ? /[\\/]/ : /\//;
+  return p.split(separators).filter(Boolean).join('/');
 }
 
 /**

--- a/understand-anything-plugin/skills/understand/finalize-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/finalize-incremental.mjs
@@ -348,6 +348,13 @@ function main() {
     const assembled = normalizeAssembled(assembledRaw);
     const nodeIds = new Set(assembled.nodes.map(node => node.id));
     const pathIndex = buildPathIndex(assembled.nodes);
+    const missingAnalyzedPaths = plan.filesToReanalyze.filter(path => !pathIndex.has(path));
+    if (missingAnalyzedPaths.length > 0) {
+      throw new Error(
+        `Assembled graph is missing whole-file nodes for analyzed paths: ` +
+        `${missingAnalyzedPaths.join(', ')}; baseline not advanced`,
+      );
+    }
     if (plan.rerunArchitecture && !existsSync(join(intermediateDir, 'layers.json'))) {
       throw new Error('Architecture update requires layers.json; baseline not advanced');
     }

--- a/understand-anything-plugin/skills/understand/finalize-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/finalize-incremental.mjs
@@ -1,0 +1,408 @@
+#!/usr/bin/env node
+/**
+ * Finalize a prepared incremental update without another LLM pass.
+ *
+ * Usage: node finalize-incremental.mjs <projectRoot>
+ *
+ * For PARTIAL_UPDATE / ARCHITECTURE_UPDATE, reads assembled-graph.json plus
+ * either the previous or regenerated layers/tour, performs deterministic
+ * dangling-reference cleanup and local layer placement, then atomically saves
+ * knowledge-graph.json. Only after that succeeds does it patch fingerprints
+ * and advance meta.json. SKIP applies the fingerprint/meta patch only; a
+ * generated-artifact-only SKIP deliberately advances nothing.
+ */
+
+import { createRequire } from 'node:module';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  existsSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pluginRoot = resolve(__dirname, '../..');
+const require = createRequire(resolve(pluginRoot, 'package.json'));
+
+let core;
+try {
+  core = await import(pathToFileURL(require.resolve('@understand-anything/core')).href);
+} catch {
+  core = await import(pathToFileURL(resolve(pluginRoot, 'packages/core/dist/index.js')).href);
+}
+
+const { resolveUaDir } = core;
+const LAYER_NODE_TYPES = new Set([
+  'file',
+  'config',
+  'document',
+  'service',
+  'pipeline',
+  'table',
+  'schema',
+  'resource',
+  'endpoint',
+]);
+const WHOLE_FILE_TYPES = new Set([
+  'file',
+  'config',
+  'document',
+  'service',
+  'pipeline',
+  'schema',
+  'resource',
+]);
+
+function readJson(path, fallback = null) {
+  if (!existsSync(path)) return fallback;
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function atomicWriteJson(path, value) {
+  const tempPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+  renameSync(tempPath, path);
+  // Verify the durable target, not the temporary file.
+  JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function normalizeRelativePath(value) {
+  if (typeof value !== 'string' || !value || isAbsolute(value)) return null;
+  const path = value.replaceAll('\\', '/').replace(/^\.\//, '');
+  if (!path || path.split('/').some(part => part === '..')) return null;
+  return path;
+}
+
+function unwrap(value, key) {
+  return Array.isArray(value) ? value : Array.isArray(value?.[key]) ? value[key] : [];
+}
+
+function slug(value) {
+  const result = String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  return result || 'other';
+}
+
+function buildPathIndex(nodes) {
+  const index = new Map();
+  const selectedTypes = new Map();
+  for (const node of nodes) {
+    if (!WHOLE_FILE_TYPES.has(node.type)) continue;
+    const path = normalizeRelativePath(node.filePath);
+    if (!path || node.id !== `${node.type}:${path}`) continue;
+    if (!index.has(path) || (node.type === 'file' && selectedTypes.get(path) !== 'file')) {
+      index.set(path, node.id);
+      selectedTypes.set(path, node.type);
+    }
+  }
+  return index;
+}
+
+function resolveNodeRef(value, nodeIds, pathIndex) {
+  if (typeof value === 'object' && value) value = value.id;
+  if (typeof value !== 'string' || !value) return null;
+  if (nodeIds.has(value)) return value;
+  const path = normalizeRelativePath(value);
+  return path ? pathIndex.get(path) ?? null : null;
+}
+
+function normalizeLayerShape(rawLayers, nodeIds, pathIndex) {
+  return unwrap(rawLayers, 'layers').map((layer, index) => {
+    const refs = Array.isArray(layer?.nodeIds)
+      ? layer.nodeIds
+      : Array.isArray(layer?.nodes)
+        ? layer.nodes
+        : [];
+    const name = typeof layer?.name === 'string' && layer.name ? layer.name : 'Other';
+    return {
+      id: typeof layer?.id === 'string' && layer.id ? layer.id : `layer:${slug(name)}`,
+      name,
+      description:
+        typeof layer?.description === 'string'
+          ? layer.description
+          : index === 0
+            ? 'Project files'
+            : '',
+      nodeIds: refs
+        .map(ref => resolveNodeRef(ref, nodeIds, pathIndex))
+        .filter(Boolean),
+    };
+  });
+}
+
+function directorySegments(filePath) {
+  const parts = normalizeRelativePath(filePath)?.split('/') ?? [];
+  return parts.slice(0, -1);
+}
+
+function commonParentDepth(leftPath, rightPath) {
+  const left = directorySegments(leftPath);
+  const right = directorySegments(rightPath);
+  let depth = 0;
+  while (depth < left.length && depth < right.length && left[depth] === right[depth]) depth++;
+  return depth;
+}
+
+function assignLayers(rawLayers, nodes, edges) {
+  const nodeIds = new Set(nodes.map(node => node.id));
+  const pathIndex = buildPathIndex(nodes);
+  const layerable = nodes.filter(node => LAYER_NODE_TYPES.has(node.type));
+  const nodeById = new Map(nodes.map(node => [node.id, node]));
+  const layers = normalizeLayerShape(rawLayers, nodeIds, pathIndex);
+  const assigned = new Set();
+
+  for (const layer of layers) {
+    layer.nodeIds = layer.nodeIds.filter(id => {
+      if (assigned.has(id)) return false;
+      assigned.add(id);
+      return true;
+    });
+  }
+
+  const adjacency = new Map();
+  for (const edge of edges) {
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) continue;
+    if (!adjacency.has(edge.source)) adjacency.set(edge.source, new Set());
+    if (!adjacency.has(edge.target)) adjacency.set(edge.target, new Set());
+    adjacency.get(edge.source).add(edge.target);
+    adjacency.get(edge.target).add(edge.source);
+  }
+
+  const candidates = layers.filter(layer => layer.nodeIds.length > 0);
+  for (const node of layerable) {
+    if (assigned.has(node.id)) continue;
+    if (candidates.length === 0) {
+      const fallback = {
+        id: 'layer:other',
+        name: 'Other',
+        description: 'Files not assigned to another architectural layer',
+        nodeIds: [],
+      };
+      layers.push(fallback);
+      candidates.push(fallback);
+    }
+
+    let bestLayer = candidates[0];
+    let bestDepth = -1;
+    let bestConnections = -1;
+    for (const layer of candidates) {
+      let depth = 0;
+      for (const memberId of layer.nodeIds) {
+        const member = nodeById.get(memberId);
+        if (member?.filePath && node.filePath) {
+          depth = Math.max(depth, commonParentDepth(node.filePath, member.filePath));
+        }
+      }
+      const neighborIds = adjacency.get(node.id) ?? new Set();
+      const connections = layer.nodeIds.reduce(
+        (count, memberId) => count + (neighborIds.has(memberId) ? 1 : 0),
+        0,
+      );
+      // Strict comparisons preserve original layer order as the final tie-break.
+      if (depth > bestDepth || (depth === bestDepth && connections > bestConnections)) {
+        bestLayer = layer;
+        bestDepth = depth;
+        bestConnections = connections;
+      }
+    }
+    bestLayer.nodeIds.push(node.id);
+    assigned.add(node.id);
+  }
+
+  return layers.filter(layer => layer.nodeIds.length > 0);
+}
+
+function normalizeTour(rawTour, nodeIds, pathIndex) {
+  return unwrap(rawTour, 'steps')
+    .map((step, index) => {
+      const refs = Array.isArray(step?.nodeIds)
+        ? step.nodeIds
+        : Array.isArray(step?.nodesToInspect)
+          ? step.nodesToInspect
+          : [];
+      const normalized = {
+        order: Number.isFinite(step?.order) ? step.order : index + 1,
+        title: typeof step?.title === 'string' ? step.title : `Step ${index + 1}`,
+        description:
+          typeof step?.description === 'string'
+            ? step.description
+            : typeof step?.whyItMatters === 'string'
+              ? step.whyItMatters
+              : '',
+        nodeIds: [...new Set(
+          refs.map(ref => resolveNodeRef(ref, nodeIds, pathIndex)).filter(Boolean),
+        )],
+      };
+      if (typeof step?.languageLesson === 'string') {
+        normalized.languageLesson = step.languageLesson;
+      }
+      return normalized;
+    })
+    .sort((a, b) => a.order - b.order);
+}
+
+function normalizeAssembled(assembled) {
+  const nodesById = new Map();
+  for (const node of assembled?.nodes ?? []) {
+    if (node && typeof node.id === 'string' && node.id) nodesById.set(node.id, node);
+  }
+  const nodes = [...nodesById.values()];
+  const nodeIds = new Set(nodesById.keys());
+  const seenEdges = new Set();
+  const edges = [];
+  for (const edge of assembled?.edges ?? []) {
+    if (!nodeIds.has(edge?.source) || !nodeIds.has(edge?.target)) continue;
+    if (edge.source === edge.target) continue;
+    const key = `${edge.source}\0${edge.target}\0${edge.type}`;
+    if (seenEdges.has(key)) continue;
+    seenEdges.add(key);
+    edges.push(edge);
+  }
+  return { nodes, edges };
+}
+
+function normalizeFingerprintStore(raw, baseCommit) {
+  if (raw && raw.files && typeof raw.files === 'object' && !Array.isArray(raw.files)) {
+    return raw;
+  }
+  return {
+    version: '1.0.0',
+    gitCommitHash: baseCommit,
+    generatedAt: new Date(0).toISOString(),
+    files: raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {},
+  };
+}
+
+function isGeneratedOnly(plan) {
+  return plan.generatedArtifactFiles.length > 0
+    && plan.filesToReanalyze.length === 0
+    && plan.deletedFiles.length === 0
+    && plan.cosmeticFiles.length === 0
+    && plan.ignoredFiles.length === 0;
+}
+
+function patchFingerprints(uaDir, plan, patch) {
+  const fingerprintPath = join(uaDir, 'fingerprints.json');
+  const store = normalizeFingerprintStore(readJson(fingerprintPath, null), plan.baseCommit);
+  const files = { ...store.files };
+  for (const filePath of patch.deletedFiles ?? []) delete files[filePath];
+  for (const [filePath, fingerprint] of Object.entries(patch.files ?? {})) {
+    files[filePath] = fingerprint;
+  }
+  atomicWriteJson(fingerprintPath, {
+    version: '1.0.0',
+    gitCommitHash: plan.headCommit,
+    generatedAt: new Date().toISOString(),
+    files,
+  });
+}
+
+function advanceMeta(uaDir, plan, analyzedFiles) {
+  const metaPath = join(uaDir, 'meta.json');
+  const previous = readJson(metaPath, {});
+  atomicWriteJson(metaPath, {
+    ...previous,
+    lastAnalyzedAt: new Date().toISOString(),
+    gitCommitHash: plan.headCommit,
+    version: previous.version ?? '1.0.0',
+    analyzedFiles,
+  });
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length !== 1 || args[0].startsWith('--')) {
+    throw new Error('Usage: node finalize-incremental.mjs <projectRoot>');
+  }
+  const projectRoot = realpathSync(args[0]);
+  const uaDir = resolveUaDir(projectRoot);
+  const intermediateDir = join(uaDir, 'intermediate');
+  const plan = readJson(join(intermediateDir, 'incremental-plan.json'));
+  const patch = readJson(join(intermediateDir, 'fingerprint-patch.json'));
+  const scan = readJson(join(intermediateDir, 'scan-result.json'), { totalFiles: 0 });
+  if (!plan || !patch) throw new Error('Incremental plan or fingerprint patch is missing');
+  if (patch.baseCommit !== plan.baseCommit || patch.headCommit !== plan.headCommit) {
+    throw new Error('Fingerprint patch does not match the incremental plan commits');
+  }
+
+  if (plan.action === 'FULL_UPDATE') {
+    throw new Error('FULL_UPDATE must run the full /understand pipeline');
+  }
+  if (plan.action === 'SKIP' && isGeneratedOnly(plan)) {
+    process.stdout.write('Generated artifacts only: analysis baseline unchanged\n');
+    return;
+  }
+
+  if (plan.action !== 'SKIP') {
+    const previousGraph = readJson(join(uaDir, 'knowledge-graph.json'), {});
+    const assembledRaw = readJson(join(intermediateDir, 'assembled-graph.json'));
+    if (!assembledRaw || !Array.isArray(assembledRaw.nodes) || !Array.isArray(assembledRaw.edges)) {
+      throw new Error('assembled-graph.json is missing or invalid; baseline not advanced');
+    }
+    const assembled = normalizeAssembled(assembledRaw);
+    const nodeIds = new Set(assembled.nodes.map(node => node.id));
+    const pathIndex = buildPathIndex(assembled.nodes);
+    if (plan.rerunArchitecture && !existsSync(join(intermediateDir, 'layers.json'))) {
+      throw new Error('Architecture update requires layers.json; baseline not advanced');
+    }
+    if (plan.rerunTour && !existsSync(join(intermediateDir, 'tour.json'))) {
+      throw new Error('Architecture update requires tour.json; baseline not advanced');
+    }
+    const rawLayers = plan.rerunArchitecture
+      ? readJson(join(intermediateDir, 'layers.json'))
+      : previousGraph.layers ?? [];
+    const rawTour = plan.rerunTour
+      ? readJson(join(intermediateDir, 'tour.json'))
+      : previousGraph.tour ?? [];
+    const now = new Date().toISOString();
+    const graph = {
+      ...previousGraph,
+      version: previousGraph.version ?? '1.0.0',
+      project: {
+        ...(previousGraph.project ?? {}),
+        analyzedAt: now,
+        gitCommitHash: plan.headCommit,
+      },
+      nodes: assembled.nodes,
+      edges: assembled.edges,
+      layers: assignLayers(rawLayers, assembled.nodes, assembled.edges),
+      tour: normalizeTour(rawTour, nodeIds, pathIndex),
+    };
+
+    // Ordering is intentional: a failed graph save must never advance the
+    // structural baseline and hide the failed update from the next run.
+    atomicWriteJson(join(uaDir, 'knowledge-graph.json'), graph);
+  }
+
+  patchFingerprints(uaDir, plan, patch);
+  advanceMeta(uaDir, plan, scan.totalFiles);
+  process.stdout.write(
+    `Incremental update finalized: ${plan.action}; analyzedFiles=${scan.totalFiles}\n`,
+  );
+}
+
+function isCliEntry() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
+if (isCliEntry()) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`finalize-incremental.mjs failed: ${error.message}\n${error.stack}\n`);
+    process.exit(1);
+  }
+}
+
+export { assignLayers, commonParentDepth, normalizeTour };

--- a/understand-anything-plugin/skills/understand/finalize-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/finalize-incremental.mjs
@@ -315,6 +315,20 @@ function advanceMeta(uaDir, plan, analyzedFiles) {
   });
 }
 
+function projectMetadata(previousProject, plan, scan) {
+  const languages = [...new Set(
+    (scan.files ?? [])
+      .map(file => file?.language)
+      .filter(language => typeof language === 'string' && language.length > 0),
+  )].sort();
+  return {
+    ...(previousProject ?? {}),
+    languages,
+    analyzedAt: new Date().toISOString(),
+    gitCommitHash: plan.headCommit,
+  };
+}
+
 function main() {
   const args = process.argv.slice(2);
   if (args.length !== 1 || args[0].startsWith('--')) {
@@ -339,8 +353,21 @@ function main() {
     return;
   }
 
+  const graphPath = join(uaDir, 'knowledge-graph.json');
+
+  if (plan.action === 'SKIP') {
+    const previousGraph = readJson(graphPath);
+    if (!previousGraph || !Array.isArray(previousGraph.nodes) || !Array.isArray(previousGraph.edges)) {
+      throw new Error('knowledge-graph.json is missing or invalid; baseline not advanced');
+    }
+    atomicWriteJson(graphPath, {
+      ...previousGraph,
+      project: projectMetadata(previousGraph.project, plan, scan),
+    });
+  }
+
   if (plan.action !== 'SKIP') {
-    const previousGraph = readJson(join(uaDir, 'knowledge-graph.json'), {});
+    const previousGraph = readJson(graphPath, {});
     const assembledRaw = readJson(join(intermediateDir, 'assembled-graph.json'));
     if (!assembledRaw || !Array.isArray(assembledRaw.nodes) || !Array.isArray(assembledRaw.edges)) {
       throw new Error('assembled-graph.json is missing or invalid; baseline not advanced');
@@ -372,9 +399,8 @@ function main() {
       ...previousGraph,
       version: previousGraph.version ?? '1.0.0',
       project: {
-        ...(previousGraph.project ?? {}),
+        ...projectMetadata(previousGraph.project, plan, scan),
         analyzedAt: now,
-        gitCommitHash: plan.headCommit,
       },
       nodes: assembled.nodes,
       edges: assembled.edges,
@@ -384,7 +410,7 @@ function main() {
 
     // Ordering is intentional: a failed graph save must never advance the
     // structural baseline and hide the failed update from the next run.
-    atomicWriteJson(join(uaDir, 'knowledge-graph.json'), graph);
+    atomicWriteJson(graphPath, graph);
   }
 
   patchFingerprints(uaDir, plan, patch);

--- a/understand-anything-plugin/skills/understand/finalize-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/finalize-incremental.mjs
@@ -267,6 +267,39 @@ function normalizeAssembled(assembled) {
   return { nodes, edges };
 }
 
+function refreshGraphImports(graph, importMap, refreshPaths) {
+  const pathIndex = buildPathIndex(graph.nodes);
+  const refreshedSourceIds = new Set(
+    refreshPaths.map(path => pathIndex.get(path)).filter(Boolean),
+  );
+  const edges = graph.edges.filter(
+    edge => !(edge.type === 'imports' && refreshedSourceIds.has(edge.source)),
+  );
+  const seen = new Set(edges.map(edge => `${edge.source}\0${edge.target}\0${edge.type}`));
+
+  for (const sourcePath of refreshPaths) {
+    const source = pathIndex.get(sourcePath);
+    if (!source) continue;
+    const targets = Array.isArray(importMap?.[sourcePath]) ? importMap[sourcePath] : [];
+    for (const targetPath of targets) {
+      const target = pathIndex.get(targetPath);
+      if (!target || source === target) continue;
+      const key = `${source}\0${target}\0imports`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      edges.push({
+        source,
+        target,
+        type: 'imports',
+        direction: 'forward',
+        weight: 0.7,
+        recoveredFromImportMap: true,
+      });
+    }
+  }
+  return { ...graph, edges };
+}
+
 function normalizeFingerprintStore(raw, baseCommit) {
   if (raw && raw.files && typeof raw.files === 'object' && !Array.isArray(raw.files)) {
     return raw;
@@ -354,14 +387,22 @@ function main() {
   }
 
   const graphPath = join(uaDir, 'knowledge-graph.json');
+  const importMapRefreshPaths = Array.isArray(plan.importMapRefreshPaths)
+    ? plan.importMapRefreshPaths
+    : [];
 
   if (plan.action === 'SKIP') {
     const previousGraph = readJson(graphPath);
     if (!previousGraph || !Array.isArray(previousGraph.nodes) || !Array.isArray(previousGraph.edges)) {
       throw new Error('knowledge-graph.json is missing or invalid; baseline not advanced');
     }
+    const refreshedGraph = refreshGraphImports(
+      previousGraph,
+      scan.importMap ?? {},
+      importMapRefreshPaths,
+    );
     atomicWriteJson(graphPath, {
-      ...previousGraph,
+      ...refreshedGraph,
       project: projectMetadata(previousGraph.project, plan, scan),
     });
   }
@@ -372,7 +413,11 @@ function main() {
     if (!assembledRaw || !Array.isArray(assembledRaw.nodes) || !Array.isArray(assembledRaw.edges)) {
       throw new Error('assembled-graph.json is missing or invalid; baseline not advanced');
     }
-    const assembled = normalizeAssembled(assembledRaw);
+    const assembled = refreshGraphImports(
+      normalizeAssembled(assembledRaw),
+      scan.importMap ?? {},
+      importMapRefreshPaths,
+    );
     const nodeIds = new Set(assembled.nodes.map(node => node.id));
     const pathIndex = buildPathIndex(assembled.nodes);
     const missingAnalyzedPaths = plan.filesToReanalyze.filter(path => !pathIndex.has(path));
@@ -438,4 +483,4 @@ if (isCliEntry()) {
   }
 }
 
-export { assignLayers, commonParentDepth, normalizeTour };
+export { assignLayers, commonParentDepth, normalizeTour, refreshGraphImports };

--- a/understand-anything-plugin/skills/understand/finalize-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/finalize-incremental.mjs
@@ -71,7 +71,8 @@ function atomicWriteJson(path, value) {
 
 function normalizeRelativePath(value) {
   if (typeof value !== 'string' || !value || isAbsolute(value)) return null;
-  const path = value.replaceAll('\\', '/').replace(/^\.\//, '');
+  const platformPath = process.platform === 'win32' ? value.replaceAll('\\', '/') : value;
+  const path = platformPath.replace(/^\.\//, '');
   if (!path || path.split('/').some(part => part === '..')) return null;
   return path;
 }

--- a/understand-anything-plugin/skills/understand/finalize-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/finalize-incremental.mjs
@@ -104,6 +104,18 @@ function buildPathIndex(nodes) {
   return index;
 }
 
+function hasAnalyzedFileCoverage(nodes, filePath) {
+  return nodes.some(node => {
+    const path = normalizeRelativePath(node.filePath);
+    if (path !== filePath || typeof node.id !== 'string') return false;
+    if (WHOLE_FILE_TYPES.has(node.type)) return node.id === `${node.type}:${filePath}`;
+    if (node.type === 'table' || node.type === 'endpoint') {
+      return node.id.startsWith(`${node.type}:${filePath}:`);
+    }
+    return false;
+  });
+}
+
 function resolveNodeRef(value, nodeIds, pathIndex) {
   if (typeof value === 'object' && value) value = value.id;
   if (typeof value !== 'string' || !value) return null;
@@ -420,7 +432,9 @@ function main() {
     );
     const nodeIds = new Set(assembled.nodes.map(node => node.id));
     const pathIndex = buildPathIndex(assembled.nodes);
-    const missingAnalyzedPaths = plan.filesToReanalyze.filter(path => !pathIndex.has(path));
+    const missingAnalyzedPaths = plan.filesToReanalyze.filter(
+      path => !hasAnalyzedFileCoverage(assembled.nodes, path),
+    );
     if (missingAnalyzedPaths.length > 0) {
       throw new Error(
         `Assembled graph is missing whole-file nodes for analyzed paths: ` +
@@ -483,4 +497,10 @@ if (isCliEntry()) {
   }
 }
 
-export { assignLayers, commonParentDepth, normalizeTour, refreshGraphImports };
+export {
+  assignLayers,
+  commonParentDepth,
+  hasAnalyzedFileCoverage,
+  normalizeTour,
+  refreshGraphImports,
+};

--- a/understand-anything-plugin/skills/understand/merge-batch-graphs.py
+++ b/understand-anything-plugin/skills/understand/merge-batch-graphs.py
@@ -970,6 +970,56 @@ def merge_and_normalize(batches: list[dict[str, Any]]) -> tuple[dict[str, Any], 
 
 # ── Imports-edge recovery from importMap ──────────────────────────────────
 
+WHOLE_FILE_NODE_TYPES: frozenset[str] = frozenset(
+    {"file", "config", "document", "service", "pipeline", "schema", "resource"}
+)
+
+
+def build_whole_file_node_index(
+    nodes: list[dict[str, Any]],
+) -> tuple[dict[str, str], list[str]]:
+    """Map each filePath to its canonical whole-file node id.
+
+    Only exact ``<type>:<filePath>`` IDs qualify. This intentionally excludes
+    child constructs such as tables and endpoints, even when they carry the
+    same ``filePath``. If an analyzer emitted more than one whole-file node for
+    a path, ``file:`` wins; otherwise the first stable graph occurrence wins.
+    """
+    index: dict[str, str] = {}
+    selected_types: dict[str, str] = {}
+    warnings: list[str] = []
+
+    for node in nodes:
+        node_type = node.get("type")
+        file_path = node.get("filePath")
+        node_id = node.get("id")
+        if (
+            node_type not in WHOLE_FILE_NODE_TYPES
+            or not isinstance(file_path, str)
+            or not file_path
+            or node_id != f"{node_type}:{file_path}"
+        ):
+            continue
+
+        existing_id = index.get(file_path)
+        if existing_id is None:
+            index[file_path] = node_id
+            selected_types[file_path] = node_type
+            continue
+
+        existing_type = selected_types[file_path]
+        if node_type == "file" and existing_type != "file":
+            index[file_path] = node_id
+            selected_types[file_path] = node_type
+            selected = node_id
+        else:
+            selected = existing_id
+        warnings.append(
+            f"  Warning: multiple whole-file nodes for {file_path}; selected {selected}"
+        )
+
+    return index, warnings
+
 def recover_imports_from_scan(
     assembled: dict[str, Any],
     scan_result_path: Path,
@@ -995,11 +1045,9 @@ def recover_imports_from_scan(
     if not isinstance(import_map, dict):
         return 0, [f"  importMap recovery skipped — no importMap field in {scan_result_path.name}"]
 
-    # Build the set of file: node ids actually present in the assembled graph.
-    file_node_ids: set[str] = set()
-    for node in assembled["nodes"]:
-        if node.get("type") == "file":
-            file_node_ids.add(node.get("id", ""))
+    file_path_to_node_id, conflict_warnings = build_whole_file_node_index(
+        assembled["nodes"]
+    )
 
     # Build the set of (source, target) imports edges already present.
     existing: set[tuple[str, str]] = set()
@@ -1013,16 +1061,16 @@ def recover_imports_from_scan(
     for src_path, targets in import_map.items():
         if not isinstance(targets, list):
             continue
-        src_id = f"file:{src_path}"
-        if src_id not in file_node_ids:
+        src_id = file_path_to_node_id.get(src_path)
+        if src_id is None:
             if targets:
                 skipped_no_src_node += 1
             continue
         for tgt_path in targets:
             if not isinstance(tgt_path, str) or not tgt_path:
                 continue
-            tgt_id = f"file:{tgt_path}"
-            if tgt_id not in file_node_ids:
+            tgt_id = file_path_to_node_id.get(tgt_path)
+            if tgt_id is None:
                 skipped_no_tgt_node += 1
                 continue
             if src_id == tgt_id:
@@ -1040,7 +1088,7 @@ def recover_imports_from_scan(
             existing.add((src_id, tgt_id))
             recovered += 1
 
-    lines: list[str] = []
+    lines: list[str] = list(conflict_warnings)
     lines.append(
         f"  Recovered {recovered} `imports` edges from importMap "
         f"({len(import_map)} entries scanned)"
@@ -1048,12 +1096,12 @@ def recover_imports_from_scan(
     if skipped_no_src_node:
         lines.append(
             f"  Skipped {skipped_no_src_node} importMap source files "
-            f"with no `file:` node in graph"
+            f"with no whole-file node in graph"
         )
     if skipped_no_tgt_node:
         lines.append(
             f"  Skipped {skipped_no_tgt_node} importMap target paths "
-            f"with no `file:` node in graph"
+            f"with no whole-file node in graph"
         )
     return recovered, lines
 

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -8,7 +8,7 @@
  *
  * Writes under <UA_DIR>/intermediate:
  *   - incremental-plan.json
- *   - changed-files.txt
+ *   - changed-files.json
  *   - fingerprint-patch.json
  *   - incremental-baseline.json (retry-safe copy of the pre-update scan)
  *   - batch-existing.json (PARTIAL/ARCHITECTURE only)
@@ -673,11 +673,7 @@ async function main() {
     files: currentFingerprints.files,
     deletedFiles,
   });
-  writeFileSync(
-    join(intermediateDir, 'changed-files.txt'),
-    filesToReanalyze.length > 0 ? `${filesToReanalyze.join('\n')}\n` : '',
-    'utf-8',
-  );
+  atomicWriteJson(join(intermediateDir, 'changed-files.json'), filesToReanalyze);
 
   if (decision.action === 'PARTIAL_UPDATE' || decision.action === 'ARCHITECTURE_UPDATE') {
     const pathsToReplace = new Set([...filesToReanalyze, ...deletedFiles]);

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -381,7 +381,17 @@ function refreshImportMap({ projectRoot, intermediateDir, oldScan, currentScan, 
     analysisPaths,
   });
   run(process.execPath, [IMPORT_SCRIPT, inputPath, outputPath]);
-  const selective = readJson(outputPath)?.importMap ?? {};
+  const extraction = readJson(outputPath);
+  const failures = Array.isArray(extraction?.failures) ? extraction.failures : [];
+  if (failures.length > 0) {
+    const preview = failures
+      .slice(0, 5)
+      .map(failure => `${failure.path ?? '<global>'} (${failure.stage})`)
+      .join(', ');
+    const suffix = failures.length > 5 ? ` (+${failures.length - 5} more)` : '';
+    throw new Error(`Import extraction reported failures: ${preview}${suffix}`);
+  }
+  const selective = extraction?.importMap ?? {};
   const currentPaths = new Set(currentScan.files.map(file => file.path));
   const importMap = {};
   for (const file of currentScan.files) {

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -276,7 +276,10 @@ async function buildCurrentFingerprints(projectRoot, paths, headCommit) {
     const registry = new PluginRegistry();
     registry.register(treeSitter);
     registerAllParsers(registry);
-    return buildFingerprintStore(projectRoot, paths, registry, headCommit);
+    const structuralFingerprintLanguages = new Set(tsConfigs.map(config => config.id));
+    return buildFingerprintStore(projectRoot, paths, registry, headCommit, {
+      structuralFingerprintLanguages,
+    });
   } catch (error) {
     process.stderr.write(
       `Warning: prepare-incremental: structural parser initialization failed ` +

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -60,6 +60,15 @@ const {
 const SCAN_SCRIPT = join(__dirname, 'scan-project.mjs');
 const IMPORT_SCRIPT = join(__dirname, 'extract-import-map.mjs');
 const GENERATED_ROOTS = new Set(['.ua', '.understand-anything']);
+const WHOLE_FILE_TYPES = new Set([
+  'file',
+  'config',
+  'document',
+  'service',
+  'pipeline',
+  'schema',
+  'resource',
+]);
 
 function comparePaths(a, b) {
   if (a === b) return 0;
@@ -387,19 +396,31 @@ function refreshImportMap({ projectRoot, intermediateDir, oldScan, currentScan, 
   return importMap;
 }
 
-function pruneExistingGraph(graph, pathsToReplace) {
+function pruneExistingGraph(graph, pathsToReplace, importPathsToRefresh = new Set()) {
   const removedNodeIds = new Set();
+  const refreshedImportSourceIds = new Set();
   const nodes = [];
   for (const node of graph?.nodes ?? []) {
     const path = normalizeRelativePath(node?.filePath);
     if (path && pathsToReplace.has(path)) removedNodeIds.add(node.id);
-    else nodes.push(node);
+    else {
+      nodes.push(node);
+      if (
+        path
+        && importPathsToRefresh.has(path)
+        && WHOLE_FILE_TYPES.has(node.type)
+        && node.id === `${node.type}:${path}`
+      ) {
+        refreshedImportSourceIds.add(node.id);
+      }
+    }
   }
   const retainedIds = new Set(nodes.map(node => node.id));
   const edges = (graph?.edges ?? []).filter(
     edge =>
       !removedNodeIds.has(edge.source)
       && !removedNodeIds.has(edge.target)
+      && !(edge.type === 'imports' && refreshedImportSourceIds.has(edge.source))
       && retainedIds.has(edge.source)
       && retainedIds.has(edge.target),
   );
@@ -591,6 +612,7 @@ async function main() {
     cosmeticFiles: analysis.cosmeticOnlyFiles,
     ignoredFiles,
     generatedArtifactFiles,
+    importMapRefreshPaths: importAnalysisPaths,
     rerunArchitecture: decision.rerunArchitecture,
     rerunTour: decision.rerunTour,
     reason: decision.reason,
@@ -614,7 +636,7 @@ async function main() {
     const pathsToReplace = new Set([...filesToReanalyze, ...deletedFiles]);
     atomicWriteJson(
       join(intermediateDir, 'batch-existing.json'),
-      pruneExistingGraph(graph, pathsToReplace),
+      pruneExistingGraph(graph, pathsToReplace, new Set(importAnalysisPaths)),
     );
   }
   atomicWriteJson(join(intermediateDir, 'incremental-plan.json'), plan);

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -80,6 +80,14 @@ function isGeneratedArtifact(path) {
   return GENERATED_ROOTS.has(path.split('/')[0]);
 }
 
+function isImportResolverConfig(path) {
+  const name = path.split('/').at(-1);
+  return name === 'tsconfig.json'
+    || name === 'go.mod'
+    || name === 'composer.json'
+    || name === 'Package.swift';
+}
+
 function readJson(path, fallback = null) {
   if (!existsSync(path)) return fallback;
   try {
@@ -485,7 +493,17 @@ async function main() {
   const missingImportEntries = currentInventory.filter(
     path => !Object.hasOwn(oldScan?.importMap ?? {}, path),
   );
-  const importAnalysisPaths = sorted([...filesToReanalyze, ...missingImportEntries]);
+  // Adding/removing a resolution candidate can change an unchanged importer's
+  // winner (foo.ts vs foo.js vs foo/index.ts). Resolver configuration edits
+  // likewise affect importers that did not change. Recompute the complete map
+  // for those inventory/context changes; ordinary file edits remain selective.
+  const importResolutionContextChanged =
+    analysis.newFiles.length > 0
+    || deletedFiles.length > 0
+    || currentChangedPaths.some(isImportResolverConfig);
+  const importAnalysisPaths = importResolutionContextChanged
+    ? currentInventory
+    : sorted([...filesToReanalyze, ...missingImportEntries]);
   const importMap = refreshImportMap({
     projectRoot,
     intermediateDir,
@@ -579,6 +597,7 @@ if (isCliEntry()) {
 
 export {
   isGeneratedArtifact,
+  isImportResolverConfig,
   normalizeRelativePath,
   parseNameStatusZ,
   pruneExistingGraph,

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -82,7 +82,8 @@ function sorted(values) {
 
 function normalizeRelativePath(value) {
   if (typeof value !== 'string' || value.length === 0 || isAbsolute(value)) return null;
-  const posix = value.replaceAll('\\', '/').replace(/^\.\//, '');
+  const platformPath = process.platform === 'win32' ? value.replaceAll('\\', '/') : value;
+  const posix = platformPath.replace(/^\.\//, '');
   if (!posix || posix.split('/').some(part => part === '..')) return null;
   return posix;
 }

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -53,6 +53,7 @@ const {
   buildFingerprintStore,
   compareFingerprints,
   classifyUpdate,
+  createIgnoreFilter,
   resolveUaDir,
 } = core;
 
@@ -171,6 +172,42 @@ function pathsFromChanges(changes) {
     if (change.newPath) paths.push(change.newPath);
   }
   return sorted(paths);
+}
+
+function parseNulPaths(output) {
+  return output
+    .split('\0')
+    .map(normalizeRelativePath)
+    .filter(Boolean);
+}
+
+function relevantWorktreeChanges(projectRoot, excludePatterns) {
+  const paths = sorted([
+    ...parseNulPaths(run(
+      'git',
+      ['diff', '--cached', '--name-only', '-z', '--relative', '--', '.'],
+      { cwd: projectRoot },
+    )),
+    ...parseNulPaths(run(
+      'git',
+      ['diff', '--name-only', '-z', '--relative', '--', '.'],
+      { cwd: projectRoot },
+    )),
+    ...parseNulPaths(run(
+      'git',
+      ['ls-files', '--others', '--exclude-standard', '-z', '--', '.'],
+      { cwd: projectRoot },
+    )),
+  ]);
+  const ignoreFilter = createIgnoreFilter(projectRoot, excludePatterns);
+  return paths.filter(path => {
+    if (isGeneratedArtifact(path)) return false;
+    const name = path.split('/').at(-1);
+    // These control which files the live scanner can see, so a dirty version
+    // is relevant even though the control file itself is not analyzed.
+    if (name === '.gitignore' || name === '.understandignore') return true;
+    return !ignoreFilter.isIgnored(path);
+  });
 }
 
 function normalizeFingerprintStore(raw, baseCommit) {
@@ -398,6 +435,15 @@ async function main() {
 
   const baseCommit = resolveCommit(projectRoot, args.baseCommit);
   const headCommit = resolveCommit(projectRoot, 'HEAD');
+  const dirtyPaths = relevantWorktreeChanges(projectRoot, args.excludePatterns);
+  if (dirtyPaths.length > 0) {
+    const preview = dirtyPaths.slice(0, 10).join(', ');
+    const suffix = dirtyPaths.length > 10 ? ` (+${dirtyPaths.length - 10} more)` : '';
+    throw new Error(
+      `Working tree has relevant uncommitted changes: ${preview}${suffix}. ` +
+      `Commit or stash them before incremental analysis so the HEAD baseline remains reproducible.`,
+    );
+  }
   const changes = parseNameStatusZ(
     run(
       'git',
@@ -599,6 +645,7 @@ export {
   isGeneratedArtifact,
   isImportResolverConfig,
   normalizeRelativePath,
+  relevantWorktreeChanges,
   parseNameStatusZ,
   pruneExistingGraph,
 };

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -503,7 +503,7 @@ async function main() {
     || currentChangedPaths.some(isImportResolverConfig);
   const importAnalysisPaths = importResolutionContextChanged
     ? currentInventory
-    : sorted([...filesToReanalyze, ...missingImportEntries]);
+    : sorted([...currentChangedPaths, ...missingImportEntries]);
   const importMap = refreshImportMap({
     projectRoot,
     intermediateDir,

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -382,7 +382,7 @@ function runScan(projectRoot, outputPath, excludePatterns) {
   return readJson(outputPath);
 }
 
-function refreshImportMap({ projectRoot, intermediateDir, oldScan, currentScan, analysisPaths }) {
+function refreshImportMap({ projectRoot, intermediateDir, previousScan, currentScan, analysisPaths }) {
   const inputPath = join(intermediateDir, 'incremental-import-input.json');
   const outputPath = join(intermediateDir, 'incremental-import-output.json');
   atomicWriteJson(inputPath, {
@@ -408,7 +408,7 @@ function refreshImportMap({ projectRoot, intermediateDir, oldScan, currentScan, 
     const path = file.path;
     const candidate = Object.hasOwn(selective, path)
       ? selective[path]
-      : oldScan?.importMap?.[path];
+      : previousScan?.importMap?.[path];
     importMap[path] = Array.isArray(candidate)
       ? sorted(candidate.filter(target => typeof target === 'string' && currentPaths.has(target)))
       : [];
@@ -608,7 +608,7 @@ async function main() {
     decision.filesToReanalyze.filter(path => currentInventorySet.has(path)),
   );
   const missingImportEntries = currentInventory.filter(
-    path => !Object.hasOwn(oldScan?.importMap ?? {}, path),
+    path => !Object.hasOwn(baselineScan?.importMap ?? {}, path),
   );
   // Adding/removing a resolution candidate can change an unchanged importer's
   // winner (foo.ts vs foo.js vs foo/index.ts). Resolver configuration edits
@@ -624,7 +624,7 @@ async function main() {
   const importMap = refreshImportMap({
     projectRoot,
     intermediateDir,
-    oldScan,
+    previousScan: baselineScan,
     currentScan,
     analysisPaths: importAnalysisPaths,
   });

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -24,6 +24,7 @@ import { dirname, basename, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -217,6 +218,14 @@ function relevantWorktreeChanges(projectRoot, excludePatterns) {
     if (name === '.gitignore' || name === '.understandignore') return true;
     return !ignoreFilter.isIgnored(path);
   });
+}
+
+function isTrackedSymlink(projectRoot, filePath) {
+  try {
+    return lstatSync(join(projectRoot, filePath)).isSymbolicLink();
+  } catch {
+    return false;
+  }
 }
 
 function normalizeFingerprintStore(raw, baseCommit) {
@@ -509,6 +518,15 @@ async function main() {
 
   const currentScanPath = join(intermediateDir, 'current-scan.json');
   const currentScan = runScan(projectRoot, currentScanPath, args.excludePatterns);
+  const scanFailures = Array.isArray(currentScan?.failures) ? currentScan.failures : [];
+  if (scanFailures.length > 0) {
+    const preview = scanFailures
+      .slice(0, 5)
+      .map(failure => `${failure.path ?? '<global>'} (${failure.stage})`)
+      .join(', ');
+    const suffix = scanFailures.length > 5 ? ` (+${scanFailures.length - 5} more)` : '';
+    throw new Error(`Project scan reported failures: ${preview}${suffix}`);
+  }
   const currentInventory = sorted(currentScan.files.map(file => file.path));
   const currentInventorySet = new Set(currentInventory);
   // If a previous attempt saved the graph but failed before fingerprints/meta,
@@ -521,6 +539,24 @@ async function main() {
   const inventoryGraph = graphMatchesUncommittedHead ? {} : graph;
   const oldInventory = inventoryFrom(baselineScan, inventoryGraph, oldFingerprints);
   const oldInventorySet = new Set(oldInventory);
+  const trackedPaths = new Set(parseNulPaths(run(
+    'git',
+    ['ls-files', '--cached', '-z', '--', '.'],
+    { cwd: projectRoot },
+  )));
+  const currentIgnoreFilter = createIgnoreFilter(projectRoot, args.excludePatterns);
+  const unexplainedMissingFiles = oldInventory.filter(path =>
+    !currentInventorySet.has(path)
+    && trackedPaths.has(path)
+    && !currentIgnoreFilter.isIgnored(path)
+    && !isTrackedSymlink(projectRoot, path),
+  );
+  if (unexplainedMissingFiles.length > 0) {
+    throw new Error(
+      `Project scan omitted tracked, non-ignored files: ` +
+      `${unexplainedMissingFiles.slice(0, 10).join(', ')}. Baseline not advanced.`,
+    );
+  }
 
   const generatedArtifactFiles = sorted(diffPaths.filter(isGeneratedArtifact));
   const nonGeneratedDiffPaths = diffPaths.filter(path => !isGeneratedArtifact(path));

--- a/understand-anything-plugin/skills/understand/prepare-incremental.mjs
+++ b/understand-anything-plugin/skills/understand/prepare-incremental.mjs
@@ -1,0 +1,585 @@
+#!/usr/bin/env node
+/**
+ * Prepare a deterministic incremental /understand update.
+ *
+ * Usage:
+ *   node prepare-incremental.mjs <projectRoot> <baseCommit>
+ *     [--exclude <comma-separated-patterns>]
+ *
+ * Writes under <UA_DIR>/intermediate:
+ *   - incremental-plan.json
+ *   - changed-files.txt
+ *   - fingerprint-patch.json
+ *   - incremental-baseline.json (retry-safe copy of the pre-update scan)
+ *   - batch-existing.json (PARTIAL/ARCHITECTURE only)
+ *
+ * It also atomically refreshes scan-result.json (except for a commit whose
+ * only changes are generated analysis artifacts). All git subprocess
+ * arguments are parameterized and all path lists use Git's NUL-delimited
+ * format so spaces, renames, and non-ASCII filenames round-trip safely.
+ */
+
+import { createRequire } from 'node:module';
+import { dirname, basename, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pluginRoot = resolve(__dirname, '../..');
+const require = createRequire(resolve(pluginRoot, 'package.json'));
+
+let core;
+try {
+  core = await import(pathToFileURL(require.resolve('@understand-anything/core')).href);
+} catch {
+  core = await import(pathToFileURL(resolve(pluginRoot, 'packages/core/dist/index.js')).href);
+}
+
+const {
+  TreeSitterPlugin,
+  PluginRegistry,
+  builtinLanguageConfigs,
+  registerAllParsers,
+  buildFingerprintStore,
+  compareFingerprints,
+  classifyUpdate,
+  resolveUaDir,
+} = core;
+
+const SCAN_SCRIPT = join(__dirname, 'scan-project.mjs');
+const IMPORT_SCRIPT = join(__dirname, 'extract-import-map.mjs');
+const GENERATED_ROOTS = new Set(['.ua', '.understand-anything']);
+
+function comparePaths(a, b) {
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+function sorted(values) {
+  return [...new Set(values)].sort(comparePaths);
+}
+
+function normalizeRelativePath(value) {
+  if (typeof value !== 'string' || value.length === 0 || isAbsolute(value)) return null;
+  const posix = value.replaceAll('\\', '/').replace(/^\.\//, '');
+  if (!posix || posix.split('/').some(part => part === '..')) return null;
+  return posix;
+}
+
+function isGeneratedArtifact(path) {
+  return GENERATED_ROOTS.has(path.split('/')[0]);
+}
+
+function readJson(path, fallback = null) {
+  if (!existsSync(path)) return fallback;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'));
+  } catch (error) {
+    throw new Error(`Could not parse ${path}: ${error.message}`);
+  }
+}
+
+function atomicWriteJson(path, value) {
+  const tempPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, 'utf-8');
+  renameSync(tempPath, path);
+}
+
+function clearIncrementalScratch(intermediateDir) {
+  const exactNames = new Set([
+    'assembled-graph.json',
+    'batch-existing.json',
+    'batches.json',
+    'layers.json',
+    'tour.json',
+  ]);
+  for (const name of readdirSync(intermediateDir)) {
+    if (exactNames.has(name) || /^batch-\d+(?:-part-\d+)?\.json$/.test(name)) {
+      unlinkSync(join(intermediateDir, name));
+    }
+  }
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: 'utf-8',
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    const detail = result.stderr?.trim() || result.stdout?.trim() || `exit ${result.status}`;
+    throw new Error(`${command} failed: ${detail}`);
+  }
+  if (result.stderr) process.stderr.write(result.stderr);
+  return result.stdout;
+}
+
+function resolveCommit(projectRoot, value) {
+  return run(
+    'git',
+    ['rev-parse', '--verify', '--end-of-options', `${value}^{commit}`],
+    { cwd: projectRoot },
+  ).trim();
+}
+
+function parseNameStatusZ(output) {
+  if (!output) return [];
+  const fields = output.split('\0');
+  if (fields.at(-1) === '') fields.pop();
+  const changes = [];
+  for (let i = 0; i < fields.length;) {
+    const status = fields[i++];
+    if (!status) continue;
+    const kind = status[0];
+    if (kind === 'R' || kind === 'C') {
+      const oldPath = normalizeRelativePath(fields[i++]);
+      const newPath = normalizeRelativePath(fields[i++]);
+      if (!oldPath || !newPath) throw new Error(`Invalid ${kind} path in git diff`);
+      changes.push({ status, oldPath, newPath });
+    } else {
+      const path = normalizeRelativePath(fields[i++]);
+      if (!path) throw new Error(`Invalid path in git diff for status ${status}`);
+      changes.push({ status, path });
+    }
+  }
+  return changes;
+}
+
+function pathsFromChanges(changes) {
+  const paths = [];
+  for (const change of changes) {
+    if (change.path) paths.push(change.path);
+    if (change.oldPath) paths.push(change.oldPath);
+    if (change.newPath) paths.push(change.newPath);
+  }
+  return sorted(paths);
+}
+
+function normalizeFingerprintStore(raw, baseCommit) {
+  if (raw && raw.files && typeof raw.files === 'object' && !Array.isArray(raw.files)) {
+    return raw;
+  }
+  // Compatibility with the early auto-update prompt, which wrote a bare
+  // path -> fingerprint dictionary instead of FingerprintStore.
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return {
+      version: '1.0.0',
+      gitCommitHash: baseCommit,
+      generatedAt: new Date(0).toISOString(),
+      files: raw,
+    };
+  }
+  return {
+    version: '1.0.0',
+    gitCommitHash: baseCommit,
+    generatedAt: new Date(0).toISOString(),
+    files: {},
+  };
+}
+
+function inventoryFrom(scan, graph, fingerprints) {
+  const paths = [];
+  for (const file of scan?.files ?? []) paths.push(file?.path);
+  for (const node of graph?.nodes ?? []) paths.push(node?.filePath);
+  paths.push(...Object.keys(fingerprints.files ?? {}));
+  return sorted(
+    paths
+      .map(normalizeRelativePath)
+      .filter(path => path && !isGeneratedArtifact(path)),
+  );
+}
+
+function contentOnlyFingerprint(filePath) {
+  const content = readFileSync(filePath.absolutePath, 'utf-8');
+  const contentHash = require('node:crypto').createHash('sha256').update(content).digest('hex');
+  return {
+    filePath: filePath.relativePath,
+    contentHash,
+    functions: [],
+    classes: [],
+    imports: [],
+    exports: [],
+    totalLines: content.split('\n').length,
+    hasStructuralAnalysis: false,
+  };
+}
+
+async function buildCurrentFingerprints(projectRoot, paths, headCommit) {
+  if (paths.length === 0) {
+    return {
+      version: '1.0.0',
+      gitCommitHash: headCommit,
+      generatedAt: new Date().toISOString(),
+      files: {},
+    };
+  }
+
+  try {
+    const tsConfigs = builtinLanguageConfigs.filter(config => config.treeSitter);
+    const treeSitter = new TreeSitterPlugin(tsConfigs);
+    await treeSitter.init();
+    const registry = new PluginRegistry();
+    registry.register(treeSitter);
+    registerAllParsers(registry);
+    return buildFingerprintStore(projectRoot, paths, registry, headCommit);
+  } catch (error) {
+    process.stderr.write(
+      `Warning: prepare-incremental: structural parser initialization failed ` +
+      `(${error.message}); changed files will be classified conservatively\n`,
+    );
+    const files = {};
+    for (const relativePath of paths) {
+      files[relativePath] = contentOnlyFingerprint({
+        relativePath,
+        absolutePath: join(projectRoot, relativePath),
+      });
+    }
+    return {
+      version: '1.0.0',
+      gitCommitHash: headCommit,
+      generatedAt: new Date().toISOString(),
+      files,
+    };
+  }
+}
+
+function analyzeInventoryChanges({
+  currentChangedPaths,
+  currentFingerprints,
+  oldFingerprints,
+  oldInventory,
+  deletedFiles,
+}) {
+  const oldInventorySet = new Set(oldInventory);
+  const fileChanges = [];
+  const newFiles = [];
+  const structurallyChangedFiles = [];
+  const cosmeticOnlyFiles = [];
+  const unchangedFiles = [];
+
+  for (const filePath of currentChangedPaths) {
+    const current = currentFingerprints.files[filePath];
+    if (!current) {
+      throw new Error(`File disappeared while preparing incremental update: ${filePath}`);
+    }
+    const previous = oldFingerprints.files[filePath];
+    if (!oldInventorySet.has(filePath)) {
+      newFiles.push(filePath);
+      fileChanges.push({ filePath, changeLevel: 'STRUCTURAL', details: ['new file'] });
+      continue;
+    }
+    if (!previous) {
+      structurallyChangedFiles.push(filePath);
+      fileChanges.push({
+        filePath,
+        changeLevel: 'STRUCTURAL',
+        details: ['no fingerprint baseline — conservative classification'],
+      });
+      continue;
+    }
+    const result = compareFingerprints(previous, current);
+    fileChanges.push(result);
+    if (result.changeLevel === 'STRUCTURAL') structurallyChangedFiles.push(filePath);
+    else if (result.changeLevel === 'COSMETIC') cosmeticOnlyFiles.push(filePath);
+    else unchangedFiles.push(filePath);
+  }
+
+  for (const filePath of deletedFiles) {
+    fileChanges.push({ filePath, changeLevel: 'STRUCTURAL', details: ['file deleted or ignored'] });
+  }
+
+  return {
+    fileChanges,
+    newFiles: sorted(newFiles),
+    deletedFiles: sorted(deletedFiles),
+    structurallyChangedFiles: sorted(structurallyChangedFiles),
+    cosmeticOnlyFiles: sorted(cosmeticOnlyFiles),
+    unchangedFiles: sorted(unchangedFiles),
+  };
+}
+
+function runScan(projectRoot, outputPath, excludePatterns) {
+  const args = [SCAN_SCRIPT, projectRoot, outputPath, '--exclude-analysis-data'];
+  if (excludePatterns.length > 0) args.push('--exclude', excludePatterns.join(','));
+  run(process.execPath, args);
+  return readJson(outputPath);
+}
+
+function refreshImportMap({ projectRoot, intermediateDir, oldScan, currentScan, analysisPaths }) {
+  const inputPath = join(intermediateDir, 'incremental-import-input.json');
+  const outputPath = join(intermediateDir, 'incremental-import-output.json');
+  atomicWriteJson(inputPath, {
+    projectRoot,
+    files: currentScan.files,
+    analysisPaths,
+  });
+  run(process.execPath, [IMPORT_SCRIPT, inputPath, outputPath]);
+  const selective = readJson(outputPath)?.importMap ?? {};
+  const currentPaths = new Set(currentScan.files.map(file => file.path));
+  const importMap = {};
+  for (const file of currentScan.files) {
+    const path = file.path;
+    const candidate = Object.hasOwn(selective, path)
+      ? selective[path]
+      : oldScan?.importMap?.[path];
+    importMap[path] = Array.isArray(candidate)
+      ? sorted(candidate.filter(target => typeof target === 'string' && currentPaths.has(target)))
+      : [];
+  }
+  return importMap;
+}
+
+function pruneExistingGraph(graph, pathsToReplace) {
+  const removedNodeIds = new Set();
+  const nodes = [];
+  for (const node of graph?.nodes ?? []) {
+    const path = normalizeRelativePath(node?.filePath);
+    if (path && pathsToReplace.has(path)) removedNodeIds.add(node.id);
+    else nodes.push(node);
+  }
+  const retainedIds = new Set(nodes.map(node => node.id));
+  const edges = (graph?.edges ?? []).filter(
+    edge =>
+      !removedNodeIds.has(edge.source)
+      && !removedNodeIds.has(edge.target)
+      && retainedIds.has(edge.source)
+      && retainedIds.has(edge.target),
+  );
+  return { nodes, edges };
+}
+
+function parseArgs(argv) {
+  const positionals = [];
+  const excludePatterns = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--exclude') {
+      const value = argv[++i];
+      if (!value || value.startsWith('--')) throw new Error('--exclude requires patterns');
+      excludePatterns.push(...value.split(',').map(item => item.trim()).filter(Boolean));
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      positionals.push(arg);
+    }
+  }
+  if (positionals.length !== 2) {
+    throw new Error(
+      'Usage: node prepare-incremental.mjs <projectRoot> <baseCommit> [--exclude <patterns>]',
+    );
+  }
+  return { projectRoot: positionals[0], baseCommit: positionals[1], excludePatterns };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const projectRoot = realpathSync(args.projectRoot);
+  const uaDir = resolveUaDir(projectRoot);
+  const intermediateDir = join(uaDir, 'intermediate');
+  mkdirSync(intermediateDir, { recursive: true });
+
+  const baseCommit = resolveCommit(projectRoot, args.baseCommit);
+  const headCommit = resolveCommit(projectRoot, 'HEAD');
+  const changes = parseNameStatusZ(
+    run(
+      'git',
+      ['diff', '--name-status', '-z', '--relative', baseCommit, headCommit, '--', '.'],
+      { cwd: projectRoot },
+    ),
+  );
+  const diffPaths = pathsFromChanges(changes);
+
+  const scanPath = join(intermediateDir, 'scan-result.json');
+  const oldScan = readJson(scanPath, {});
+  const graph = readJson(join(uaDir, 'knowledge-graph.json'), {});
+  const oldFingerprints = normalizeFingerprintStore(
+    readJson(join(uaDir, 'fingerprints.json'), null),
+    baseCommit,
+  );
+  const baselineSnapshotPath = join(intermediateDir, 'incremental-baseline.json');
+  const existingSnapshot = readJson(baselineSnapshotPath, null);
+  const baselineScan = existingSnapshot?.baseCommit === baseCommit
+    ? existingSnapshot.scan
+    : oldScan;
+  if (existingSnapshot?.baseCommit !== baseCommit) {
+    atomicWriteJson(baselineSnapshotPath, { baseCommit, scan: oldScan });
+  }
+  // A failed prior attempt can leave complete or split analyzer batches behind.
+  // Remove only known internal scratch names before planning the retry so the
+  // merge cannot resurrect deleted nodes from stale output.
+  clearIncrementalScratch(intermediateDir);
+
+  const currentScanPath = join(intermediateDir, 'current-scan.json');
+  const currentScan = runScan(projectRoot, currentScanPath, args.excludePatterns);
+  const currentInventory = sorted(currentScan.files.map(file => file.path));
+  const currentInventorySet = new Set(currentInventory);
+  // If a previous attempt saved the graph but failed before fingerprints/meta,
+  // its project hash is already HEAD. Do not let that partially advanced graph
+  // redefine the previous inventory; the preserved scan + old fingerprints are
+  // the retry baseline. A graph still tied to baseCommit remains useful for
+  // recovering files omitted by an older scan/fingerprint format.
+  const graphMatchesUncommittedHead =
+    graph?.project?.gitCommitHash === headCommit && headCommit !== baseCommit;
+  const inventoryGraph = graphMatchesUncommittedHead ? {} : graph;
+  const oldInventory = inventoryFrom(baselineScan, inventoryGraph, oldFingerprints);
+  const oldInventorySet = new Set(oldInventory);
+
+  const generatedArtifactFiles = sorted(diffPaths.filter(isGeneratedArtifact));
+  const nonGeneratedDiffPaths = diffPaths.filter(path => !isGeneratedArtifact(path));
+  const deletedFiles = sorted(oldInventory.filter(path => !currentInventorySet.has(path)));
+  const ignoredFiles = sorted(
+    nonGeneratedDiffPaths.filter(
+      path => !currentInventorySet.has(path) && !oldInventorySet.has(path),
+    ),
+  );
+  const currentChangedPaths = sorted([
+    ...nonGeneratedDiffPaths.filter(path => currentInventorySet.has(path)),
+    ...currentInventory.filter(path => !oldInventorySet.has(path)),
+  ]);
+
+  const currentFingerprints = await buildCurrentFingerprints(
+    projectRoot,
+    currentChangedPaths,
+    headCommit,
+  );
+  const analysis = analyzeInventoryChanges({
+    currentChangedPaths,
+    currentFingerprints,
+    oldFingerprints,
+    oldInventory,
+    deletedFiles,
+  });
+  const decision = classifyUpdate(
+    analysis,
+    oldInventory.length,
+    oldInventory,
+    currentInventory,
+  );
+
+  const onlyGeneratedArtifacts =
+    generatedArtifactFiles.length > 0
+    && nonGeneratedDiffPaths.length === 0
+    && deletedFiles.length === 0
+    && currentChangedPaths.length === 0;
+  if (decision.action === 'SKIP') {
+    if (onlyGeneratedArtifacts) {
+      decision.reason = 'Only generated analysis artifacts changed; baseline not advanced';
+    } else if (ignoredFiles.length > 0 && analysis.cosmeticOnlyFiles.length === 0) {
+      decision.reason = `${ignoredFiles.length} changed file(s) are outside the current analysis inventory`;
+    }
+  }
+
+  const filesToReanalyze = sorted(
+    decision.filesToReanalyze.filter(path => currentInventorySet.has(path)),
+  );
+  const missingImportEntries = currentInventory.filter(
+    path => !Object.hasOwn(oldScan?.importMap ?? {}, path),
+  );
+  const importAnalysisPaths = sorted([...filesToReanalyze, ...missingImportEntries]);
+  const importMap = refreshImportMap({
+    projectRoot,
+    intermediateDir,
+    oldScan,
+    currentScan,
+    analysisPaths: importAnalysisPaths,
+  });
+
+  const refreshedScan = {
+    ...oldScan,
+    contentDigest: currentScan.contentDigest,
+    files: currentScan.files,
+    totalFiles: currentScan.totalFiles,
+    filteredByIgnore: currentScan.filteredByIgnore,
+    estimatedComplexity: currentScan.estimatedComplexity,
+    importMap,
+  };
+  delete refreshedScan.scriptCompleted;
+  delete refreshedScan.stats;
+  if (!Object.hasOwn(refreshedScan, 'name')) refreshedScan.name = basename(projectRoot);
+  if (!Object.hasOwn(refreshedScan, 'description')) refreshedScan.description = 'No description available';
+  if (!Array.isArray(refreshedScan.languages)) refreshedScan.languages = [];
+  if (!Array.isArray(refreshedScan.frameworks)) refreshedScan.frameworks = [];
+
+  // Generated-only commits intentionally keep every baseline artifact tied to
+  // the last analyzed source commit. Other zero-token paths still refresh the
+  // deterministic scan so cosmetic line counts and ignore changes are saved.
+  if (!onlyGeneratedArtifacts) atomicWriteJson(scanPath, refreshedScan);
+
+  const plan = {
+    baseCommit,
+    headCommit,
+    action: decision.action,
+    filesToReanalyze,
+    deletedFiles,
+    cosmeticFiles: analysis.cosmeticOnlyFiles,
+    ignoredFiles,
+    generatedArtifactFiles,
+    rerunArchitecture: decision.rerunArchitecture,
+    rerunTour: decision.rerunTour,
+    reason: decision.reason,
+  };
+
+  atomicWriteJson(join(intermediateDir, 'fingerprint-patch.json'), {
+    version: '1.0.0',
+    baseCommit,
+    headCommit,
+    generatedAt: currentFingerprints.generatedAt,
+    files: currentFingerprints.files,
+    deletedFiles,
+  });
+  writeFileSync(
+    join(intermediateDir, 'changed-files.txt'),
+    filesToReanalyze.length > 0 ? `${filesToReanalyze.join('\n')}\n` : '',
+    'utf-8',
+  );
+
+  if (decision.action === 'PARTIAL_UPDATE' || decision.action === 'ARCHITECTURE_UPDATE') {
+    const pathsToReplace = new Set([...filesToReanalyze, ...deletedFiles]);
+    atomicWriteJson(
+      join(intermediateDir, 'batch-existing.json'),
+      pruneExistingGraph(graph, pathsToReplace),
+    );
+  }
+  atomicWriteJson(join(intermediateDir, 'incremental-plan.json'), plan);
+
+  process.stdout.write(
+    `Incremental plan: ${plan.action}; analyze=${filesToReanalyze.length}; ` +
+    `delete=${deletedFiles.length}; cosmetic=${plan.cosmeticFiles.length}; ` +
+    `ignored=${ignoredFiles.length}; generated=${generatedArtifactFiles.length}\n`,
+  );
+}
+
+function isCliEntry() {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+}
+
+if (isCliEntry()) {
+  try {
+    await main();
+  } catch (error) {
+    process.stderr.write(`prepare-incremental.mjs failed: ${error.message}\n${error.stack}\n`);
+    process.exit(1);
+  }
+}
+
+export {
+  isGeneratedArtifact,
+  normalizeRelativePath,
+  parseNameStatusZ,
+  pruneExistingGraph,
+};

--- a/understand-anything-plugin/skills/understand/scan-project.mjs
+++ b/understand-anything-plugin/skills/understand/scan-project.mjs
@@ -649,7 +649,7 @@ function hasUserIgnoreFile(projectRoot) {
  * Per-file failure: emits a Warning: and returns null. Caller decides
  * whether to drop the file or keep it with sizeLines=0.
  */
-function readAndCountLines(absPath, posixPath) {
+function readAndCountLines(absPath, posixPath, failures) {
   try {
     const buf = readFileSync(absPath);
     // Manual newline count beats split('\n').length on large files — no
@@ -660,6 +660,7 @@ function readAndCountLines(absPath, posixPath) {
     }
     return { bytes: buf, sizeLines: count };
   } catch (err) {
+    failures.push({ path: posixPath, stage: 'file-read', message: err.message });
     process.stderr.write(
       `Warning: scan-project: ${posixPath} — line count failed ` +
       `(${err.message}) — file skipped from output\n`,
@@ -757,6 +758,8 @@ async function main() {
     process.exit(1);
   }
 
+  const failures = [];
+
   // 1. Enumerate. Either git ls-files or recursive walk.
   const candidates = enumerateFiles(projectRoot).filter(
     rel =>
@@ -814,13 +817,14 @@ async function main() {
         continue;
       }
     } catch (err) {
+      failures.push({ path: rel, stage: 'file-lstat', message: err.message });
       process.stderr.write(
         `Warning: scan-project: ${rel} — lstat failed (${err.message}) ` +
         `— file skipped from output\n`,
       );
       continue;
     }
-    const scanned = readAndCountLines(absPath, rel);
+    const scanned = readAndCountLines(absPath, rel, failures);
     if (scanned === null) {
       // readAndCountLines already emitted the Warning: line.
       continue;
@@ -855,6 +859,7 @@ async function main() {
     totalFiles: fileEntries.length,
     filteredByIgnore,
     estimatedComplexity,
+    failures,
     stats: {
       filesScanned: fileEntries.length,
       byCategory,

--- a/understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs
+++ b/understand-anything-plugin/src/__tests__/merge-recover-imports.test.mjs
@@ -53,6 +53,14 @@ function fileNode(path) {
   };
 }
 
+function wholeFileNode(type, path) {
+  return {
+    ...fileNode(path),
+    id: `${type}:${path}`,
+    type,
+  };
+}
+
 function importsEdge(src, tgt) {
   return {
     source: `file:${src}`,
@@ -144,7 +152,7 @@ describe("merge-batch-graphs.py imports recovery", () => {
 
     const { assembled, stderr } = runMerge();
     expect(assembled.edges.filter((e) => e.type === "imports")).toHaveLength(0);
-    expect(stderr).toContain("Skipped 1 importMap source files with no `file:` node");
+    expect(stderr).toContain("Skipped 1 importMap source files with no whole-file node");
   });
 
   it("skips importMap targets that don't have a file: node", () => {
@@ -164,7 +172,7 @@ describe("merge-batch-graphs.py imports recovery", () => {
 
     const { assembled, stderr } = runMerge();
     expect(assembled.edges.filter((e) => e.type === "imports")).toHaveLength(0);
-    expect(stderr).toContain("Skipped 2 importMap target paths with no `file:` node");
+    expect(stderr).toContain("Skipped 2 importMap target paths with no whole-file node");
   });
 
   it("works when scan-result.json is missing (incremental update path)", () => {
@@ -200,6 +208,86 @@ describe("merge-batch-graphs.py imports recovery", () => {
 
     const { assembled } = runMerge();
     expect(assembled.edges.filter((e) => e.type === "imports")).toHaveLength(0);
+  });
+
+  it.each([
+    ['file', 'config'],
+    ['file', 'schema'],
+    ['config', 'file'],
+  ])('recovers %s to %s imports through whole-file nodes', (sourceType, targetType) => {
+    writeFileSync(
+      join(intermediateDir, 'batch-0.json'),
+      JSON.stringify({
+        nodes: [
+          wholeFileNode(sourceType, 'src/source.ts'),
+          wholeFileNode(targetType, 'config/target.json'),
+        ],
+        edges: [],
+      }),
+    );
+    writeFileSync(
+      join(intermediateDir, 'scan-result.json'),
+      JSON.stringify({
+        importMap: { 'src/source.ts': ['config/target.json'] },
+      }),
+    );
+
+    const { assembled } = runMerge();
+    expect(assembled.edges.filter((edge) => edge.type === 'imports')).toEqual([
+      expect.objectContaining({
+        source: `${sourceType}:src/source.ts`,
+        target: `${targetType}:config/target.json`,
+      }),
+    ]);
+  });
+
+  it('prefers file nodes over other whole-file nodes for the same path', () => {
+    writeFileSync(
+      join(intermediateDir, 'batch-0.json'),
+      JSON.stringify({
+        nodes: [
+          wholeFileNode('config', 'src/source.ts'),
+          wholeFileNode('file', 'src/source.ts'),
+          wholeFileNode('schema', 'src/target.ts'),
+          wholeFileNode('file', 'src/target.ts'),
+        ],
+        edges: [],
+      }),
+    );
+    writeFileSync(
+      join(intermediateDir, 'scan-result.json'),
+      JSON.stringify({ importMap: { 'src/source.ts': ['src/target.ts'] } }),
+    );
+
+    const { assembled, stderr } = runMerge();
+    expect(assembled.edges.filter((edge) => edge.type === 'imports')).toEqual([
+      expect.objectContaining({
+        source: 'file:src/source.ts',
+        target: 'file:src/target.ts',
+      }),
+    ]);
+    expect(stderr).toContain('multiple whole-file nodes for src/source.ts');
+    expect(stderr).toContain('selected file:src/source.ts');
+  });
+
+  it('does not use child constructs as whole-file import endpoints', () => {
+    const table = {
+      ...wholeFileNode('schema', 'db/schema.sql'),
+      id: 'table:db/schema.sql:users',
+      type: 'table',
+    };
+    writeFileSync(
+      join(intermediateDir, 'batch-0.json'),
+      JSON.stringify({ nodes: [fileNode('src/source.ts'), table], edges: [] }),
+    );
+    writeFileSync(
+      join(intermediateDir, 'scan-result.json'),
+      JSON.stringify({ importMap: { 'src/source.ts': ['db/schema.sql'] } }),
+    );
+
+    const { assembled, stderr } = runMerge();
+    expect(assembled.edges.filter((edge) => edge.type === 'imports')).toHaveLength(0);
+    expect(stderr).toContain('no whole-file node in graph');
   });
 });
 


### PR DESCRIPTION
## Summary

- refresh the current file inventory and selectively rebuild import data before incremental batching
- classify updates from before/after inventories, including deletes, renames, ignore changes, cosmetic edits, generated artifacts, and full-rebuild thresholds
- add retry-safe deterministic preparation/finalization so graph saves precede fingerprint and metadata advancement
- skip file analysis and whole-graph LLM stages when the update does not require them
- recover import edges through all valid whole-file node types, with stable conflict handling
- baseline fingerprints for every analyzed file while preserving legacy input compatibility

Closes #590
Closes #611
Closes #622

## Incremental behavior

- deletion-only and empty analyzer plans go directly through deterministic graph cleanup
- cosmetic-only and irrelevant changes spend zero LLM tokens
- generated-analysis-artifact-only commits do not advance the source baseline
- partial structural changes analyze only current changed files and preserve layer/tour prose
- architecture updates rerun architecture and tour only when directory or change-count thresholds require it
- more than 30 structural changes or more than 50 percent of the project automatically selects a full rebuild

## Validation

- `pnpm test` — 526 passed, 4 skipped
- `python3 tests/skill/understand/test_merge_batch_graphs.py` — 82 passed
- `pnpm lint`
- `pnpm build`
- `git diff --check`