### PR TITLE
fix(install): point kimi platform in install.ps1 at .kimi-code skills dir

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -38,7 +38,7 @@ $Platforms = [ordered]@{
     vscode      = @{ Target = (Join-Path $HOME '.copilot\skills');            Style = 'per-skill' }
     hermes      = @{ Target = (Join-Path $HOME '.hermes\skills');             Style = 'folder' }
     cline       = @{ Target = (Join-Path $HOME '.cline\skills');              Style = 'folder' }
-    kimi        = @{ Target = (Join-Path $HOME '.kimi\skills');               Style = 'folder' }
+    kimi        = @{ Target = (Join-Path $HOME '.kimi-code\skills');          Style = 'folder' }
     trae        = @{ Target = (Join-Path $HOME '.trae\skills');               Style = 'per-skill' }
     nanobot     = @{ Target = (Join-Path $HOME '.nanobot\workspace\skills');  Style = 'per-skill' }
     kiro        = @{ Target = (Join-Path $HOME '.kiro\skills');               Style = 'per-skill' }


### PR DESCRIPTION
## Summary

#685 moved the kimi target in `install.sh` to `~/.kimi-code/skills`, because the Kimi CLI renamed its config directory and never reads the legacy `~/.kimi/skills` path. `install.ps1` was not updated with it, so the Windows installer still links skills into the path the current binary ignores.

`tests/install/platform-table-consistency.test.mjs` already asserts that both scripts resolve to the same skills target, so this divergence is also what leaves the **`Test skill` step red on `main`** since #685 — the CI run for `5feed1f2` fails on both `ubuntu-latest` and `windows-latest` with:

```
tests/install/platform-table-consistency.test.mjs: AssertionError: target for "kimi":
expected '.kimi/skills' to be '.kimi-code/skills'
```

([job 101928071372](https://github.com/Egonex-AI/Understand-Anything/actions/runs/34183820289/job/101928071372), step `Test skill`)

## Linked issue(s)

No tracking issue. #337 ("it doesn't work with kimi code cli") is the report #685 fixed; this is the Windows half of it. Relevant: #499 proposes moving kimi to `~/.agents/skills` per-skill in `install.sh` only — whichever target wins, both scripts need to move together or this test goes red again.

## Changes

One line: `install.ps1` kimi target `.kimi\skills` → `.kimi-code\skills`, keeping the table's `Style` column aligned at its existing column.

## How I tested this

- `pnpm exec vitest run tests/install/` — 6 passed. On unmodified `main` the same file fails 1 of 6 with exactly the CI assertion above.
- `install.ps1` parses with no syntax errors (`[Parser]::ParseFile`), and `Join-Path $HOME '.kimi-code\skills'` resolves to `C:\Users\<user>\.kimi-code\skills`, which normalizes to the same `.kimi-code/skills` as `install.sh`.

- [x] `pnpm lint`
- [x] `pnpm --filter @understand-anything/core test`
- [x] `pnpm test` (this change turns the `tests/install` failure green; see #686 for the unrelated pre-existing Windows failures)
- [x] Manual smoke test (PowerShell parse + path resolution, above)

## Versioning

- [x] N/A — I did not bump the manifests; #685 and similar install fixes left the bump to a separate `chore(release)` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
