### PR TITLE
fix(skills): report unreadable files separately from files with no parser

### DIFF
--- a/tests/skill/understand/test_extract_structure_cli.test.mjs
+++ b/tests/skill/understand/test_extract_structure_cli.test.mjs
@@ -1,0 +1,157 @@
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+// This synchronous subprocess suite can exceed 60 seconds on Windows. Yield
+// between cases so Vitest can service onTaskUpdate replies while tests run.
+afterEach(async () => {
+  await new Promise(resolve => setImmediate(resolve));
+});
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(__dirname, '../../../understand-anything-plugin/skills/understand/extract-structure.mjs');
+
+/** Write a source tree from a `files` object: { 'a/b.ts': '...', ... }. */
+function setupTree(files) {
+  const root = mkdtempSync(join(tmpdir(), 'ua-xstruct-test-'));
+  for (const [relPath, contents] of Object.entries(files)) {
+    const abs = join(root, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, contents, 'utf-8');
+  }
+  return root;
+}
+
+/**
+ * Run extract-structure.mjs. Returns { status, stderr, output } where `output`
+ * is the parsed JSON written by the script (or null when unreadable).
+ */
+function runScript(input) {
+  const scratch = mkdtempSync(join(tmpdir(), 'ua-xstruct-run-'));
+  const inputPath = join(scratch, 'input.json');
+  const outputPath = join(scratch, 'output.json');
+  writeFileSync(inputPath, JSON.stringify(input), 'utf-8');
+  const result = spawnSync('node', [SCRIPT, inputPath, outputPath], { encoding: 'utf-8' });
+  let output = null;
+  try {
+    output = JSON.parse(readFileSync(outputPath, 'utf-8'));
+  } catch {
+    /* output missing on hard failure */
+  }
+  return { status: result.status, stderr: result.stderr, output, scratch };
+}
+
+const batchFile = (path, language = 'typescript') => ({
+  path,
+  language,
+  fileCategory: 'code',
+});
+
+describe('extract-structure.mjs — unreadable files vs. files with no parser', () => {
+  let projectRoot;
+  const scratchDirs = [];
+
+  afterEach(() => {
+    if (projectRoot) {
+      rmSync(projectRoot, { recursive: true, force: true });
+      projectRoot = null;
+    }
+    for (const dir of scratchDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a file that cannot be read separately from a file with no parser', () => {
+    projectRoot = setupTree({
+      'src/readable.ts': 'export function alpha(x) { return x + 1; }\n',
+      'src/unsupported.xyz': 'no parser handles this\n',
+    });
+
+    const run = runScript({
+      projectRoot,
+      batchFiles: [batchFile('src/readable.ts'), batchFile('src/missing.ts'), batchFile('src/unsupported.xyz', 'unknown')],
+      batchImportData: {},
+    });
+    scratchDirs.push(run.scratch);
+
+    // One file read fine, so this is not the pathological case and must not fail.
+    expect(run.status).toBe(0);
+    expect(run.output.scriptCompleted).toBe(true);
+    expect(run.output.filesAnalyzed).toBe(1);
+
+    // Only the genuinely unreadable file is reported as unreadable, with its error code.
+    expect(run.output.filesUnreadable).toEqual([{ path: 'src/missing.ts', code: 'ENOENT' }]);
+
+    // filesSkipped stays the superset so "every batch file is accounted for" holds.
+    expect(run.output.filesSkipped.sort()).toEqual(['src/missing.ts', 'src/unsupported.xyz']);
+
+    // The unreadable file is surfaced on stderr rather than reading as routine.
+    expect(run.stderr).toContain('src/missing.ts');
+    expect(run.stderr).toContain('projectRoot');
+  });
+
+  it('fails loudly when no file in the batch could be read', () => {
+    // The reported scenario: a projectRoot that does not resolve, so every
+    // join(projectRoot, file.path) misses.
+    projectRoot = setupTree({
+      'src/alpha.ts': 'export function alpha(x) { return x + 1; }\n',
+      'src/beta.ts': 'export function beta(y) { return y * 2; }\n',
+    });
+
+    const run = runScript({
+      projectRoot: join(projectRoot, 'wrong-root'),
+      batchFiles: [batchFile('src/alpha.ts'), batchFile('src/beta.ts')],
+      batchImportData: {},
+    });
+    scratchDirs.push(run.scratch);
+
+    // Non-zero so the caller aborts instead of accepting stub nodes.
+    expect(run.status).not.toBe(0);
+    expect(run.stderr).toContain('projectRoot');
+
+    // The output is still written so the caller can inspect what failed.
+    expect(run.output.scriptCompleted).toBe(true);
+    expect(run.output.filesAnalyzed).toBe(0);
+    expect(run.output.filesUnreadable).toEqual([
+      { path: 'src/alpha.ts', code: 'ENOENT' },
+      { path: 'src/beta.ts', code: 'ENOENT' },
+    ]);
+    expect(run.output.filesSkipped.sort()).toEqual(['src/alpha.ts', 'src/beta.ts']);
+  });
+
+  it('does not fail a batch that contains no files', () => {
+    projectRoot = setupTree({});
+
+    const run = runScript({ projectRoot, batchFiles: [], batchImportData: {} });
+    scratchDirs.push(run.scratch);
+
+    expect(run.status).toBe(0);
+    expect(run.output.filesAnalyzed).toBe(0);
+    expect(run.output.filesUnreadable).toEqual([]);
+    expect(run.output.filesSkipped).toEqual([]);
+  });
+
+  it('keeps both buckets empty for a fully readable batch', () => {
+    projectRoot = setupTree({
+      'src/alpha.ts': 'export function alpha(x) { return x + 1; }\n',
+      'src/beta.ts': 'export function beta(y) { return y * 2; }\n',
+    });
+
+    const run = runScript({
+      projectRoot,
+      batchFiles: [batchFile('src/alpha.ts'), batchFile('src/beta.ts')],
+      batchImportData: {},
+    });
+    scratchDirs.push(run.scratch);
+
+    expect(run.status).toBe(0);
+    expect(run.output.filesAnalyzed).toBe(2);
+    expect(run.output.filesUnreadable).toEqual([]);
+    expect(run.output.filesSkipped).toEqual([]);
+    expect(run.stderr).toBe('');
+  });
+});

--- a/understand-anything-plugin/agents/file-analyzer.md
+++ b/understand-anything-plugin/agents/file-analyzer.md
@@ -88,6 +88,7 @@ Read `$UA_DIR/tmp/ua-file-extract-results-<batchIndex>.json`. The output format 
   "scriptCompleted": true,
   "filesAnalyzed": 5,
   "filesSkipped": ["path/to/binary.wasm"],
+  "filesUnreadable": [],
   "results": [
     {
       "path": "src/index.ts",
@@ -117,6 +118,8 @@ Read `$UA_DIR/tmp/ua-file-extract-results-<batchIndex>.json`. The output format 
   ]
 }
 ```
+
+**Read failures are not skips.** `filesSkipped` lists every batch file that produced no result, including benign cases (`.wasm`, `.sln`, `.xaml` — no registered parser). `filesUnreadable` is the subset that could not be read from disk at all (`[{ "path": ..., "code": "ENOENT" }]`). A non-empty `filesUnreadable` means the paths are wrong, not the code — most often a `projectRoot` that does not resolve. When it is non-empty the script also writes a note to stderr, and when *every* file in the batch is unreadable it exits non-zero (per Step 2, report that as a hard failure). Never treat an unreadable file as "unsupported language" and never emit a bare stub node for it: report the failure instead.
 
 **Non-code structural fields.** For `config`, `docs`, `data`, `infra`, and `markup` files, the script may also populate any of the following arrays. Treat each entry as a potential sub-file node and emit a corresponding `<prefix>:<path>:<name>` node in your output if it meets the significance filter:
 

--- a/understand-anything-plugin/skills/understand/extract-structure.mjs
+++ b/understand-anything-plugin/skills/understand/extract-structure.mjs
@@ -13,7 +13,12 @@
  *   { projectRoot, batchFiles: [{path, language, sizeLines, fileCategory}], batchImportData }
  *
  * Output JSON:
- *   { scriptCompleted, filesAnalyzed, filesSkipped, results: [...] }
+ *   { scriptCompleted, filesAnalyzed, filesSkipped, filesUnreadable, results: [...] }
+ *
+ * `filesSkipped` lists every batch file that produced no result, and
+ * `filesUnreadable` is the subset of those that could not be read at all
+ * (ENOENT / EACCES / ...). Only the latter points at a broken `projectRoot`;
+ * a file skipped for having no registered parser is expected and benign.
  */
 
 import { createRequire } from 'node:module';
@@ -83,6 +88,7 @@ async function main() {
 
   const results = [];
   const filesSkipped = [];
+  const filesUnreadable = [];
   const analysisOutcomes = {
     structure: { succeeded: 0, failed: 0 },
     callGraph: { succeeded: 0, failed: 0, skipped: 0 },
@@ -95,8 +101,16 @@ async function main() {
     let content;
     try {
       content = readFileSync(absolutePath, 'utf-8');
-    } catch {
+    } catch (err) {
+      // Keep the path in filesSkipped so "every batch file is accounted for"
+      // still holds for callers that only read that field, but also record it
+      // in filesUnreadable so a wrong projectRoot stays distinguishable from a
+      // file that merely has no parser.
       filesSkipped.push(file.path);
+      filesUnreadable.push({
+        path: file.path,
+        code: typeof err?.code === 'string' ? err.code : null,
+      });
       continue;
     }
 
@@ -128,6 +142,7 @@ async function main() {
     scriptCompleted: true,
     filesAnalyzed: results.length,
     filesSkipped,
+    filesUnreadable,
     analysisOutcomes,
     results,
   };
@@ -136,6 +151,25 @@ async function main() {
 
   if (!existsSync(outputPath)) {
     throw new Error(`output file missing after write: ${outputPath}`);
+  }
+
+  if (filesUnreadable.length > 0) {
+    process.stderr.write(
+      `extract-structure.mjs: ${filesUnreadable.length}/${batchFiles.length} batch file(s) could not be read ` +
+      `(e.g. ${filesUnreadable[0].path} [${filesUnreadable[0].code ?? 'unknown error'}]); ` +
+      `verify that projectRoot resolves: ${projectRoot}\n`,
+    );
+  }
+
+  // A batch where nothing at all could be read is always a configuration
+  // error (wrong projectRoot, mismatched mount, ...), never a property of the
+  // analyzed code. Report it as a failure instead of a clean run so callers
+  // cannot mistake it for "every file simply lacks a parser".
+  if (batchFiles.length > 0 && filesUnreadable.length === batchFiles.length) {
+    throw new Error(
+      `no file in the batch could be read (${filesUnreadable.length}/${batchFiles.length}); ` +
+      `projectRoot is likely wrong: ${projectRoot}`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

`extract-structure.mjs` put every file it failed to **read** into `filesSkipped` — the same bucket as files that simply have **no parser** — and exited 0 either way. A `projectRoot` that does not resolve therefore produced a clean-looking run with `filesAnalyzed: 0` and all files "skipped", which is indistinguishable from "this batch is all `.sln`/`.xaml`/`.txt`". The file-analyzer agent is instructed to treat exit 0 as success, so a wrong root could be accepted as an unsupported-language batch.

Reproduced against `main` at `5feed1f`, with a batch of two readable `.ts` files and a `projectRoot` that does not exist:

```
EXIT_CODE=0
{ "scriptCompleted": true, "filesAnalyzed": 0,
  "filesSkipped": ["src/a.ts", "src/b.ts"], "results": [] }
```

The same run with a correct root reads `src/a.ts` normally and skips only the genuinely unsupported `.xyz`, i.e. the two outcomes are indistinguishable to the caller.

## Changes

- Record read failures in a new `filesUnreadable` array of `{ path, code }` (`ENOENT`, `EACCES`, …), reported alongside `filesSkipped`.
- Write a one-line stderr note naming the first unreadable path and `projectRoot` when `filesUnreadable` is non-empty.
- Exit non-zero when **no** file in the batch could be read (`filesUnreadable.length === batchFiles.length`), after the output file is written so the caller can still inspect what failed. Guarded on `batchFiles.length > 0` so an empty batch is not a failure.
- `filesSkipped` still lists every file that produced no result, so callers that account for coverage — `summarizeStructureOutput()` in the large-repo benchmark counts skipped paths toward `missingStructurePaths` — keep working unchanged.
- `file-analyzer.md`: document the new field and state that a non-empty `filesUnreadable` is a path problem, not an unsupported language.

## Linked issue(s)

Closes #647

## How I tested this

New `tests/skill/understand/test_extract_structure_cli.test.mjs` drives the real CLI via `spawnSync` (same harness as `test_extract_import_map.test.mjs`) and covers: a mixed batch (unreadable file is reported separately, exit 0), the all-unreadable case (non-zero exit, output still written), an empty batch, and an all-readable batch. All four cases fail against unpatched `main` — e.g. `expected +0 not to be +0` for the exit-code assertion — and pass with the fix.

- [x] `pnpm lint`
- [x] `pnpm --filter @understand-anything/core test` — 1012 passed, 1 skipped
- [x] `pnpm test` — see note below
- [x] Manual smoke test: ran the CLI with a wrong root and a correct root (transcript above)

`pnpm test` on this branch fails 4 tests in 2 files, and pristine `main` fails 3 in the same 2 files:

- `tests/skill/understand/test_prepare_incremental.test.mjs` — pre-existing, Windows-specific (`finalize` exits `3221226505`, i.e. `STATUS_STACK_BUFFER_OVERRUN`); the count varies between 2 and 3 run-to-run on unmodified `main`, so it is flaky on this host.
- `tests/install/platform-table-consistency.test.mjs` — pre-existing and unrelated to this change; fixed separately in #687.

`pnpm test` was green on Linux in CI for these paths before the current `main` breakage.

## Versioning

- [x] N/A — I did not bump the manifests. This does change user-visible behaviour (exit code plus a new output field), so please bump on merge if you want it attributed to a release; #685, #683 and similar merged fixes left the bump to a separate `chore(release)` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

