### PR TITLE
fix(install): point kimi platform to .kimi-code skills dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ vibe|$HOME/.vibe/skills|per-skill
 vscode|$HOME/.copilot/skills|per-skill
 hermes|$HOME/.hermes/skills|folder
 cline|$HOME/.cline/skills|folder
-kimi|$HOME/.kimi/skills|folder
+kimi|$HOME/.kimi-code/skills|folder
 trae|$HOME/.trae/skills|per-skill
 nanobot|$HOME/.nanobot/workspace/skills|per-skill
 kiro|$HOME/.kiro/skills|per-skill


### PR DESCRIPTION
## Summary

The Kimi CLI migrated its config directory from `~/.kimi` to `~/.kimi-code`, but `install.sh` still links skills into the legacy `~/.kimi/skills` path, which the current binary never reads. Skills installed for the `kimi` platform are therefore invisible to the CLI.

## Change

Update the platform table entry so `kimi` skills are linked into `$HOME/.kimi-code/skills`:

```diff
-kimi|$HOME/.kimi/skills|folder
+kimi|$HOME/.kimi-code/skills|folder
```

## Verification

After the fix, `./install.sh kimi` creates `~/.kimi-code/skills/understand-anything → <plugin>/skills`, alongside the user's existing skills, and the CLI picks it up.

## Notes

Found while troubleshooting on a machine where `~/.kimi-code/bin/kimi` is the active binary yet the installer wrote the symlink to the unused `~/.kimi/skills`.